### PR TITLE
Add dance improvements + fix regressions

### DIFF
--- a/m4d/ClientApp/components.d.ts
+++ b/m4d/ClientApp/components.d.ts
@@ -147,6 +147,7 @@ declare module 'vue' {
     IBiPersonPlusFill: typeof import('~icons/bi/person-plus-fill')['default']
     IBiPlay: typeof import('~icons/bi/play')['default']
     IBiPlayCircleFill: typeof import('~icons/bi/play-circle-fill')['default']
+    IBiPlus: typeof import('~icons/bi/plus')['default']
     IBiPlusCircle: typeof import('~icons/bi/plus-circle')['default']
     IBiQuestionCircle: typeof import('~icons/bi/question-circle')['default']
     IBiSearch: typeof import('~icons/bi/search')['default']

--- a/m4d/ClientApp/src/components/DanceChooser.vue
+++ b/m4d/ClientApp/src/components/DanceChooser.vue
@@ -56,7 +56,6 @@ const tempoFiltered = computed(() => {
 });
 
 const tempoType = TempoType.Measures;
-const hasTempo = computed(() => !!props.tempo && !!props.numerator);
 
 const exists = (danceId: string): boolean => {
   const filtered = props.filterIds;

--- a/m4d/ClientApp/src/components/DanceChooser.vue
+++ b/m4d/ClientApp/src/components/DanceChooser.vue
@@ -56,7 +56,7 @@ const tempoFiltered = computed(() => {
 });
 
 const tempoType = TempoType.Measures;
-const hasTempo = (() => !!props.tempo && !!props.numerator)();
+const hasTempo = computed(() => !!props.tempo && !!props.numerator);
 
 const exists = (danceId: string): boolean => {
   const filtered = props.filterIds;

--- a/m4d/ClientApp/src/components/DanceChooser.vue
+++ b/m4d/ClientApp/src/components/DanceChooser.vue
@@ -67,7 +67,11 @@ const exists = (danceId: string): boolean => {
 };
 
 const chooseEvent = (id?: string, event?: MouseEvent): void => {
-  choose(id, event?.ctrlKey);
+  const persist = event?.ctrlKey;
+  if (persist) {
+    event?.preventDefault();
+  }
+  choose(id, persist);
 };
 
 const choose = (id?: string, persist?: boolean): void => {
@@ -110,7 +114,7 @@ const isGroup = (dance: NamedObject) => {
             button
             :active="danceId === dance.id"
             :disabled="exists(dance.id)"
-            @click="chooseEvent(dance.id, $event)"
+            @click.prevent="chooseEvent(dance.id, $event)"
           >
             <DanceName
               :dance="dance"
@@ -131,7 +135,7 @@ const isGroup = (dance: NamedObject) => {
             :class="{ item: isGroup(dance), 'sub-item': !isGroup(dance) }"
             :active="danceId === dance.id"
             :disabled="exists(dance.id) || (isGroup(dance) && !includeGroups)"
-            @click="chooseEvent(dance.id, $event)"
+            @click.prevent="chooseEvent(dance.id, $event)"
           >
             <DanceName
               :dance="dance"

--- a/m4d/ClientApp/src/components/SongTable.vue
+++ b/m4d/ClientApp/src/components/SongTable.vue
@@ -1,5 +1,5 @@
 <script script setup lang="ts">
-import { DanceRatingVote } from "@/models/DanceRatingDelta";
+import { DanceRatingVote, VoteDirection } from "@/models/DanceRatingDelta";
 import { DanceHandler } from "@/models/DanceHandler";
 import { DanceRating } from "@/models/DanceRating";
 import { Song } from "@/models/Song";
@@ -14,11 +14,13 @@ import { TagHandler } from "@/models/TagHandler";
 import { computed, ref, watch } from "vue";
 import { getMenuContext } from "@/helpers/GetMenuContext";
 import { useWindowSize } from "@vueuse/core";
-import type { TableFieldRaw } from "bootstrap-vue-next";
+import { useModalController, type TableFieldRaw } from "bootstrap-vue-next";
 import beat10 from "@/assets/images/icons/beat-10.png";
 import energy10 from "@/assets/images/icons/Energy-10.png";
 import mood10 from "@/assets/images/icons/mood-10.png";
 import { formatDate } from "@/helpers/timeHelpers";
+
+const { hide } = useModalController();
 
 type SongField = Exclude<TableFieldRaw<SongEditor>, string>;
 
@@ -68,6 +70,7 @@ const currentDance = ref<DanceHandler>(
 const playModalVisible = ref(false);
 const likeModalVisible = ref(false);
 const orderModalVisible = ref(false);
+const addDanceModalVisible = ref(false);
 
 const currentSong = ref<SongEditor>(new SongEditor());
 
@@ -339,6 +342,13 @@ const showLikeModal = (songId: string): void => {
   likeModalVisible.value = true;
 };
 
+const showAddDanceModal = (songId: string): void => {
+  const editor = findEditor(songId)!;
+  console.log("AddDance", editor.song.explicitDanceIds, editor.song.tempo, editor.song.numerator);
+  currentSong.value = editor;
+  addDanceModalVisible.value = true;
+};
+
 // INT-TODO: We should consider warning the user before removing the song from the list
 //  Or throwing up a toast to click to get it back
 const onDanceVote = (editor: SongEditor, vote: DanceRatingVote): void => {
@@ -351,6 +361,15 @@ const onDanceVote = (editor: SongEditor, vote: DanceRatingVote): void => {
     filter.singleDance &&
     filter.danceQuery.danceList[0] == vote.danceId;
   onEditSong(history, remove);
+};
+
+const onAddDance = (danceId?: string, persist?: boolean): void => {
+  if (danceId) {
+    onDanceVote(currentSong.value as SongEditor, new DanceRatingVote(danceId, VoteDirection.Up));
+  }
+  if (!persist) {
+    hide();
+  }
 };
 
 const onEditSong = (history: SongHistory, remove: boolean = false): void => {
@@ -534,6 +553,16 @@ const onEditSong = (history: SongHistory, remove: boolean = false): void => {
           @dance-clicked="showDanceModal(data.item, $event)"
           @dance-vote="onDanceVote(data.item, $event)"
         />
+        <BButton
+          v-if="!!context.userName"
+          title="Add Dance"
+          variant="dance"
+          size="sm"
+          style="margin-inline-end: 0.25em"
+          @click="showAddDanceModal(data.item.song.id)"
+        >
+          <IBiPlusCircle />
+        </BButton>
       </template>
       <template #head(tags)>
         <SortableHeader
@@ -691,6 +720,14 @@ const onEditSong = (history: SongHistory, remove: boolean = false): void => {
       @edit-song="onEditSong"
     />
     <PlayModal v-model="playModalVisible" :song="currentSong.song as Song" />
+    <DanceChooser
+      v-model="addDanceModalVisible"
+      :filter-ids="currentSong.song.explicitDanceIds"
+      :tempo="currentSong.song.tempo"
+      :numerator="currentSong.song.numerator"
+      :hide-name-link="true"
+      @choose-dance="onAddDance"
+    />
   </div>
 </template>
 

--- a/m4d/ClientApp/src/components/SongTable.vue
+++ b/m4d/ClientApp/src/components/SongTable.vue
@@ -344,7 +344,6 @@ const showLikeModal = (songId: string): void => {
 
 const showAddDanceModal = (songId: string): void => {
   const editor = findEditor(songId)!;
-  console.log("AddDance", editor.song.explicitDanceIds, editor.song.tempo, editor.song.numerator);
   currentSong.value = editor;
   addDanceModalVisible.value = true;
 };

--- a/m4d/ClientApp/src/models/Song.ts
+++ b/m4d/ClientApp/src/models/Song.ts
@@ -245,6 +245,32 @@ export class Song extends TaggableObject {
       : undefined;
   }
 
+  public get explicitDanceIds(): string[] {
+    const tags = this.tags;
+    return tags
+      ? tags
+          .filter(
+            (t) => t.category === "Dance" && !t.value.startsWith("!") && !t.value.startsWith("-"),
+          )
+          .map((t) => safeDanceDatabase().fromName(t.value)!.id)
+      : [];
+  }
+
+  public hasMeterTag(numerator: number): boolean {
+    return !!this.tags.find((t) => t.key === `${numerator}/4:Tempo`);
+  }
+
+  public get numerator(): number | undefined {
+    if (this.hasMeterTag(4)) {
+      return 4;
+    } else if (this.hasMeterTag(3)) {
+      return 3;
+    } else if (this.hasMeterTag(2)) {
+      return 2;
+    }
+    return undefined;
+  }
+
   private loadProperties(properties: SongProperty[], currentUser?: string): void {
     const isUserModified = new Set<string>();
     let created = true;

--- a/m4d/ClientApp/src/pages/album/__tests__/__snapshots__/album.test.ts.snap
+++ b/m4d/ClientApp/src/pages/album/__tests__/__snapshots__/album.test.ts.snap
@@ -217,6 +217,7 @@ exports[`Album > renders an album page 1`] = `
                   </svg> Salsa <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Latin" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -560,6 +561,7 @@ exports[`Album > renders an album page 1`] = `
                   </svg> Rumba <span class="badge text-bg-light">6</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -813,6 +815,7 @@ exports[`Album > renders an album page 1`] = `
                   </svg> Samba <span class="badge text-bg-light">4</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1990S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1059,6 +1062,7 @@ exports[`Album > renders an album page 1`] = `
                   </svg> Merengue <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1350,6 +1354,7 @@ exports[`Album > renders an album page 1`] = `
                   </svg> Cha Cha <span class="badge text-bg-light">3</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1600,6 +1605,7 @@ exports[`Album > renders an album page 1`] = `
                   </svg> Salsa <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1740,6 +1746,7 @@ exports[`Album > renders an album page 1`] = `
                   </svg> Samba <span class="badge text-bg-light">2</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1788,6 +1795,8 @@ exports[`Album > renders an album page 1`] = `
           <!---->
           <!---->
         </table>
+        <!--teleport start-->
+        <!--teleport end-->
         <!--teleport start-->
         <!--teleport end-->
         <!--teleport start-->

--- a/m4d/ClientApp/src/pages/artist/__tests__/__snapshots__/artist.test.ts.snap
+++ b/m4d/ClientApp/src/pages/artist/__tests__/__snapshots__/artist.test.ts.snap
@@ -193,6 +193,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Samba <span class="badge text-bg-light">3</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -281,6 +282,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Merengue <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -378,6 +380,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Rumba <span class="badge text-bg-light">2</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -484,6 +487,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Cha Cha <span class="badge text-bg-light">3</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -604,6 +608,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Samba <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1990S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -792,6 +797,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Samba <span class="badge text-bg-light">3</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1990S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1008,6 +1014,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Salsa <span class="badge text-bg-light">2</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1210,6 +1217,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Salsa <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1754,6 +1762,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Rumba <span class="badge text-bg-light">6</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1919,6 +1928,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Samba <span class="badge text-bg-light">5</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2086,6 +2096,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Cha Cha <span class="badge text-bg-light">9</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2246,6 +2257,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Cha Cha <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2505,6 +2517,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Merengue <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2611,6 +2624,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Samba <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2717,6 +2731,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Hustle <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2830,6 +2845,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Samba <span class="badge text-bg-light">4</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1990S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3002,6 +3018,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Samba <span class="badge text-bg-light">2</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3108,6 +3125,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Night Club Two Step <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3277,6 +3295,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Cumbia <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3573,6 +3592,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Samba <span class="badge text-bg-light">2</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1990S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3747,6 +3767,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Cha Cha <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3853,6 +3874,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Samba <span class="badge text-bg-light">3</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -4022,6 +4044,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Night Club Two Step <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -4299,6 +4322,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Cha Cha <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Pop Latino" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -4389,6 +4413,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Salsa <span class="badge text-bg-light">3</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -4837,6 +4862,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Rumba <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="First Dance" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -4946,6 +4972,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> West Coast Swing <span class="badge text-bg-light">2</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1990S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -5157,6 +5184,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Merengue <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -5556,6 +5584,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Samba <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -5653,6 +5682,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Cha Cha <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -5942,6 +5972,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Merengue <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -6084,6 +6115,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Cha Cha <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -6260,6 +6292,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Merengue <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -6634,6 +6667,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Rumba <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -6713,6 +6747,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Hustle <span class="badge text-bg-light">2</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class=""></td>
               <td class="">
@@ -6799,6 +6834,7 @@ exports[`Artist > renders an artist page 1`] = `
                   </svg> Salsa <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -6866,6 +6902,8 @@ exports[`Artist > renders an artist page 1`] = `
           <!---->
           <!---->
         </table>
+        <!--teleport start-->
+        <!--teleport end-->
         <!--teleport start-->
         <!--teleport end-->
         <!--teleport start-->

--- a/m4d/ClientApp/src/pages/custom-search/__tests__/__snapshots__/custom-search.test.ts.snap
+++ b/m4d/ClientApp/src/pages/custom-search/__tests__/__snapshots__/custom-search.test.ts.snap
@@ -242,6 +242,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Slow Foxtrot <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1966" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -454,6 +455,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Viennese Waltz <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                       <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                     </svg></button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -770,6 +772,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> West Coast Swing <span class="badge text-bg-light">2</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1940S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1014,6 +1017,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Slow Foxtrot <span class="badge text-bg-light">2</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1213,6 +1217,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> West Coast Swing <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1990S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1376,6 +1381,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Slow Foxtrot <span class="badge text-bg-light">3</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                       <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                     </svg></button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1556,6 +1562,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Slow Waltz <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="3/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1675,6 +1682,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Slow Waltz <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Holiday" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1778,6 +1786,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Slow Waltz <span class="badge text-bg-light">5</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                       <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                     </svg></button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="3/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1929,6 +1938,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> West Coast Swing <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2060,6 +2070,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> West Coast Swing <span class="badge text-bg-light">3</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2196,6 +2207,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Slow Waltz <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Holiday" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2306,6 +2318,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Slow Foxtrot <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2453,6 +2466,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Slow Foxtrot <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2591,6 +2605,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Rumba <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Christmas" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2669,6 +2684,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Rumba <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Christmas" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2756,6 +2772,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Cha Cha <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Holiday" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2859,6 +2876,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Night Club Two Step <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3012,6 +3030,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Cha Cha <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3184,6 +3203,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Slow Waltz <span class="badge text-bg-light">10</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                       <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                     </svg></button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="3/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3269,6 +3289,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Cha Cha <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="Christmas Crackers" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3393,6 +3414,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Slow Foxtrot <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3490,6 +3512,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Cha Cha <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Alternative" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3621,6 +3644,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Slow Foxtrot <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3820,6 +3844,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                     </svg> Samba <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                       <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                     </svg></button>
+                  <!--v-if-->
                 </td>
                 <td class="">
                   <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1970S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3920,6 +3945,8 @@ exports[`Custom Search > renders a custom search page 1`] = `
             <!---->
             <!---->
           </table>
+          <!--teleport start-->
+          <!--teleport end-->
           <!--teleport start-->
           <!--teleport end-->
           <!--teleport start-->

--- a/m4d/ClientApp/src/pages/dance-details/__tests__/__snapshots__/dance-details.test.ts.snap
+++ b/m4d/ClientApp/src/pages/dance-details/__tests__/__snapshots__/dance-details.test.ts.snap
@@ -1586,6 +1586,8 @@ The Bolero is generally danced as the fourth dance of [American Rhythm](/dances/
 <!--teleport end-->
 <!--teleport start-->
 <!--teleport end-->
+<!--teleport start-->
+<!--teleport end-->
 </div>
 </div>
 </div>
@@ -1600,7 +1602,7 @@ The Bolero is generally danced as the fourth dance of [American Rhythm](/dances/
     <div>
       <h4>Competition Tempo Information</h4>
       <div class="table-responsive">
-        <table id="BootstrapVueNext__ID__v-63__" class="table b-table table-hover table-striped" aria-busy="false">
+        <table id="BootstrapVueNext__ID__v-70__" class="table b-table table-hover table-striped" aria-busy="false">
           <thead class="">
             <tr class="">
               <th scope="col" class="">Name

--- a/m4d/ClientApp/src/pages/new-music/__tests__/__snapshots__/new-music.test.ts.snap
+++ b/m4d/ClientApp/src/pages/new-music/__tests__/__snapshots__/new-music.test.ts.snap
@@ -171,6 +171,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Rumba <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -284,6 +285,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Freestyle <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -556,6 +558,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Neo Tango <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="DWTS" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -748,6 +751,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Tango (Ballroom) <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1046,6 +1050,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Contemporary <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1245,6 +1250,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Paso Doble <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1579,6 +1585,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Contemporary <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1787,6 +1794,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Tango (Ballroom) <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2013,6 +2021,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> West Coast Swing <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2164,6 +2173,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Salsa <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Latin Jazz" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2263,6 +2273,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Quickstep <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2485,6 +2496,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Slow Foxtrot <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2680,6 +2692,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Slow Waltz <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Instrumental" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2766,6 +2779,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Viennese Waltz <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2859,6 +2873,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Lindy Hop <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Jazz" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2967,6 +2982,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Cumbia <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Latin" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3039,6 +3055,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Cumbia <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Latin" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3111,6 +3128,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Slow Foxtrot <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class=""></td>
               <td class="">
@@ -3186,6 +3204,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Slow Foxtrot <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3272,6 +3291,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Viennese Waltz <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="French Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3358,6 +3378,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Samba <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="French Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3471,6 +3492,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Viennese Waltz <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="3/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3616,6 +3638,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> West Coast Swing <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3713,6 +3736,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> Cumbia <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Latin" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3785,6 +3809,7 @@ exports[`New Music > renders a new music page 1`] = `
                   </svg> East Coast Swing <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3837,6 +3862,8 @@ exports[`New Music > renders a new music page 1`] = `
           <!---->
           <!---->
         </table>
+        <!--teleport start-->
+        <!--teleport end-->
         <!--teleport start-->
         <!--teleport end-->
         <!--teleport start-->

--- a/m4d/ClientApp/src/pages/playlist-viewer/__tests__/__snapshots__/playlist-viewer.test.ts.snap
+++ b/m4d/ClientApp/src/pages/playlist-viewer/__tests__/__snapshots__/playlist-viewer.test.ts.snap
@@ -209,6 +209,7 @@ exports[`Playlist Viewer > renders a playlist viewer index page 1`] = `
                   </svg> Castle Foxtrot <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -363,6 +364,7 @@ exports[`Playlist Viewer > renders a playlist viewer index page 1`] = `
                   </svg> Rumba <span class="badge text-bg-light">3</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1960S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -538,6 +540,7 @@ exports[`Playlist Viewer > renders a playlist viewer index page 1`] = `
                   </svg> Castle Foxtrot <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -647,6 +650,7 @@ exports[`Playlist Viewer > renders a playlist viewer index page 1`] = `
                   </svg> Rumba <span class="badge text-bg-light">2</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1960S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -884,6 +888,7 @@ exports[`Playlist Viewer > renders a playlist viewer index page 1`] = `
                   </svg> Rumba <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1960S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1068,6 +1073,7 @@ exports[`Playlist Viewer > renders a playlist viewer index page 1`] = `
                   </svg> Rumba <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="3/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1259,6 +1265,7 @@ exports[`Playlist Viewer > renders a playlist viewer index page 1`] = `
                   </svg> Night Club Two Step <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1377,6 +1384,7 @@ exports[`Playlist Viewer > renders a playlist viewer index page 1`] = `
                   </svg> West Coast Swing <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1940S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1459,6 +1467,8 @@ exports[`Playlist Viewer > renders a playlist viewer index page 1`] = `
           <!---->
           <!---->
         </table>
+        <!--teleport start-->
+        <!--teleport end-->
         <!--teleport start-->
         <!--teleport end-->
         <!--teleport start-->

--- a/m4d/ClientApp/src/pages/song-index/__tests__/__snapshots__/song-index.test.ts.snap
+++ b/m4d/ClientApp/src/pages/song-index/__tests__/__snapshots__/song-index.test.ts.snap
@@ -210,6 +210,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> Viennese Waltz <span class="badge text-bg-light">2</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="3/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -484,6 +485,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> West Coast Swing <span class="badge text-bg-light">2</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="2017" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -670,6 +672,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> Slow Foxtrot <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="2001" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -927,6 +930,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> West Coast Swing <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1940S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1211,6 +1215,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> Slow Foxtrot <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1960S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1456,6 +1461,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> West Coast Swing <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1640,6 +1646,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> West Coast Swing <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1970S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -1867,6 +1874,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> Slow Foxtrot <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="2000S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2059,6 +2067,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> West Coast Swing <span class="badge text-bg-light">2</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1980S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2235,6 +2244,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> West Coast Swing <span class="badge text-bg-light">4</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="2000S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2483,6 +2493,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> Slow Foxtrot <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1990S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2696,6 +2707,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> West Coast Swing <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="2010S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -2885,6 +2897,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> Jazz <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="2010S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3159,6 +3172,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> West Coast Swing <span class="badge text-bg-light">2</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1940S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3465,6 +3479,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> West Coast Swing <span class="badge text-bg-light">2</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1970S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3722,6 +3737,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> Cha Cha <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="2000S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -3877,6 +3893,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> West Coast Swing <span class="badge text-bg-light">4</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="2010S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -4025,6 +4042,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> Rumba <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="2000S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -4198,6 +4216,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> Jive <span class="badge text-bg-light">5</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -4444,6 +4463,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> Cha Cha <span class="badge text-bg-light">2</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -4544,6 +4564,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> Cha Cha <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -4608,6 +4629,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> Cha Cha <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Alternative" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -4701,6 +4723,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> Cha Cha <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -4819,6 +4842,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> Cha Cha <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -4937,6 +4961,7 @@ exports[`Song Index > renders a song index page 1`] = `
                   </svg> Cha Cha <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
+                <!--v-if-->
               </td>
               <td class="">
                 <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
@@ -4985,6 +5010,8 @@ exports[`Song Index > renders a song index page 1`] = `
           <!---->
           <!---->
         </table>
+        <!--teleport start-->
+        <!--teleport end-->
         <!--teleport start-->
         <!--teleport end-->
         <!--teleport start-->

--- a/m4d/ClientApp/src/pages/song/components/SongCore.vue
+++ b/m4d/ClientApp/src/pages/song/components/SongCore.vue
@@ -94,30 +94,16 @@ const artistLink = computed(() => {
   const artist = song.value.artist;
   return artist ? `/song/artist?name=${artist}` : undefined;
 });
+
 const explicitDanceIds = computed(() => {
-  const tags = song.value.tags;
-  return tags
-    ? tags
-        .filter(
-          (t) => t.category === "Dance" && !t.value.startsWith("!") && !t.value.startsWith("-"),
-        )
-        .map((t) => danceDB.fromName(t.value)!.id)
-    : [];
+  return song.value.explicitDanceIds;
 });
+
 const explicitDanceRatings = computed(() => {
   const ratings = song.value.danceRatings ?? [];
   return explicitDanceIds.value.map((id) => ratings.find((dr) => dr.danceId === id)!);
 });
-const numerator = computed(() => {
-  if (hasMeterTag(4)) {
-    return 4;
-  } else if (hasMeterTag(3)) {
-    return 3;
-  } else if (hasMeterTag(2)) {
-    return 2;
-  }
-  return undefined;
-});
+
 const hasUserChanges = computed(() => !!editor.value?.userHasPreviousChanges);
 const editing = computed(() => modified.value || edit.value);
 const isCreator = computed(() => {
@@ -156,9 +142,6 @@ const onDeleteDance = (dr: DanceRating): void => {
 };
 const addProperty = (property: SongProperty): void => {
   safeEditor.value.addProperty(property.name, property.value);
-};
-const hasMeterTag = (numerator: number): boolean => {
-  return !!song.value.tags.find((t) => t.key === `${numerator}/4:Tempo`);
 };
 const onClickLike = (): void => {
   safeEditor.value.toggleLike();
@@ -469,10 +452,9 @@ onBeforeUnmount(() => {
     <DanceChooser
       :filter-ids="explicitDanceIds"
       :tempo="song.tempo"
-      :numerator="numerator"
+      :numerator="song.numerator"
       :hide-name-link="true"
       @choose-dance="addDance"
-      @update-song="updateSong"
     />
     <TagModal v-model="tagModalVisible" :tag-handler="currentTag as TagHandler" />
   </div>

--- a/m4d/ClientApp/src/pages/tempo-counter/components/TempoDeltaInfo.vue
+++ b/m4d/ClientApp/src/pages/tempo-counter/components/TempoDeltaInfo.vue
@@ -31,7 +31,7 @@ const deltaMessage = computed(() => {
     :variant="variant"
     href="#"
     class="d-flex justify-content-between align-items-center"
-    @click="emit('choose-dance', dance.dance.id, $event.ctrlKey)"
+    @click.prevent="emit('choose-dance', dance.dance.id, $event.ctrlKey)"
   >
     <DanceName
       :dance="dance.dance"


### PR DESCRIPTION
- Add a simple "+" button to the dance tags section of a song in song tables for signed in users to add new dances
- Fix an issue where the browser was opening a new tab if you held down the ctrl key to keep the add dance dialog open
- Fix a couple of regressions with schema update, where some of the "Next" overrides didn't make it into the base class.