### PR TITLE
Small fixes for batch updates

### DIFF
--- a/m4d/Controllers/SongController.cs
+++ b/m4d/Controllers/SongController.cs
@@ -732,7 +732,7 @@ public class SongController : ContentController
     [HttpPost]
     [ValidateAntiForgeryToken]
     [Authorize(Roles = "dbAdmin")]
-    public async Task<ActionResult> BatchAdminEdit(SongFilter filter, string properties, string user = null)
+    public async Task<ActionResult> BatchAdminEdit(string properties, string user = null)
     {
         UseVue = UseVue.No;
         Debug.Assert(User.Identity != null, "User.Identity != null");

--- a/m4d/Properties/launchSettings.json
+++ b/m4d/Properties/launchSettings.json
@@ -47,6 +47,16 @@
       },
       "applicationUrl": "https://localhost:5001;http://localhost:5000"
     },
+    "m4d-prod-db": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "SEARCHINDEX": "SongIndexProd",
+        "ASPNETCORE_VITE": "true"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    },
     "m4d-spotify": {
       "commandName": "Project",
       "launchBrowser": true,


### PR DESCRIPTION
- several of the batch update endpoints had explicit song filter parameters, which no longer bind correctly - move to using the implicit song filter
- I don’t think dynamic changing of the azure search db is working. for now, create a launch profile for production so I can point to that from a dev machine to do batch updating