### PR TITLE
Local Development Access to Production Database

### DIFF
--- a/architecture/azure-app-service-setup-managed-identity.md
+++ b/architecture/azure-app-service-setup-managed-identity.md
@@ -1108,7 +1108,7 @@ The `m4d-prod-db` launch profile in `Properties/launchSettings.json` is pre-conf
 - `PROD_DB=true` — signals `Program.cs` to load `ProdConnectionString` from user secrets
 - `SEARCHINDEX=SongIndexProd` — uses the production search index
 
-Migrations are **automatically skipped** when the connection string targets `*.database.windows.net` in Development mode — no opt-in flag needed.
+Migrations are **automatically skipped** when `PROD_DB` is set — no separate opt-in flag needed.
 
 ```bash
 dotnet run --launch-profile m4d-prod-db --project m4d
@@ -1124,7 +1124,7 @@ On launch, a browser window will open for Azure AD authentication (with MFA). Af
 
 ```txt
 [Database] PROD_DB mode: Using ProdConnectionString from user secrets
-Skipping database migrations and seed data - Azure SQL detected in Development mode
+Skipping database migrations and seed data - PROD_DB is set
 ```
 
 Browse to `https://localhost:5001` and verify production song data loads.
@@ -1140,7 +1140,8 @@ Simply use any other launch profile (e.g., `m4d-vite`, `m4d-build`). The product
 - **No passwords stored**: Authentication uses your Azure AD identity via interactive browser login
 - **Visible reminder**: The interactive login prompt on each launch makes it unmistakable that you're connected to production
 - **Auditable**: All database access is logged under your Azure AD identity
-- **Automatic migration guard**: Migrations are automatically skipped when the connection string targets `*.database.windows.net` in Development mode — no opt-in flag to forget
+- **Automatic migration guard**: Migrations are automatically skipped when `PROD_DB` is set — no separate flag to forget
+- **Development-only**: `PROD_DB` is ignored outside the Development environment, so it can't accidentally change the DB in staging/production
 - **Connection string not in source control**: Stored in user secrets, loaded only when `PROD_DB=true`
 - **Firewall scoped**: Only your specific IP address can connect (not open to all)
 - **Profile-scoped**: `PROD_DB=true` only applies when using the `m4d-prod-db` profile — other profiles use LocalDB

--- a/architecture/azure-app-service-setup-managed-identity.md
+++ b/architecture/azure-app-service-setup-managed-identity.md
@@ -694,27 +694,23 @@ If you see errors, proceed to Phase 6 (Troubleshooting).
 1. **Browse to**: `https://m4d-<environment>.azurewebsites.net`
 
 2. **Verify Home Page**:
-
    - ✅ Page loads without errors
    - ✅ Navigation menu appears
    - ✅ No error messages
    - Tests: Azure Search, App Configuration
 
 3. **Verify Search**:
-
    - Click "Songs" or search for a dance/song
    - ✅ Search results appear
    - Tests: Azure Search indexes
 
 4. **Verify User Registration/Login**:
-
    - Click "Register" or "Log In"
    - ✅ Form appears
    - ✅ Can create account or sign in
    - Tests: SQL Database connection
 
 5. **Verify OAuth Providers** (if enabled):
-
    - Click "Log in with Google" (or Facebook, Spotify)
    - ✅ Redirect to provider
    - ✅ Can authenticate
@@ -1071,6 +1067,85 @@ This allows Azure health probes to pass quickly (typically < 10 seconds) instead
 
 **Background Initialization**: `StartupInitializationService` hosted service performs any post-startup validation tasks asynchronously without blocking the request pipeline.
 
+## Local Development: Access Production Database via Azure AD
+
+Enable local development access to the production Azure SQL database using your Microsoft Entra ID (Azure AD) credentials. No passwords are stored — authentication flows through `Microsoft.Data.SqlClient`'s `Active Directory Interactive` mode, which prompts a browser login with MFA support.
+
+### Prerequisites
+
+- Azure CLI installed (`az --version`)
+- Your Microsoft account is configured as the Azure AD admin on SQL Server `n8a541qjnq` (see [Phase 2.4](#24-azure-sql-server---verify-azure-ad-admin-one-time))
+
+### Step 1: Add Dev Machine IP to SQL Server Firewall
+
+1. Azure Portal → **SQL Server** (`n8a541qjnq`)
+2. **Security** → **Networking** → **Firewall rules**
+3. Click **+ Add your client IPv4 address** (or add manually):
+   - **Rule name**: `dev-machine`
+   - **Start IP**: `<your-public-IP>`
+   - **End IP**: `<your-public-IP>`
+4. Click **Save**
+
+**Note**: If your IP changes frequently, you'll need to update this rule. A static IP or VPN is ideal.
+
+### Step 2: Sign In to Azure CLI
+
+```bash
+az login --tenant 77fd022e-b4cb-4681-aa1d-c4f8ec6bec90
+```
+
+The `--tenant` flag is required because the Azure AD admin is a personal Microsoft account (`live.com#`) which requires MFA — without it, `az login` fails with `AADSTS50076`.
+
+Authenticate with the same Microsoft account that is the SQL Server Azure AD admin.
+
+Verify:
+
+```bash
+az account show --query "{name:name, user:user.name}" -o table
+```
+
+### Step 3: Launch with Production Database Profile
+
+The `m4d-prod-db` launch profile in `Properties/launchSettings.json` is pre-configured with everything needed:
+
+- `ConnectionStrings__DanceMusicContextConnection` — production connection string using `Active Directory Interactive` authentication (environment variables use `__` as a separator and take highest priority in ASP.NET Core configuration)
+- `SEARCHINDEX=SongIndexProd` — uses the production search index
+- `SKIP_MIGRATIONS=true` — **prevents** running `db.Migrate()` and dev seed data against production
+
+```bash
+dotnet run --launch-profile m4d-prod-db --project m4d
+```
+
+Or launch via VS Code / Visual Studio using the **m4d-prod-db** profile.
+
+**Why environment variable instead of user secrets?** User secrets override `appsettings.json` for ALL launch profiles, so every profile (`m4d-vite`, `m4d-build`, etc.) would hit the production database. By using an environment variable in `launchSettings.json`, the production connection is scoped to only the `m4d-prod-db` profile. All other profiles continue using LocalDB from `appsettings.json`.
+
+**Note**: `launchSettings.json` is not deployed to production (it's a local development file). The production connection string uses `Active Directory Interactive` which prompts a browser login with MFA support on first connection — no passwords are stored.
+
+### Step 4: Verify
+
+On launch, a browser window will open for Azure AD authentication (with MFA). After signing in, check the console output for:
+
+```
+Skipping database migrations and seed data - SKIP_MIGRATIONS is set
+```
+
+Browse to `https://localhost:5001` and verify production song data loads. The interactive login prompt serves as a deliberate reminder that you are running against the production database.
+
+### Switching Back to LocalDB
+
+Simply use any other launch profile (e.g., `m4d-vite`, `m4d-build`). The production connection string is scoped to `m4d-prod-db` only — no cleanup needed.
+
+### Security Considerations
+
+- **No passwords stored**: Authentication uses your Azure AD identity via interactive browser login
+- **Visible reminder**: The interactive login prompt on each launch makes it unmistakable that you're connected to production
+- **Auditable**: All database access is logged under your Azure AD identity
+- **Migration guard**: `SKIP_MIGRATIONS=true` in the launch profile prevents accidental schema changes or dev seed data on production
+- **Firewall scoped**: Only your specific IP address can connect (not open to all)
+- **Profile-scoped**: The production connection string only applies when using the `m4d-prod-db` profile — other profiles use LocalDB
+- **No deployment risk**: `launchSettings.json` is a local development file, not deployed to Azure
+
 ## Related Documentation
 
 - [Managed Identity Self-Contained Plan](managed-identity-self-contained-plan.md) - Overall migration strategy and troubleshooting log
@@ -1081,5 +1156,6 @@ This allows Azure health probes to pass quickly (typically < 10 seconds) instead
 
 | Date       | Change                                              | Author                               |
 | ---------- | --------------------------------------------------- | ------------------------------------ |
+| 2025-07-12 | Added local development production DB access guide  | Azure AD Interactive auth setup      |
 | 2026-01-06 | Added performance optimization section              | Startup timeout troubleshooting      |
 | 2025-12-31 | Initial version based on troubleshooting experience | Extracted from managed-identity plan |

--- a/architecture/azure-app-service-setup-managed-identity.md
+++ b/architecture/azure-app-service-setup-managed-identity.md
@@ -1073,7 +1073,7 @@ Enable local development access to the production Azure SQL database using your 
 
 ### Prerequisites
 
-- Azure CLI installed (`az --version`)
+- Azure CLI installed (`az --version`) — needed for managing firewall rules
 - Your Microsoft account is configured as the Azure AD admin on SQL Server `n8a541qjnq` (see [Phase 2.4](#24-azure-sql-server---verify-azure-ad-admin-one-time))
 
 ### Step 1: Add Dev Machine IP to SQL Server Firewall
@@ -1088,29 +1088,27 @@ Enable local development access to the production Azure SQL database using your 
 
 **Note**: If your IP changes frequently, you'll need to update this rule. A static IP or VPN is ideal.
 
-### Step 2: Sign In to Azure CLI
+### Step 2: Store Production Connection String in User Secrets
+
+The production connection string is stored in [user secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets) — never in source control.
 
 ```bash
-az login --tenant 77fd022e-b4cb-4681-aa1d-c4f8ec6bec90
+cd m4d
+dotnet user-secrets set ProdConnectionString "Server=n8a541qjnq.database.windows.net,1433;Initial Catalog=music4dance_db;Authentication=Active Directory Interactive;Encrypt=True;TrustServerCertificate=False"
 ```
 
-The `--tenant` flag is required because the Azure AD admin is a personal Microsoft account (`live.com#`) which requires MFA — without it, `az login` fails with `AADSTS50076`.
+`Active Directory Interactive` prompts a browser login with MFA support on first connection. This is both secure and serves as a visible reminder that you're running against production.
 
-Authenticate with the same Microsoft account that is the SQL Server Azure AD admin.
-
-Verify:
-
-```bash
-az account show --query "{name:name, user:user.name}" -o table
-```
+**Note**: `az login` is **not** required for database access — `Active Directory Interactive` handles authentication directly. You only need `az login` for Azure CLI management tasks (e.g., updating firewall rules).
 
 ### Step 3: Launch with Production Database Profile
 
-The `m4d-prod-db` launch profile in `Properties/launchSettings.json` is pre-configured with everything needed:
+The `m4d-prod-db` launch profile in `Properties/launchSettings.json` is pre-configured with:
 
-- `ConnectionStrings__DanceMusicContextConnection` — production connection string using `Active Directory Interactive` authentication (environment variables use `__` as a separator and take highest priority in ASP.NET Core configuration)
+- `PROD_DB=true` — signals `Program.cs` to load `ProdConnectionString` from user secrets
 - `SEARCHINDEX=SongIndexProd` — uses the production search index
-- `SKIP_MIGRATIONS=true` — **prevents** running `db.Migrate()` and dev seed data against production
+
+Migrations are **automatically skipped** when the connection string targets `*.database.windows.net` in Development mode — no opt-in flag needed.
 
 ```bash
 dotnet run --launch-profile m4d-prod-db --project m4d
@@ -1118,19 +1116,20 @@ dotnet run --launch-profile m4d-prod-db --project m4d
 
 Or launch via VS Code / Visual Studio using the **m4d-prod-db** profile.
 
-**Why environment variable instead of user secrets?** User secrets override `appsettings.json` for ALL launch profiles, so every profile (`m4d-vite`, `m4d-build`, etc.) would hit the production database. By using an environment variable in `launchSettings.json`, the production connection is scoped to only the `m4d-prod-db` profile. All other profiles continue using LocalDB from `appsettings.json`.
-
-**Note**: `launchSettings.json` is not deployed to production (it's a local development file). The production connection string uses `Active Directory Interactive` which prompts a browser login with MFA support on first connection — no passwords are stored.
+**Why user secrets + PROD_DB flag?** User secrets keep the production connection string out of source control. The `PROD_DB` flag ensures the production connection string is only loaded for this specific profile — all other profiles continue using LocalDB from `appsettings.json`.
 
 ### Step 4: Verify
 
 On launch, a browser window will open for Azure AD authentication (with MFA). After signing in, check the console output for:
 
-```
-Skipping database migrations and seed data - SKIP_MIGRATIONS is set
+```txt
+[Database] PROD_DB mode: Using ProdConnectionString from user secrets
+Skipping database migrations and seed data - Azure SQL detected in Development mode
 ```
 
-Browse to `https://localhost:5001` and verify production song data loads. The interactive login prompt serves as a deliberate reminder that you are running against the production database.
+Browse to `https://localhost:5001` and verify production song data loads.
+
+If you see `PROD_DB is set but ProdConnectionString is not configured`, run the `dotnet user-secrets set` command from Step 2.
 
 ### Switching Back to LocalDB
 
@@ -1141,9 +1140,10 @@ Simply use any other launch profile (e.g., `m4d-vite`, `m4d-build`). The product
 - **No passwords stored**: Authentication uses your Azure AD identity via interactive browser login
 - **Visible reminder**: The interactive login prompt on each launch makes it unmistakable that you're connected to production
 - **Auditable**: All database access is logged under your Azure AD identity
-- **Migration guard**: `SKIP_MIGRATIONS=true` in the launch profile prevents accidental schema changes or dev seed data on production
+- **Automatic migration guard**: Migrations are automatically skipped when the connection string targets `*.database.windows.net` in Development mode — no opt-in flag to forget
+- **Connection string not in source control**: Stored in user secrets, loaded only when `PROD_DB=true`
 - **Firewall scoped**: Only your specific IP address can connect (not open to all)
-- **Profile-scoped**: The production connection string only applies when using the `m4d-prod-db` profile — other profiles use LocalDB
+- **Profile-scoped**: `PROD_DB=true` only applies when using the `m4d-prod-db` profile — other profiles use LocalDB
 - **No deployment risk**: `launchSettings.json` is a local development file, not deployed to Azure
 
 ## Related Documentation
@@ -1154,8 +1154,8 @@ Simply use any other launch profile (e.g., `m4d-vite`, `m4d-build`). The product
 
 ## Change Log
 
-| Date       | Change                                              | Author                               |
-| ---------- | --------------------------------------------------- | ------------------------------------ |
-| 2025-07-12 | Added local development production DB access guide  | Azure AD Interactive auth setup      |
-| 2026-01-06 | Added performance optimization section              | Startup timeout troubleshooting      |
-| 2025-12-31 | Initial version based on troubleshooting experience | Extracted from managed-identity plan |
+| Date       | Change                                                 | Author                                               |
+| ---------- | ------------------------------------------------------ | ---------------------------------------------------- |
+| 2026-04-08 | Local dev prod DB: user secrets + auto migration guard | PROD_DB flag, no connection string in source control |
+| 2026-01-06 | Added performance optimization section                 | Startup timeout troubleshooting                      |
+| 2025-12-31 | Initial version based on troubleshooting experience    | Extracted from managed-identity plan                 |

--- a/m4d/Program.cs
+++ b/m4d/Program.cs
@@ -114,12 +114,12 @@ if (!string.IsNullOrEmpty(connectionString))
 else
 {
     Console.WriteLine("[Database] WARNING: No connection string found - database will be unavailable");
-    Console.WriteLine("[Database] Expected 'AZURE_SQL_CONNECTIONSTRING' (Azure Service Connector) or 'DanceMusicContextConnection' (local)");
+    Console.WriteLine("[Database] Expected 'AZURE_SQL_CONNECTIONSTRING' (Azure Service Connector), 'DanceMusicContextConnection' (local), or PROD_DB + ProdConnectionString (user secrets)");
 }
 
-// When PROD_DB is set, override connection string from ProdConnectionString
+// When PROD_DB is set in Development, override connection string from ProdConnectionString
 // (stored in user secrets via: dotnet user-secrets set ProdConnectionString "<connection-string>")
-var useProdDb = builder.Configuration.GetValue<bool>("PROD_DB");
+var useProdDb = builder.Configuration.GetValue<bool>("PROD_DB") && builder.Environment.IsDevelopment();
 if (useProdDb)
 {
     var prodConnectionString = builder.Configuration["ProdConnectionString"];
@@ -133,6 +133,10 @@ if (useProdDb)
         Console.WriteLine("[Database] WARNING: PROD_DB is set but ProdConnectionString is not configured");
         Console.WriteLine("[Database] Set it via: dotnet user-secrets set ProdConnectionString \"Server=<server>.database.windows.net,1433;Initial Catalog=<db>;Authentication=Active Directory Interactive;Encrypt=True;TrustServerCertificate=False\"");
     }
+}
+else if (builder.Configuration.GetValue<bool>("PROD_DB") && !builder.Environment.IsDevelopment())
+{
+    Console.WriteLine("[Database] WARNING: PROD_DB is set but ignored outside Development environment");
 }
 
 var services = builder.Services;
@@ -839,12 +843,9 @@ _ = Task.Run(async () =>
         return;
     }
 
-    var skipMigrations = isDevelopment
-        && !string.IsNullOrEmpty(connectionString)
-        && connectionString.Contains(".database.windows.net", StringComparison.OrdinalIgnoreCase);
-    if (skipMigrations)
+    if (useProdDb)
     {
-        Console.WriteLine("Skipping database migrations and seed data - Azure SQL detected in Development mode");
+        Console.WriteLine("Skipping database migrations and seed data - PROD_DB is set");
         return;
     }
 

--- a/m4d/Program.cs
+++ b/m4d/Program.cs
@@ -821,6 +821,13 @@ _ = Task.Run(async () =>
         return;
     }
 
+    var skipMigrations = configuration.GetValue<bool>("SKIP_MIGRATIONS");
+    if (skipMigrations)
+    {
+        Console.WriteLine("Skipping database migrations and seed data - SKIP_MIGRATIONS is set");
+        return;
+    }
+
     Console.WriteLine("Running database migrations in background...");
     try
     {

--- a/m4d/Program.cs
+++ b/m4d/Program.cs
@@ -117,6 +117,24 @@ else
     Console.WriteLine("[Database] Expected 'AZURE_SQL_CONNECTIONSTRING' (Azure Service Connector) or 'DanceMusicContextConnection' (local)");
 }
 
+// When PROD_DB is set, override connection string from ProdConnectionString
+// (stored in user secrets via: dotnet user-secrets set ProdConnectionString "<connection-string>")
+var useProdDb = builder.Configuration.GetValue<bool>("PROD_DB");
+if (useProdDb)
+{
+    var prodConnectionString = builder.Configuration["ProdConnectionString"];
+    if (!string.IsNullOrEmpty(prodConnectionString))
+    {
+        connectionString = prodConnectionString;
+        Console.WriteLine("[Database] PROD_DB mode: Using ProdConnectionString from user secrets");
+    }
+    else
+    {
+        Console.WriteLine("[Database] WARNING: PROD_DB is set but ProdConnectionString is not configured");
+        Console.WriteLine("[Database] Set it via: dotnet user-secrets set ProdConnectionString \"Server=<server>.database.windows.net,1433;Initial Catalog=<db>;Authentication=Active Directory Interactive;Encrypt=True;TrustServerCertificate=False\"");
+    }
+}
+
 var services = builder.Services;
 var environment = builder.Environment;
 var configuration = builder.Configuration;
@@ -821,10 +839,12 @@ _ = Task.Run(async () =>
         return;
     }
 
-    var skipMigrations = configuration.GetValue<bool>("SKIP_MIGRATIONS");
+    var skipMigrations = isDevelopment
+        && !string.IsNullOrEmpty(connectionString)
+        && connectionString.Contains(".database.windows.net", StringComparison.OrdinalIgnoreCase);
     if (skipMigrations)
     {
-        Console.WriteLine("Skipping database migrations and seed data - SKIP_MIGRATIONS is set");
+        Console.WriteLine("Skipping database migrations and seed data - Azure SQL detected in Development mode");
         return;
     }
 

--- a/m4d/Properties/launchSettings.json
+++ b/m4d/Properties/launchSettings.json
@@ -53,7 +53,9 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "SEARCHINDEX": "SongIndexProd",
-        "ASPNETCORE_VITE": "true"
+        "ASPNETCORE_VITE": "true",
+        "SKIP_MIGRATIONS": "true",
+        "ConnectionStrings__DanceMusicContextConnection": "Server=n8a541qjnq.database.windows.net,1433;Initial Catalog=music4dance_db;Authentication=Active Directory Interactive;Encrypt=True;TrustServerCertificate=False"
       },
       "applicationUrl": "https://localhost:5001;http://localhost:5000"
     },

--- a/m4d/Properties/launchSettings.json
+++ b/m4d/Properties/launchSettings.json
@@ -54,8 +54,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "SEARCHINDEX": "SongIndexProd",
         "ASPNETCORE_VITE": "true",
-        "SKIP_MIGRATIONS": "true",
-        "ConnectionStrings__DanceMusicContextConnection": "Server=n8a541qjnq.database.windows.net,1433;Initial Catalog=music4dance_db;Authentication=Active Directory Interactive;Encrypt=True;TrustServerCertificate=False"
+        "PROD_DB": "true"
       },
       "applicationUrl": "https://localhost:5001;http://localhost:5000"
     },


### PR DESCRIPTION
## Summary

Adds a secure way to run the application locally against the production Azure SQL database using Azure AD authentication (`Active Directory Interactive`). No passwords or connection strings are committed to source control.

## Changes

- **`m4d/Program.cs`**: Added `PROD_DB` mode (Development-only) that loads `ProdConnectionString` from user secrets. Migrations are automatically skipped when `PROD_DB` is set.
- **`m4d/Properties/launchSettings.json`**: `m4d-prod-db` launch profile uses `PROD_DB=true` flag — connection string comes from user secrets, not launchSettings.
- **`architecture/azure-app-service-setup-managed-identity.md`**: New “Local Development: Access Production Database via Azure AD” section with full setup guide.

## Key Design Decisions

- **User secrets + PROD_DB flag**: The production connection string is stored in user secrets (never in source control). The `PROD_DB=true` environment variable in launchSettings gates when it’s loaded, so other profiles continue using LocalDB.
- **Auto-detect migration guard**: Migrations are automatically skipped when `PROD_DB` is set. This is tied to the explicit flag rather than connection string pattern matching, so it doesn’t interfere with other Azure SQL databases (staging/test). `PROD_DB` itself is ignored outside Development, preventing accidental use in staging/production.
- **Active Directory Interactive**: Chosen over `Active Directory Default` because the Azure AD admin is a personal Microsoft account requiring MFA. The interactive browser prompt also serves as a visible reminder that you’re running against production.
