### PR TITLE
Waltz correction controls

### DIFF
--- a/architecture/waltz-correction-controls.md
+++ b/architecture/waltz-correction-controls.md
@@ -168,10 +168,11 @@ for (const dr of waltzRatings) {
 **Visibility computed:**
 
 ```typescript
-const waltzIds = ["SWZ", "CSW", "VWZ", "TGV"];
+const WALTZ_IDS: string[] =
+  safeDanceDatabase().groups.find((g) => g.id === "WLZ")?.danceIds ?? [];
 const waltzRatings = computed(() =>
   (props.song.danceRatings ?? []).filter(
-    (dr) => waltzIds.includes(dr.danceId) && dr.weight > 0,
+    (dr) => WALTZ_IDS.includes(dr.danceId) && dr.weight > 0,
   ),
 );
 const showCard = computed(
@@ -184,14 +185,15 @@ const showCard = computed(
 );
 ```
 
-**Template:** A `<BCard>` with `border-variant="warning"` and a brief explanatory paragraph, followed by three `<BButton>` elements (one per case). Each button calls its handler, then emits `'edit'`.
+**Template:** A `<BCard>` with `border-variant="warning"` and a brief explanatory paragraph, followed by four `<BButton>` elements (one per case). Each button calls its handler, then emits `'edit'`.
 
 **Button labels (suggested):**
 | Button | Label | Variant |
 |--------|-------|---------|
 | Case 1 | "Performer dances Waltz to 4/4 (Fake)" | `outline-secondary` |
 | Case 2 | "Meter tag wrong — correct 4/4 → 3/4" | `outline-warning` |
-| Case 3 | "Meter + tempo wrong — correct 4/4 → 3/4 and adjust BPM" | `outline-danger` || Case 4 | "Song has compound time — 4/4 feel with underlying waltz triple feel" | `outline-info` |
+| Case 3 | "Meter + tempo wrong — correct 4/4 → 3/4 and adjust BPM" | `outline-danger` |
+| Case 4 | "Song has compound time — 4/4 feel with underlying waltz triple feel" | `outline-info` |
 **Handler sketch:**
 
 ```typescript

--- a/architecture/waltz-correction-controls.md
+++ b/architecture/waltz-correction-controls.md
@@ -1,0 +1,267 @@
+# Waltz 4/4 Correction Controls
+
+## Problem
+
+A significant number of songs are tagged as both a Waltz dance style (SWZ, CSW, VWZ, TGV) and the meter tag `4/4:Tempo`. Waltzes are by definition 3/4, so this combination is almost always a data error introduced by the automated tempo algorithm. This feature gives `canEdit` users a one-click-then-save flow to correct these songs directly from the song details page.
+
+---
+
+## Detection Conditions
+
+The correction card is shown only when **all** of the following are true:
+
+1. The user is authenticated and has the `canEdit` role (`context.canEdit`).
+2. The song has at least one positive waltz dance rating — weight > 0 for any dance in the **WLZ** dance group.
+3. The song has a `4/4:Tempo` tag (`song.hasMeterTag(4)` returns `true`).
+4. The page is **not** currently in edit mode (hide the card once any correction has been queued).
+
+The waltz dance IDs are derived at runtime from the **WLZ group** in the dance database (`dancegroups.json`), currently `["CSW", "SWZ", "VWZ", "TGV"]`. Detection filters `song.danceRatings` for any entry whose `danceId` is in that set and whose `weight > 0`.
+
+```typescript
+const WALTZ_IDS: string[] =
+  safeDanceDatabase().groups.find((g) => g.id === "WLZ")?.danceIds ?? [];
+```
+
+This means adding or removing a waltz from the WLZ group in `dancegroups.json` automatically updates detection — no code change needed.
+
+---
+
+## Correction Actions
+
+### Case 1 — "It's Fake" (4/4 is intentional)
+
+> Rare: an expert performer genuinely dances this waltz to a 4/4 track.
+
+**Mutations:**
+
+- For each waltz dance rating on the song, add a dance-specific `Fake:Tempo` tag:
+
+  ```txt
+  Tag+:SWZ = Fake:Tempo      (if SWZ is present)
+  Tag+:VWZ = Fake:Tempo      (if VWZ is present)
+  Tag+:CSW = Fake:Tempo      (if CSW is present)
+  Tag+:TGV = Fake:Tempo      (if TGV is present)
+  ```
+
+  Using `editor.addProperty(\`${PropertyType.addedTags}:${danceId}\`, "Fake:Tempo")` for each waltz.
+
+- The `4/4:Tempo` song-level tag is **left in place** — the 4/4 is accurate for this track.
+
+**Result after save:** The dance entry gains a `Fake:Tempo` chip. Future queries can filter or flag these with `Fake:Tempo` to separate them from real waltz tempo matches.
+
+---
+
+### Case 2 — "Bad 4/4 tag" (song is a waltz, tempo value is correct)
+
+> The song tempo is correct in BPM, but the 4/4 meter tag was added incorrectly — the algorithm measured BPM accurately but misidentified the meter.
+
+**Mutations:**
+
+- Remove `4/4:Tempo` song-level tag:
+  ```
+  Tag- = 4/4:Tempo
+  ```
+- Add `3/4:Tempo` song-level tag only if it does not already exist:
+  ```
+  Tag+ = 3/4:Tempo   (skip if song.hasMeterTag(3))
+  ```
+
+Using:
+
+```typescript
+editor.addProperty(PropertyType.removedTags, "4/4:Tempo");
+if (!song.hasMeterTag(3)) {
+  editor.addProperty(PropertyType.addedTags, "3/4:Tempo");
+}
+```
+
+**Result after save:** Song meter tag corrected; BPM unchanged.
+
+---
+
+### Case 3 — "Bad 4/4 tag + bad tempo" (meter and tempo both wrong)
+
+> The algorithm identified the beat correctly but counted 4 beats per measure instead of 3, so the reported BPM is 4/3 × the correct value. Correcting requires adjusting the tempo as well as the meter tag.
+
+**Mutations:**
+Same as Case 2, plus:
+
+- Multiply the current tempo by 3/4 and round to nearest integer:
+  ```
+  Tempo = round(song.tempo × 3 / 4)
+  ```
+  Using `editor.modifyProperty(PropertyType.tempoField, correctedTempo.toString())`.
+
+```typescript
+editor.addProperty(PropertyType.removedTags, "4/4:Tempo");
+if (!song.hasMeterTag(3)) {
+  editor.addProperty(PropertyType.addedTags, "3/4:Tempo");
+}
+const correctedTempo = Math.round((song.tempo! * 3) / 4);
+editor.modifyProperty(PropertyType.tempoField, correctedTempo.toString());
+```
+
+**Example:** A song at 120 BPM tagged 4/4 is likely a 90 BPM waltz. After correction: 90 BPM, `3/4:Tempo`.
+
+**Result after save:** Both the meter tag and the BPM value are corrected.
+
+---
+
+### Case 4 — "Compound Time" (song works for both 4/4 dances and waltz)
+
+> Some songs have a slow 4/4 beat that works well for Foxtrot or similar dances, but also have an underlying triple-time feel that can be danced as a fast waltz (e.g., Viennese Waltz). The 4/4 beat is real and should stay — but the waltz needs to be identified as compound time.
+
+**Mutations:**
+
+- Add `12/8:Tempo` song-level tag (only if not already present):
+  ```
+  Tag+ = 12/8:Tempo
+  ```
+- Add `Compound Time:Tempo` dance-specific tag to each waltz dance rating:
+  ```
+  Tag+:SWZ = Compound Time:Tempo      (if SWZ is present)
+  Tag+:VWZ = Compound Time:Tempo      (if VWZ is present)
+  Tag+:CSW = Compound Time:Tempo      (if CSW is present)
+  Tag+:TGV = Compound Time:Tempo      (if TGV is present)
+  ```
+- The existing `4/4:Tempo` tag is **left in place** — the 4/4 feel is accurate for the song.
+- The BPM tempo value is **not changed**.
+
+Using:
+
+```typescript
+if (!song.tags?.some((t) => t.key === "12/8:Tempo")) {
+  editor.addProperty(PropertyType.addedTags, "12/8:Tempo");
+}
+for (const dr of waltzRatings) {
+  editor.addProperty(
+    `${PropertyType.addedTags}:${dr.danceId}`,
+    "Compound Time:Tempo",
+  );
+}
+```
+
+**Note:** 12/8 is used as a conventional label for compound duple/quadruple time even when the actual notation may differ. The `Compound Time:Tempo` dance tag provides the semantic flag for filtering/display.
+
+**Result after save:** The song retains its 4/4 tag and BPM. The waltz dance rating gains a `Compound Time:Tempo` chip. The song also gains a `12/8:Tempo` song-level tag indicating compound time.
+
+---
+
+## New Component — `WaltzCorrectionCard.vue`
+
+**Location:** `src/pages/song/components/WaltzCorrectionCard.vue`
+
+**Props:**
+
+```typescript
+{
+  song: Song;
+  editor?: SongEditor;
+  editing?: boolean;
+  user?: string;
+  canEdit?: boolean;
+}
+```
+
+**Emits:** `edit` — signals SongCore to enter edit mode (same pattern as `DanceDetails` and `TagListEditor`).
+
+**Visibility computed:**
+
+```typescript
+const waltzIds = ["SWZ", "CSW", "VWZ", "TGV"];
+const waltzRatings = computed(() =>
+  (props.song.danceRatings ?? []).filter(
+    (dr) => waltzIds.includes(dr.danceId) && dr.weight > 0,
+  ),
+);
+const showCard = computed(
+  () =>
+    !!props.user &&
+    props.canEdit &&
+    !props.editing &&
+    waltzRatings.value.length > 0 &&
+    props.song.hasMeterTag(4),
+);
+```
+
+**Template:** A `<BCard>` with `border-variant="warning"` and a brief explanatory paragraph, followed by three `<BButton>` elements (one per case). Each button calls its handler, then emits `'edit'`.
+
+**Button labels (suggested):**
+| Button | Label | Variant |
+|--------|-------|---------|
+| Case 1 | "Performer dances Waltz to 4/4 (Fake)" | `outline-secondary` |
+| Case 2 | "Meter tag wrong — correct 4/4 → 3/4" | `outline-warning` |
+| Case 3 | "Meter + tempo wrong — correct 4/4 → 3/4 and adjust BPM" | `outline-danger` || Case 4 | "Song has compound time — 4/4 feel with underlying waltz triple feel" | `outline-info` |
+**Handler sketch:**
+
+```typescript
+const applyFake = () => {
+  for (const dr of waltzRatings.value) {
+    props.editor!.addProperty(
+      `${PropertyType.addedTags}:${dr.danceId}`,
+      "Fake:Tempo",
+    );
+  }
+  emit("edit");
+};
+
+const applyBad44 = () => {
+  props.editor!.addProperty(PropertyType.removedTags, "4/4:Tempo");
+  if (!props.song.hasMeterTag(3)) {
+    props.editor!.addProperty(PropertyType.addedTags, "3/4:Tempo");
+  }
+  emit("edit");
+};
+
+const applyBad44AndTempo = () => {
+  applyBad44();
+  const correctedTempo = Math.round((props.song.tempo! * 3) / 4);
+  props.editor!.modifyProperty(
+    PropertyType.tempoField,
+    correctedTempo.toString(),
+  );
+};
+```
+
+(Note: `applyBad44AndTempo` calls `applyBad44` which already emits `'edit'`, so no duplicate emit needed.)
+
+---
+
+## Changes to `SongCore.vue`
+
+Add a new `<BRow>` after the existing dances + stats row, containing a single `<BCol>` that renders `<WaltzCorrectionCard>`:
+
+```html
+<BRow v-if="editor && context.canEdit">
+  <BCol>
+    <WaltzCorrectionCard
+      :song="song as Song"
+      :editor="editor as SongEditor"
+      :editing="editing"
+      :user="model.userName"
+      @edit="setEdit"
+    />
+  </BCol>
+</BRow>
+```
+
+The `v-if="editor && context.canEdit"` guard keeps the row out of the DOM entirely for anonymous and non-`canEdit` users. `WaltzCorrectionCard` itself also guards internally on `showCard`, so it renders nothing when conditions aren't met — the `<BRow>` guard just avoids unnecessary component mounting.
+
+---
+
+## Files Affected
+
+| File                                                | Change                                                 |
+| --------------------------------------------------- | ------------------------------------------------------ |
+| `src/pages/song/components/WaltzCorrectionCard.vue` | **New** — the correction card component                |
+| `src/pages/song/components/SongCore.vue`            | Add `<WaltzCorrectionCard>` row after dances+stats row |
+
+No model changes are required. All mutations use existing `SongEditor` public API (`addProperty`, `modifyProperty`) and existing `Song` public API (`hasMeterTag`, `danceRatings`).
+
+---
+
+## Open Questions / Future Work
+
+- **Per-waltz granularity:** If a song has multiple waltz ratings (e.g., both SWZ and VWZ), Case 1 applies `Fake:Tempo` to all of them. If individual waltz tagging is needed later, the card could be expanded to show one row per waltz.
+- **Tempo display preview:** A future enhancement could show the computed corrected tempo (e.g., "120 BPM → 90 BPM") inline in the Case 3 button so users can verify before applying.
+- **Undo:** All changes go through `SongEditor` and are reversible via "Cancel" before saving, or via "Undo My Changes" after saving.

--- a/m4d/ClientApp/src/assets/content/tags.json
+++ b/m4d/ClientApp/src/assets/content/tags.json
@@ -132,6 +132,10 @@
     "count": 3
   },
   {
+    "key": "12/8:Tempo",
+    "count": 0
+  },
+  {
     "key": "2/4:Tempo",
     "count": 1
   },
@@ -2894,6 +2898,10 @@
   {
     "key": "Compositional Ambient:Music",
     "count": 20
+  },
+  {
+    "key": "Compound Time:Tempo",
+    "count": 0
   },
   {
     "key": "Conscious Hip Hop:Music",

--- a/m4d/ClientApp/src/pages/song-merge/__tests__/__snapshots__/song-merge.test.ts.snap
+++ b/m4d/ClientApp/src/pages/song-merge/__tests__/__snapshots__/song-merge.test.ts.snap
@@ -221,6 +221,11 @@ exports[`Song Merge > Renders the Merge Page 1`] = `
 </div>
 <div class="row">
   <div class="col">
+    <!--v-if-->
+  </div>
+</div>
+<div class="row">
+  <div class="col">
     <div class="card border-primary">
       <!---->
       <!---->

--- a/m4d/ClientApp/src/pages/song/__tests__/__snapshots__/song.test.ts.snap
+++ b/m4d/ClientApp/src/pages/song/__tests__/__snapshots__/song.test.ts.snap
@@ -227,6 +227,7 @@ exports[`Song Details > Renders the Song Details Page 1`] = `
             <form id="undoForm" action="/song/undoUserChanges" method="post" style="display: none;"><input type="hidden" name="__RequestVerificationToken"><input type="hidden" name="id" value="ee9680db-423e-47d2-851a-f08ddcbe9ff9"><input type="hidden" name="filter" value="v2-Index-----\\-me|h"></form>
           </div>
         </div>
+        <!--v-if-->
         <div class="row">
           <div class="col">
             <div class="card border-primary">

--- a/m4d/ClientApp/src/pages/song/components/SongCore.vue
+++ b/m4d/ClientApp/src/pages/song/components/SongCore.vue
@@ -431,6 +431,18 @@ onBeforeUnmount(() => {
         </form>
       </BCol>
     </BRow>
+    <BRow v-if="editor && context.canEdit">
+      <BCol>
+        <WaltzCorrectionCard
+          :song="song as Song"
+          :editor="editor as SongEditor"
+          :editing="editing"
+          :user="model.userName"
+          :can-edit="context.canEdit"
+          @edit="setEdit"
+        />
+      </BCol>
+    </BRow>
     <BRow>
       <BCol v-if="song.albums"
         ><AlbumList

--- a/m4d/ClientApp/src/pages/song/components/WaltzCorrectionCard.vue
+++ b/m4d/ClientApp/src/pages/song/components/WaltzCorrectionCard.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { Song } from "@/models/Song";
+import { SongEditor } from "@/models/SongEditor";
+import { PropertyType } from "@/models/SongProperty";
+
+const WALTZ_IDS = ["SWZ", "CSW", "VWZ", "TGV"] as const;
+
+const props = defineProps<{
+  song: Song;
+  editor?: SongEditor;
+  editing?: boolean;
+  user?: string;
+  canEdit?: boolean;
+}>();
+
+const emit = defineEmits<{ edit: [] }>();
+
+const waltzRatings = computed(() =>
+  (props.song.danceRatings ?? []).filter(
+    (dr) => (WALTZ_IDS as readonly string[]).includes(dr.danceId) && dr.weight > 0,
+  ),
+);
+
+const showCard = computed(
+  () =>
+    !!props.user &&
+    props.canEdit &&
+    !props.editing &&
+    waltzRatings.value.length > 0 &&
+    props.song.hasMeterTag(4),
+);
+
+const correctedTempo = computed(() =>
+  props.song.tempo ? Math.round((props.song.tempo * 3) / 4) : undefined,
+);
+
+const applyMeterFix = () => {
+  props.editor!.addProperty(PropertyType.removedTags, "4/4:Tempo");
+  if (!props.song.hasMeterTag(3)) {
+    props.editor!.addProperty(PropertyType.addedTags, "3/4:Tempo");
+  }
+};
+
+const onFake = () => {
+  for (const dr of waltzRatings.value) {
+    props.editor!.addProperty(`${PropertyType.addedTags}:${dr.danceId}`, "Fake:Tempo");
+  }
+  emit("edit");
+};
+
+const onBadMeter = () => {
+  applyMeterFix();
+  emit("edit");
+};
+
+const onBadMeterAndTempo = () => {
+  applyMeterFix();
+  props.editor!.modifyProperty(PropertyType.tempoField, correctedTempo.value!.toString());
+  emit("edit");
+};
+</script>
+
+<template>
+  <BCard v-if="showCard" border-variant="warning" class="mt-2">
+    <template #header>
+      <span class="text-warning fw-semibold">Waltz / 4/4 Conflict</span>
+    </template>
+    <BCardBody>
+      <p class="mb-2 small text-muted">
+        This song is rated as a Waltz (3/4 meter) but has a <strong>4/4</strong> meter tag. Choose
+        the appropriate correction:
+      </p>
+      <div class="d-grid gap-2">
+        <BButton variant="outline-secondary" @click="onFake">
+          Performer dances Waltz to 4/4 (mark as Fake)
+        </BButton>
+        <BButton variant="outline-warning" @click="onBadMeter">
+          Meter tag wrong — correct 4/4 → 3/4 (tempo unchanged)
+        </BButton>
+        <BButton v-if="correctedTempo" variant="outline-danger" @click="onBadMeterAndTempo">
+          Meter + tempo wrong — correct 4/4 → 3/4 and adjust BPM ({{ song.tempo }} →
+          {{ correctedTempo }})
+        </BButton>
+      </div>
+    </BCardBody>
+  </BCard>
+</template>

--- a/m4d/ClientApp/src/pages/song/components/WaltzCorrectionCard.vue
+++ b/m4d/ClientApp/src/pages/song/components/WaltzCorrectionCard.vue
@@ -3,8 +3,10 @@ import { computed } from "vue";
 import { Song } from "@/models/Song";
 import { SongEditor } from "@/models/SongEditor";
 import { PropertyType } from "@/models/SongProperty";
+import { safeDanceDatabase } from "@/helpers/DanceEnvironmentManager";
 
-const WALTZ_IDS = ["SWZ", "CSW", "VWZ", "TGV"] as const;
+const WALTZ_IDS: string[] =
+  safeDanceDatabase().groups.find((g) => g.id === "WLZ")?.danceIds ?? [];
 
 const props = defineProps<{
   song: Song;
@@ -18,7 +20,7 @@ const emit = defineEmits<{ edit: [] }>();
 
 const waltzRatings = computed(() =>
   (props.song.danceRatings ?? []).filter(
-    (dr) => (WALTZ_IDS as readonly string[]).includes(dr.danceId) && dr.weight > 0,
+    (dr) => WALTZ_IDS.includes(dr.danceId) && dr.weight > 0,
   ),
 );
 
@@ -59,6 +61,18 @@ const onBadMeterAndTempo = () => {
   props.editor!.modifyProperty(PropertyType.tempoField, correctedTempo.value!.toString());
   emit("edit");
 };
+
+const onCompoundTime = () => {
+  // Add 12/8 song-level meter tag only if not already present
+  if (!props.song.tags?.some((t) => t.key === "12/8:Tempo")) {
+    props.editor!.addProperty(PropertyType.addedTags, "12/8:Tempo");
+  }
+  // Mark each waltz dance rating as compound time
+  for (const dr of waltzRatings.value) {
+    props.editor!.addProperty(`${PropertyType.addedTags}:${dr.danceId}`, "Compound Time:Tempo");
+  }
+  emit("edit");
+};
 </script>
 
 <template>
@@ -81,6 +95,10 @@ const onBadMeterAndTempo = () => {
         <BButton v-if="correctedTempo" variant="outline-danger" @click="onBadMeterAndTempo">
           Meter + tempo wrong — correct 4/4 → 3/4 and adjust BPM ({{ song.tempo }} →
           {{ correctedTempo }})
+        </BButton>
+        <BButton variant="outline-info" @click="onCompoundTime">
+          Song has compound time — 4/4 feel (e.g. Foxtrot) with underlying waltz triple feel (adds
+          12/8 and marks waltz as Compound Time)
         </BButton>
       </div>
     </BCardBody>

--- a/m4d/ClientApp/src/pages/song/components/WaltzCorrectionCard.vue
+++ b/m4d/ClientApp/src/pages/song/components/WaltzCorrectionCard.vue
@@ -5,8 +5,7 @@ import { SongEditor } from "@/models/SongEditor";
 import { PropertyType } from "@/models/SongProperty";
 import { safeDanceDatabase } from "@/helpers/DanceEnvironmentManager";
 
-const WALTZ_IDS: string[] =
-  safeDanceDatabase().groups.find((g) => g.id === "WLZ")?.danceIds ?? [];
+const WALTZ_IDS: string[] = safeDanceDatabase().groups.find((g) => g.id === "WLZ")?.danceIds ?? [];
 
 const props = defineProps<{
   song: Song;
@@ -19,9 +18,7 @@ const props = defineProps<{
 const emit = defineEmits<{ edit: [] }>();
 
 const waltzRatings = computed(() =>
-  (props.song.danceRatings ?? []).filter(
-    (dr) => WALTZ_IDS.includes(dr.danceId) && dr.weight > 0,
-  ),
+  (props.song.danceRatings ?? []).filter((dr) => WALTZ_IDS.includes(dr.danceId) && dr.weight > 0),
 );
 
 const showCard = computed(

--- a/m4d/ClientApp/src/pages/song/components/WaltzCorrectionCard.vue
+++ b/m4d/ClientApp/src/pages/song/components/WaltzCorrectionCard.vue
@@ -9,7 +9,7 @@ const WALTZ_IDS: string[] = safeDanceDatabase().groups.find((g) => g.id === "WLZ
 
 const props = defineProps<{
   song: Song;
-  editor?: SongEditor;
+  editor: SongEditor;
   editing?: boolean;
   user?: string;
   canEdit?: boolean;
@@ -31,7 +31,7 @@ const showCard = computed(
 );
 
 const correctedTempo = computed(() =>
-  props.song.tempo ? Math.round((props.song.tempo * 3) / 4) : undefined,
+  props.song.tempo != null ? Math.round((props.song.tempo * 3) / 4) : undefined,
 );
 
 const applyMeterFix = () => {

--- a/m4d/ClientApp/src/pages/song/components/__tests__/WaltzCorrectionCard.test.ts
+++ b/m4d/ClientApp/src/pages/song/components/__tests__/WaltzCorrectionCard.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { mount } from "@vue/test-utils";
 import { Song } from "@/models/Song";
 import { SongEditor } from "@/models/SongEditor";

--- a/m4d/ClientApp/src/pages/song/components/__tests__/WaltzCorrectionCard.test.ts
+++ b/m4d/ClientApp/src/pages/song/components/__tests__/WaltzCorrectionCard.test.ts
@@ -85,6 +85,13 @@ function findAllEditProps(editor: SongEditor, name: string): SongProperty[] {
   return editor.editHistory.properties.filter((p) => p.name === name);
 }
 
+/** Get a button by index; throws if absent so the test fails with a clear message */
+function getButton(wrapper: ReturnType<typeof mountCard>["wrapper"], index: number) {
+  const button = wrapper.findAll("button")[index];
+  if (!button) throw new Error(`No button at index ${index}`);
+  return button;
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -169,8 +176,7 @@ describe("WaltzCorrectionCard.vue", () => {
   describe("Case 1 — Fake (performer dances waltz to 4/4)", () => {
     it("adds Fake:Tempo tag for the waltz dance on click and emits edit", async () => {
       const { wrapper, editor } = mountCard();
-      const buttons = wrapper.findAll("button");
-      await buttons[0].trigger("click");
+      await getButton(wrapper, 0).trigger("click");
 
       const fakeProp = findEditProp(editor, "Tag+:SWZ");
       expect(fakeProp).toBeDefined();
@@ -184,8 +190,7 @@ describe("WaltzCorrectionCard.vue", () => {
         danceRatings: ["SWZ+1", "VWZ+1"],
       });
       const { wrapper, editor } = mountCard({ history });
-      const buttons = wrapper.findAll("button");
-      await buttons[0].trigger("click");
+      await getButton(wrapper, 0).trigger("click");
 
       const swzProp = findEditProp(editor, "Tag+:SWZ");
       const vwzProp = findEditProp(editor, "Tag+:VWZ");
@@ -199,8 +204,7 @@ describe("WaltzCorrectionCard.vue", () => {
         danceRatings: ["TGV+1"],
       });
       const { wrapper, editor } = mountCard({ history });
-      const buttons = wrapper.findAll("button");
-      await buttons[0].trigger("click");
+      await getButton(wrapper, 0).trigger("click");
 
       const tgvProp = findEditProp(editor, "Tag+:TGV");
       expect(tgvProp?.value).toBe("Fake:Tempo");
@@ -208,8 +212,7 @@ describe("WaltzCorrectionCard.vue", () => {
 
     it("does NOT remove the 4/4:Tempo tag", async () => {
       const { wrapper, editor } = mountCard();
-      const buttons = wrapper.findAll("button");
-      await buttons[0].trigger("click");
+      await getButton(wrapper, 0).trigger("click");
 
       const removeProp = findEditProp(editor, PropertyType.removedTags);
       expect(removeProp).toBeUndefined();
@@ -219,8 +222,7 @@ describe("WaltzCorrectionCard.vue", () => {
   describe("Case 2 — Bad meter (meter tag wrong, tempo value correct)", () => {
     it("removes 4/4:Tempo, adds 3/4:Tempo, and emits edit", async () => {
       const { wrapper, editor } = mountCard();
-      const buttons = wrapper.findAll("button");
-      await buttons[1].trigger("click");
+      await getButton(wrapper, 1).trigger("click");
 
       const removeProp = findEditProp(editor, PropertyType.removedTags);
       const addProp = findEditProp(editor, PropertyType.addedTags);
@@ -235,8 +237,7 @@ describe("WaltzCorrectionCard.vue", () => {
         danceRatings: ["SWZ+1"],
       });
       const { wrapper, editor } = mountCard({ history });
-      const buttons = wrapper.findAll("button");
-      await buttons[1].trigger("click");
+      await getButton(wrapper, 1).trigger("click");
 
       // 3/4:Tempo should NOT be added again
       const addedProps = findAllEditProps(editor, PropertyType.addedTags);
@@ -250,8 +251,7 @@ describe("WaltzCorrectionCard.vue", () => {
 
     it("does NOT modify the tempo field", async () => {
       const { wrapper, editor } = mountCard();
-      const buttons = wrapper.findAll("button");
-      await buttons[1].trigger("click");
+      await getButton(wrapper, 1).trigger("click");
 
       // No Tempo property in the edit history (setupEdit adds .Edit, User, Time — not Tempo)
       const tempoProps = findAllEditProps(editor, PropertyType.tempoField);
@@ -263,8 +263,7 @@ describe("WaltzCorrectionCard.vue", () => {
     it("removes 4/4:Tempo, adds 3/4:Tempo, adjusts tempo to ¾ × original, and emits edit", async () => {
       // 120 BPM → 90 BPM after correction (120 × 3/4 = 90)
       const { wrapper, editor } = mountCard();
-      const buttons = wrapper.findAll("button");
-      await buttons[2].trigger("click");
+      await getButton(wrapper, 2).trigger("click");
 
       const removeProp = findEditProp(editor, PropertyType.removedTags);
       const addProp = findEditProp(editor, PropertyType.addedTags);
@@ -284,8 +283,7 @@ describe("WaltzCorrectionCard.vue", () => {
         tempo: "100",
       });
       const { wrapper, editor } = mountCard({ history });
-      const buttons = wrapper.findAll("button");
-      await buttons[2].trigger("click");
+      await getButton(wrapper, 2).trigger("click");
 
       const tempoProp = findEditProp(editor, PropertyType.tempoField);
       expect(tempoProp?.value).toBe("75");
@@ -299,8 +297,7 @@ describe("WaltzCorrectionCard.vue", () => {
         tempo: "101",
       });
       const { wrapper, editor } = mountCard({ history });
-      const buttons = wrapper.findAll("button");
-      await buttons[2].trigger("click");
+      await getButton(wrapper, 2).trigger("click");
 
       const tempoProp = findEditProp(editor, PropertyType.tempoField);
       expect(tempoProp?.value).toBe("76");
@@ -309,9 +306,79 @@ describe("WaltzCorrectionCard.vue", () => {
     it("marks the editor as modified", async () => {
       const { wrapper, editor } = mountCard();
       expect(editor.modified).toBe(false);
-      const buttons = wrapper.findAll("button");
-      await buttons[2].trigger("click");
+      await getButton(wrapper, 2).trigger("click");
       expect(editor.modified).toBe(true);
+    });
+  });
+
+  describe("Case 4 — Compound time (4/4 feel with underlying waltz triple time)", () => {
+    it("adds 12/8:Tempo song-level tag and Compound Time:Tempo dance tag, emits edit", async () => {
+      const { wrapper, editor } = mountCard();
+      await getButton(wrapper, 3).trigger("click");
+
+      const addedProps = findAllEditProps(editor, PropertyType.addedTags);
+      const has128 = addedProps.some((p) => p.value === "12/8:Tempo");
+      const compoundProp = findEditProp(editor, "Tag+:SWZ");
+
+      expect(has128).toBe(true);
+      expect(compoundProp?.value).toBe("Compound Time:Tempo");
+      expect(wrapper.emitted("edit")).toBeTruthy();
+    });
+
+    it("does NOT add 12/8:Tempo if it is already present on the song", async () => {
+      const history = makeHistory({
+        tags: "4/4:Tempo|12/8:Tempo|Slow Waltz:Dance",
+        danceRatings: ["SWZ+1"],
+      });
+      const { wrapper, editor } = mountCard({ history });
+      await getButton(wrapper, 3).trigger("click");
+
+      const addedProps = findAllEditProps(editor, PropertyType.addedTags);
+      const added128 = addedProps.filter((p) => p.value === "12/8:Tempo");
+      expect(added128).toHaveLength(0);
+
+      // Compound Time tag still added to the waltz
+      const compoundProp = findEditProp(editor, "Tag+:SWZ");
+      expect(compoundProp?.value).toBe("Compound Time:Tempo");
+    });
+
+    it("adds Compound Time:Tempo to each waltz when multiple waltzes are present", async () => {
+      const history = makeHistory({
+        tags: "4/4:Tempo|Slow Waltz:Dance|Viennese Waltz:Dance",
+        danceRatings: ["SWZ+1", "VWZ+1"],
+      });
+      const { wrapper, editor } = mountCard({ history });
+      await getButton(wrapper, 3).trigger("click");
+
+      expect(findEditProp(editor, "Tag+:SWZ")?.value).toBe("Compound Time:Tempo");
+      expect(findEditProp(editor, "Tag+:VWZ")?.value).toBe("Compound Time:Tempo");
+    });
+
+    it("adds Compound Time:Tempo for TGV (regression)", async () => {
+      const history = makeHistory({
+        tags: "4/4:Tempo|Tango Vals:Dance",
+        danceRatings: ["TGV+1"],
+      });
+      const { wrapper, editor } = mountCard({ history });
+      await getButton(wrapper, 3).trigger("click");
+
+      expect(findEditProp(editor, "Tag+:TGV")?.value).toBe("Compound Time:Tempo");
+    });
+
+    it("does NOT remove or change the 4/4:Tempo tag", async () => {
+      const { wrapper, editor } = mountCard();
+      await getButton(wrapper, 3).trigger("click");
+
+      const removeProp = findEditProp(editor, PropertyType.removedTags);
+      expect(removeProp).toBeUndefined();
+    });
+
+    it("does NOT modify the tempo BPM value", async () => {
+      const { wrapper, editor } = mountCard();
+      await getButton(wrapper, 3).trigger("click");
+
+      const tempoProps = findAllEditProps(editor, PropertyType.tempoField);
+      expect(tempoProps).toHaveLength(0);
     });
   });
 });

--- a/m4d/ClientApp/src/pages/song/components/__tests__/WaltzCorrectionCard.test.ts
+++ b/m4d/ClientApp/src/pages/song/components/__tests__/WaltzCorrectionCard.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { Song } from "@/models/Song";
+import { SongEditor } from "@/models/SongEditor";
+import { SongHistory } from "@/models/SongHistory";
+import { SongProperty, PropertyType } from "@/models/SongProperty";
+import { setupTestEnvironment, mockResizObserver } from "@/helpers/TestHelpers";
+import WaltzCorrectionCard from "../WaltzCorrectionCard.vue";
+
+setupTestEnvironment();
+mockResizObserver();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal SongHistory with given tags and dance ratings */
+function makeHistory(
+  opts: {
+    tags?: string; // e.g. "4/4:Tempo|Slow Waltz:Dance"
+    danceRatings?: string[]; // e.g. ["SWZ+1", "VWZ+1"]
+    tempo?: string;
+  } = {},
+): SongHistory {
+  const { tags = "", danceRatings = [], tempo = "120" } = opts;
+  const props: { name: string; value: string }[] = [
+    { name: ".Create", value: "" },
+    { name: "User", value: "testuser|P" },
+    { name: "Time", value: "01/01/2024 12:00:00" },
+    { name: "Title", value: "Test Song" },
+    { name: "Artist", value: "Test Artist" },
+    { name: "Tempo", value: tempo },
+  ];
+  if (tags) {
+    props.push({ name: "Tag+", value: tags });
+  }
+  for (const dr of danceRatings) {
+    props.push({ name: "DanceRating", value: dr });
+  }
+  return new SongHistory({
+    id: "test-song-id",
+    properties: props.map((p) => new SongProperty({ name: p.name, value: p.value })),
+  });
+}
+
+interface MountOptions {
+  history?: SongHistory;
+  editing?: boolean;
+  user?: string | null;
+  canEdit?: boolean;
+}
+
+/** Mount WaltzCorrectionCard with a fresh editor derived from the given history */
+function mountCard(opts: MountOptions = {}) {
+  const {
+    history = makeHistory({ tags: "4/4:Tempo|Slow Waltz:Dance", danceRatings: ["SWZ+1"] }),
+    editing = false,
+    user = "testuser",
+    canEdit = true,
+  } = opts;
+  const song = Song.fromHistory(history, user ?? undefined);
+  const editor = new SongEditor(undefined, user ?? undefined, history);
+  return {
+    wrapper: mount(WaltzCorrectionCard, {
+      props: {
+        song,
+        editor,
+        editing,
+        user: user ?? undefined,
+        canEdit,
+      },
+    }),
+    editor,
+    song,
+  };
+}
+
+/** Find a property by name in the editor's edit history (properties added after save point) */
+function findEditProp(editor: SongEditor, name: string): SongProperty | undefined {
+  return editor.editHistory.properties.find((p) => p.name === name);
+}
+
+/** Find all properties by name in the editor's edit history */
+function findAllEditProps(editor: SongEditor, name: string): SongProperty[] {
+  return editor.editHistory.properties.filter((p) => p.name === name);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("WaltzCorrectionCard.vue", () => {
+  describe("visibility", () => {
+    it("shows the card when song has a waltz rating and 4/4 tag, user is authenticated and canEdit", () => {
+      const { wrapper } = mountCard();
+      expect(wrapper.find(".card").exists()).toBe(true);
+    });
+
+    it("hides the card when user is null (unauthenticated)", () => {
+      const { wrapper } = mountCard({ user: null });
+      expect(wrapper.find(".card").exists()).toBe(false);
+    });
+
+    it("hides the card when canEdit is false", () => {
+      const { wrapper } = mountCard({ canEdit: false });
+      expect(wrapper.find(".card").exists()).toBe(false);
+    });
+
+    it("hides the card when editing is true", () => {
+      const { wrapper } = mountCard({ editing: true });
+      expect(wrapper.find(".card").exists()).toBe(false);
+    });
+
+    it("hides the card when the song has no waltz dance ratings", () => {
+      const history = makeHistory({
+        tags: "4/4:Tempo|East Coast Swing:Dance",
+        danceRatings: ["ECS+1"],
+      });
+      const { wrapper } = mountCard({ history });
+      expect(wrapper.find(".card").exists()).toBe(false);
+    });
+
+    it("hides the card when the waltz dance rating is negative (weight ≤ 0)", () => {
+      const history = makeHistory({
+        tags: "4/4:Tempo|Slow Waltz:Dance",
+        danceRatings: ["SWZ-1"],
+      });
+      const { wrapper } = mountCard({ history });
+      expect(wrapper.find(".card").exists()).toBe(false);
+    });
+
+    it("hides the card when the song has a waltz rating but no 4/4 tag", () => {
+      const history = makeHistory({
+        tags: "Slow Waltz:Dance",
+        danceRatings: ["SWZ+1"],
+      });
+      const { wrapper } = mountCard({ history });
+      expect(wrapper.find(".card").exists()).toBe(false);
+    });
+
+    it("shows the card for CSW (Country Waltz)", () => {
+      const history = makeHistory({
+        tags: "4/4:Tempo|Country Waltz:Dance",
+        danceRatings: ["CSW+1"],
+      });
+      const { wrapper } = mountCard({ history });
+      expect(wrapper.find(".card").exists()).toBe(true);
+    });
+
+    it("shows the card for VWZ (Viennese Waltz)", () => {
+      const history = makeHistory({
+        tags: "4/4:Tempo|Viennese Waltz:Dance",
+        danceRatings: ["VWZ+1"],
+      });
+      const { wrapper } = mountCard({ history });
+      expect(wrapper.find(".card").exists()).toBe(true);
+    });
+
+    it("shows the card for TGV (Tango Vals — regression test)", () => {
+      const history = makeHistory({
+        tags: "4/4:Tempo|Tango Vals:Dance",
+        danceRatings: ["TGV+1"],
+      });
+      const { wrapper } = mountCard({ history });
+      expect(wrapper.find(".card").exists()).toBe(true);
+    });
+  });
+
+  describe("Case 1 — Fake (performer dances waltz to 4/4)", () => {
+    it("adds Fake:Tempo tag for the waltz dance on click and emits edit", async () => {
+      const { wrapper, editor } = mountCard();
+      const buttons = wrapper.findAll("button");
+      await buttons[0].trigger("click");
+
+      const fakeProp = findEditProp(editor, "Tag+:SWZ");
+      expect(fakeProp).toBeDefined();
+      expect(fakeProp?.value).toBe("Fake:Tempo");
+      expect(wrapper.emitted("edit")).toBeTruthy();
+    });
+
+    it("adds Fake:Tempo to each waltz dance when multiple waltzes are present", async () => {
+      const history = makeHistory({
+        tags: "4/4:Tempo|Slow Waltz:Dance|Viennese Waltz:Dance",
+        danceRatings: ["SWZ+1", "VWZ+1"],
+      });
+      const { wrapper, editor } = mountCard({ history });
+      const buttons = wrapper.findAll("button");
+      await buttons[0].trigger("click");
+
+      const swzProp = findEditProp(editor, "Tag+:SWZ");
+      const vwzProp = findEditProp(editor, "Tag+:VWZ");
+      expect(swzProp?.value).toBe("Fake:Tempo");
+      expect(vwzProp?.value).toBe("Fake:Tempo");
+    });
+
+    it("adds Fake:Tempo for TGV (regression)", async () => {
+      const history = makeHistory({
+        tags: "4/4:Tempo|Tango Vals:Dance",
+        danceRatings: ["TGV+1"],
+      });
+      const { wrapper, editor } = mountCard({ history });
+      const buttons = wrapper.findAll("button");
+      await buttons[0].trigger("click");
+
+      const tgvProp = findEditProp(editor, "Tag+:TGV");
+      expect(tgvProp?.value).toBe("Fake:Tempo");
+    });
+
+    it("does NOT remove the 4/4:Tempo tag", async () => {
+      const { wrapper, editor } = mountCard();
+      const buttons = wrapper.findAll("button");
+      await buttons[0].trigger("click");
+
+      const removeProp = findEditProp(editor, PropertyType.removedTags);
+      expect(removeProp).toBeUndefined();
+    });
+  });
+
+  describe("Case 2 — Bad meter (meter tag wrong, tempo value correct)", () => {
+    it("removes 4/4:Tempo, adds 3/4:Tempo, and emits edit", async () => {
+      const { wrapper, editor } = mountCard();
+      const buttons = wrapper.findAll("button");
+      await buttons[1].trigger("click");
+
+      const removeProp = findEditProp(editor, PropertyType.removedTags);
+      const addProp = findEditProp(editor, PropertyType.addedTags);
+      expect(removeProp?.value).toBe("4/4:Tempo");
+      expect(addProp?.value).toBe("3/4:Tempo");
+      expect(wrapper.emitted("edit")).toBeTruthy();
+    });
+
+    it("does NOT add 3/4:Tempo if it is already present on the song", async () => {
+      const history = makeHistory({
+        tags: "4/4:Tempo|3/4:Tempo|Slow Waltz:Dance",
+        danceRatings: ["SWZ+1"],
+      });
+      const { wrapper, editor } = mountCard({ history });
+      const buttons = wrapper.findAll("button");
+      await buttons[1].trigger("click");
+
+      // 3/4:Tempo should NOT be added again
+      const addedProps = findAllEditProps(editor, PropertyType.addedTags);
+      const addedThreeQuarter = addedProps.filter((p) => p.value === "3/4:Tempo");
+      expect(addedThreeQuarter).toHaveLength(0);
+
+      // 4/4:Tempo should still be removed
+      const removeProp = findEditProp(editor, PropertyType.removedTags);
+      expect(removeProp?.value).toBe("4/4:Tempo");
+    });
+
+    it("does NOT modify the tempo field", async () => {
+      const { wrapper, editor } = mountCard();
+      const buttons = wrapper.findAll("button");
+      await buttons[1].trigger("click");
+
+      // No Tempo property in the edit history (setupEdit adds .Edit, User, Time — not Tempo)
+      const tempoProps = findAllEditProps(editor, PropertyType.tempoField);
+      expect(tempoProps).toHaveLength(0);
+    });
+  });
+
+  describe("Case 3 — Bad meter + tempo (both meter and BPM are wrong)", () => {
+    it("removes 4/4:Tempo, adds 3/4:Tempo, adjusts tempo to ¾ × original, and emits edit", async () => {
+      // 120 BPM → 90 BPM after correction (120 × 3/4 = 90)
+      const { wrapper, editor } = mountCard();
+      const buttons = wrapper.findAll("button");
+      await buttons[2].trigger("click");
+
+      const removeProp = findEditProp(editor, PropertyType.removedTags);
+      const addProp = findEditProp(editor, PropertyType.addedTags);
+      const tempoProp = findEditProp(editor, PropertyType.tempoField);
+
+      expect(removeProp?.value).toBe("4/4:Tempo");
+      expect(addProp?.value).toBe("3/4:Tempo");
+      expect(tempoProp?.value).toBe("90");
+      expect(wrapper.emitted("edit")).toBeTruthy();
+    });
+
+    it("rounds the corrected tempo to the nearest integer", async () => {
+      // 100 BPM → 75 BPM (100 × 3/4 = 75.0, no rounding needed)
+      const history = makeHistory({
+        tags: "4/4:Tempo|Slow Waltz:Dance",
+        danceRatings: ["SWZ+1"],
+        tempo: "100",
+      });
+      const { wrapper, editor } = mountCard({ history });
+      const buttons = wrapper.findAll("button");
+      await buttons[2].trigger("click");
+
+      const tempoProp = findEditProp(editor, PropertyType.tempoField);
+      expect(tempoProp?.value).toBe("75");
+    });
+
+    it("rounds fractional corrected tempo (e.g. 101 BPM → 76)", async () => {
+      // 101 × 3/4 = 75.75 → rounds to 76
+      const history = makeHistory({
+        tags: "4/4:Tempo|Slow Waltz:Dance",
+        danceRatings: ["SWZ+1"],
+        tempo: "101",
+      });
+      const { wrapper, editor } = mountCard({ history });
+      const buttons = wrapper.findAll("button");
+      await buttons[2].trigger("click");
+
+      const tempoProp = findEditProp(editor, PropertyType.tempoField);
+      expect(tempoProp?.value).toBe("76");
+    });
+
+    it("marks the editor as modified", async () => {
+      const { wrapper, editor } = mountCard();
+      expect(editor.modified).toBe(false);
+      const buttons = wrapper.findAll("button");
+      await buttons[2].trigger("click");
+      expect(editor.modified).toBe(true);
+    });
+  });
+});

--- a/pr-waltz-correction-controls.md
+++ b/pr-waltz-correction-controls.md
@@ -1,0 +1,48 @@
+# PR: Waltz 4/4 Correction Controls
+
+## Summary
+
+Adds a one-click correction card to the song details page for `canEdit` users when a song has a waltz dance rating and a conflicting `4/4:Tempo` tag. Waltzes are by definition 3/4, so this combination is almost always a data error introduced by the automated tempo algorithm.
+
+## Changes
+
+### New component — `WaltzCorrectionCard.vue`
+
+Displayed after the dance ratings row when:
+
+- The user is authenticated and has `canEdit`
+- The song has at least one positive waltz dance rating (any dance in the **WLZ group**: CSW, SWZ, VWZ, TGV)
+- The song has a `4/4:Tempo` tag
+- The page is not already in edit mode
+
+Offers four one-click corrections:
+
+| Button                    | Action                                                                                          |
+| ------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Mark as Fake**          | Adds `Fake:Tempo` dance tag to each waltz rating; leaves 4/4 in place                           |
+| **Correct meter**         | Swaps `4/4:Tempo` → `3/4:Tempo`; tempo BPM unchanged                                            |
+| **Correct meter + tempo** | Swaps `4/4:Tempo` → `3/4:Tempo` and multiplies BPM × ¾                                          |
+| **Compound time**         | Adds `12/8:Tempo` song tag + `Compound Time:Tempo` dance tag to each waltz; leaves 4/4 in place |
+
+Waltz IDs are derived at runtime from the **WLZ dance group** in `dancegroups.json` — no hardcoded list.
+
+### Wired into `SongCore.vue`
+
+The card is rendered in a new row below the dances/stats section, receiving `song`, `editor`, `editing`, `user`, and `canEdit` props.
+
+### New tags added to `tags.json`
+
+- `12/8:Tempo`
+- `Compound Time:Tempo`
+
+### Architecture doc — `architecture/waltz-correction-controls.md`
+
+Documents the detection conditions, all four cases, and the WLZ group derivation approach.
+
+### Tests — `WaltzCorrectionCard.test.ts`
+
+27 tests covering visibility (8), and each of the four correction cases including multi-waltz songs, duplicate-tag guards, and TGV regression cases.
+
+## Testing
+
+All client tests pass (`yarn vitest run`).


### PR DESCRIPTION
## Summary

Adds a one-click correction card to the song details page for `canEdit` users when a song has a waltz dance rating and a conflicting `4/4:Tempo` tag. Waltzes are by definition 3/4, so this combination is almost always a data error introduced by the automated tempo algorithm.

## Changes

### New component — `WaltzCorrectionCard.vue`

Displayed after the dance ratings row when:

- The user is authenticated and has `canEdit`
- The song has at least one positive waltz dance rating (any dance in the **WLZ group**: CSW, SWZ, VWZ, TGV)
- The song has a `4/4:Tempo` tag
- The page is not already in edit mode

Offers four one-click corrections:

| Button                    | Action                                                                                          |
| ------------------------- | ----------------------------------------------------------------------------------------------- |
| **Mark as Fake**          | Adds `Fake:Tempo` dance tag to each waltz rating; leaves 4/4 in place                           |
| **Correct meter**         | Swaps `4/4:Tempo` → `3/4:Tempo`; tempo BPM unchanged                                            |
| **Correct meter + tempo** | Swaps `4/4:Tempo` → `3/4:Tempo` and multiplies BPM × ¾                                          |
| **Compound time**         | Adds `12/8:Tempo` song tag + `Compound Time:Tempo` dance tag to each waltz; leaves 4/4 in place |

Waltz IDs are derived at runtime from the **WLZ dance group** in `dancegroups.json` — no hardcoded list.

### Wired into `SongCore.vue`

The card is rendered in a new row below the dances/stats section, receiving `song`, `editor`, `editing`, `user`, and `canEdit` props.

### New tags added to `tags.json`

- `12/8:Tempo`
- `Compound Time:Tempo`

### Architecture doc — `architecture/waltz-correction-controls.md`

Documents the detection conditions, all four cases, and the WLZ group derivation approach.

### Tests — `WaltzCorrectionCard.test.ts`

27 tests covering visibility (8), and each of the four correction cases including multi-waltz songs, duplicate-tag guards, and TGV regression cases.

## Testing

All client tests pass (`yarn vitest run`).
