### PR TITLE
"Inclusive" is a dead concept, cleaning up dancequery to reflect that

### DIFF
--- a/m4d/Controllers/SearchesController.cs
+++ b/m4d/Controllers/SearchesController.cs
@@ -1,5 +1,7 @@
 ﻿using System.Security.Authentication;
 
+using AutoMapper;
+
 using m4d.Services;
 
 using m4dModels;
@@ -14,22 +16,21 @@ using Microsoft.FeatureManagement;
 namespace m4d.Controllers;
 
 [Authorize]
-public class SearchesController : DanceMusicController
+public class SearchesController : ContentController
 {
     public SearchesController(
         DanceMusicContext context, UserManager<ApplicationUser> userManager,
         ISearchServiceManager searchService, IDanceStatsManager danceStatsManager,
         IConfiguration configuration, IFileProvider fileProvider, IBackgroundTaskQueue backroundTaskQueue,
-        IFeatureManagerSnapshot featureManager, ILogger<ActivityLogController> logger) :
+        IFeatureManagerSnapshot featureManager, ILogger<SongController> logger, LinkGenerator linkGenerator, IMapper mapper) :
         base(context, userManager, searchService, danceStatsManager, configuration,
-            fileProvider, backroundTaskQueue, featureManager, logger)
+            fileProvider, backroundTaskQueue, featureManager, logger, linkGenerator, mapper)
     {
         HelpPage = "saved-searches";
     }
 
     // GET: Searches
     public async Task<IActionResult> Index(string user, string sort = null,
-        SongFilter filter = null,
         bool showDetails = false)
     {
         if (string.IsNullOrWhiteSpace(user) || user.Equals(
@@ -66,7 +67,7 @@ public class SearchesController : DanceMusicController
 
         ViewBag.Sort = sort;
         ViewBag.ShowDetails = showDetails;
-        ViewBag.SongFilter = filter;
+        ViewBag.SongFilter = Filter;
         ViewBag.User = user;
         return View(model);
     }

--- a/m4d/Controllers/SearchesController.cs
+++ b/m4d/Controllers/SearchesController.cs
@@ -22,7 +22,7 @@ public class SearchesController : ContentController
         DanceMusicContext context, UserManager<ApplicationUser> userManager,
         ISearchServiceManager searchService, IDanceStatsManager danceStatsManager,
         IConfiguration configuration, IFileProvider fileProvider, IBackgroundTaskQueue backroundTaskQueue,
-        IFeatureManagerSnapshot featureManager, ILogger<SongController> logger, LinkGenerator linkGenerator, IMapper mapper) :
+        IFeatureManagerSnapshot featureManager, ILogger<SearchesController> logger, LinkGenerator linkGenerator, IMapper mapper) :
         base(context, userManager, searchService, danceStatsManager, configuration,
             fileProvider, backroundTaskQueue, featureManager, logger, linkGenerator, mapper)
     {

--- a/m4dModels.Tests/DanceQueryTest.cs
+++ b/m4dModels.Tests/DanceQueryTest.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -7,6 +9,13 @@ namespace m4dModels.Tests
     [TestClass]
     public class DanceQueryTest
     {
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext _)
+        {
+            var t = DanceMusicTester.LoadDances().Result;
+            Trace.WriteLine($"Loaded dances = {t}");
+        }
+
         [TestMethod]
         public void BasicDanceQuery()
         {
@@ -34,15 +43,54 @@ namespace m4dModels.Tests
             var q = new DanceQuery();
             q = q.AddDance("BOL");
             Assert.AreEqual("BOL", q.Query);
+            Assert.IsFalse(q.IsExclusive);
+            Assert.AreEqual(1, q.Dances.Count());
+            Assert.IsTrue(q.HasDance("BOL"));
+            Assert.IsFalse(q.HasDance("RMB"));
 
-            q = q.AddDance("RUM");
-            Assert.AreEqual("BOL,RUM", q.Query);
+            q = q.AddDance("RMB");
+            Assert.AreEqual("BOL,RMB", q.Query);
+            Assert.IsFalse(q.IsExclusive);
+            Assert.AreEqual(2, q.Dances.Count());
+            Assert.IsTrue(q.HasDance("BOL"));
+            Assert.IsTrue(q.HasDance("RMB"));
 
             var qX = q.MakeExclusive();
-            Assert.AreEqual("AND,BOL,RUM", qX.Query);
+            Assert.AreEqual("AND,BOL,RMB", qX.Query);
+            Assert.IsTrue(qX.IsExclusive);
+            Assert.AreEqual(2, qX.Dances.Count());
+            Assert.IsTrue(qX.HasDance("BOL"));
+            Assert.IsTrue(qX.HasDance("RMB"));
 
             q = qX.MakeInclusive();
-            Assert.AreEqual("BOL,RUM", q.Query);
+            Assert.AreEqual("BOL,RMB", q.Query);
+            Assert.IsFalse(q.IsExclusive);
+            Assert.AreEqual(2, q.Dances.Count());
+            Assert.IsTrue(q.HasDance("BOL"));
+            Assert.IsTrue(q.HasDance("RMB"));
+        }
+
+        [TestMethod]
+        public void InferredOperators_AreMappedToExplicit()
+        {
+            // ANDX should behave as AND
+            var qAndX = new DanceQuery("ADX,BOL,RMB");
+            var qAnd = new DanceQuery("AND,BOL,RMB");
+            Assert.AreEqual(qAnd.ODataFilter, qAndX.ODataFilter);
+            Assert.AreEqual(qAnd.IsExclusive, qAndX.IsExclusive);
+
+            // OOX should behave as inclusive (no prefix)
+            var qOneOfX = new DanceQuery("OOX,BOL,RMB");
+            var qOneOf = new DanceQuery("BOL,RMB");
+            Assert.AreEqual(qOneOf.ODataFilter, qOneOfX.ODataFilter);
+            Assert.AreEqual(qOneOf.IsExclusive, qOneOfX.IsExclusive);
+
+            // Mixed: inferred operator should be normalized
+            var qMixed = new DanceQuery("ADX,BOL,RMB");
+            Assert.IsTrue(qMixed.IsExclusive);
+            var qMixedInclusive = qMixed.MakeInclusive();
+            Assert.IsFalse(qMixedInclusive.IsExclusive);
+            Assert.IsFalse(qMixedInclusive.Query.StartsWith("AND,", StringComparison.InvariantCultureIgnoreCase));
         }
     }
 }

--- a/m4dModels/DanceQuery.cs
+++ b/m4dModels/DanceQuery.cs
@@ -65,7 +65,7 @@ namespace m4dModels
             get
             {
                 // Exclusive if starts with AND and more than one dance
-                return StartsWith(And) && Query.IndexOf(',', 4) != -1;
+                return StartsWith(And) && Query.IndexOf(',', And.Length + 1) != -1;
             }
         }
 


### PR DESCRIPTION
This removes the concept of inclusive from DanceQueries except where we need it to interpret old queries that may include the inclusive modifier. Similar changes to both the csharp and the typescript code.