### PR TITLE
Fix Tempo Editing & Add Song UX Improvements

### DIFF
--- a/architecture/account-management.md
+++ b/architecture/account-management.md
@@ -1,0 +1,154 @@
+# Account Management
+
+## Overview
+
+music4dance.net uses ASP.NET Core Identity for authentication and user management.
+Registration requires email confirmation. Each user has a username, email, and privacy setting.
+
+---
+
+## Username Policy
+
+### Allowed Characters
+
+- The built-in ASP.NET Identity character restriction is **disabled** (`AllowedUserNameCharacters = ""`)
+- A custom `UsernameValidator` is registered instead
+- **Allowed**: all characters **except** `:`, `;`, `,`, `|`, `@`
+
+```
+Blocked set: : ; , | @
+```
+
+These characters are blocked because they are structural delimiters in the application's internal
+formats (SongFilter, UserQuery, OData filters, and tag strings).
+
+### Why `|` Is Blocked
+
+The `UserQuery` format is `(+|-)username|modifier` where `|` separates the username from the
+modifier character (`l`, `h`, `a`, `d`, `x`). If `|` were allowed in a username, it would break
+`UserQuery` parsing:
+
+- `UserQuery.UserName` extracts via `Query[1..Query.IndexOf('|')]`
+- A username containing `|` would cause the wrong substring to be extracted
+
+### Period (`.`) in Usernames
+
+The period character **is allowed** in usernames (e.g., `forrest.csuy`). This is intentional.
+
+**URL handling:**
+
+- In URL **query strings** (e.g., `?user=forrest.csuy`): periods are unreserved characters per
+  RFC 3986 and require no encoding. These work correctly in all endpoints.
+- In URL **path segments** (e.g., `/users/info/forrest.csuy`): periods are also valid but some
+  older IIS configurations may treat segments ending in an extension-like suffix (`.csuy`) as
+  static file requests. On Azure App Service with ANCM v2 (in-process), all requests pass through
+  the ASP.NET Core pipeline regardless of extension, so this is not an issue in production.
+- In the **SongFilter serialization format**: the delimiter is `-` and periods are transparent —
+  `forrest.csuy` in the User field parses and round-trips correctly.
+- In **Azure Search OData filters**: periods are valid in string literals:
+  `Users/any(t: t eq 'forrest.csuy')` is a well-formed filter.
+
+**URL generation best practice:** When embedding a username in a URL path segment, always use
+`encodeURIComponent(username)` to handle any future allowed characters that would require encoding.
+The `UserLink.vue` component does this for path-based user URLs.
+
+### Other Implications of Allowing Periods
+
+- Usernames like `forrest.csuy` look like domain names or file names — this can confuse some
+  tooling but is not a functional problem
+- Azure App Service has no known issues with periods in ASP.NET Core route parameters
+
+---
+
+## Password Policy
+
+Password requirements use ASP.NET Core Identity defaults (not overridden in `Program.cs`):
+
+| Requirement              | Value |
+| ------------------------ | ----- |
+| Minimum length           | 6     |
+| Require digit            | Yes   |
+| Require lowercase        | Yes   |
+| Require uppercase        | Yes   |
+| Require non-alphanumeric | Yes   |
+| Required unique chars    | 1     |
+
+Password hashing uses `PasswordHasherCompatibilityMode.IdentityV2`.
+
+---
+
+## Privacy Setting
+
+Each user has a `Privacy` byte field:
+
+- `0` — maximum privacy; username is anonymized to the user's GUID in public-facing searches
+- `255` — public; username is visible in search results and history
+
+**Default**: new users are created with `Privacy = 255` (public) in `Register.cshtml.cs`.
+
+**Effect on song searches:** When someone other than the user searches for songs by that user
+(e.g., via `/Song/FilterUser?user=someuser`), `SongSearch.Search()` calls `AnonymizeFilter`
+followed by `DeanonymizeFilter`:
+
+- If `Privacy = 0`: the username is replaced with the user's GUID for the Azure Search OData
+  filter. Since songs are indexed with the lowercase username (not a GUID), this returns zero
+  results. This is by design — a private user's songs are hidden from others.
+- If `Privacy = 255`: the username is passed through unchanged; songs are found normally.
+
+**Admin bypass**: Users with the `dbAdmin` role are exempt from the privacy filter. When a
+`dbAdmin` performs a user song search, `SongSearch` skips the `AnonymizeFilter` step entirely,
+so the username is used as-is in the Azure Search query and all songs are returned regardless
+of the target user's privacy setting. This is implemented via the `isAdmin` parameter on
+`SongSearch`, populated from `User.IsInRole(DanceMusicCoreService.DbaRole)` in `DoAzureSearch`.
+
+---
+
+## Account Setup & Lockout
+
+| Setting                     | Value      |
+| --------------------------- | ---------- |
+| Requires email confirmation | Yes        |
+| Requires unique email       | Yes        |
+| Lockout on failed login     | 3 attempts |
+| Lockout duration            | 15 minutes |
+| Lockout for new users       | Yes        |
+
+---
+
+## UserQuery Format and Usernames
+
+The `UserQuery` class normalizes a username into the internal format `(+|-)username|modifier`:
+
+- `+` prefix = include songs matching this user
+- `-` prefix = exclude songs matching this user
+- Modifier: `l`=liked, `h`=don't like, `a`=any activity, `d`=upvoted, `x`=downvoted, none=any
+
+For `FilterUser?user=forrest.csuy`:
+
+1. `Filter.User = "forrest.csuy"` (raw from query string)
+2. `UserQuery.UserName` = `"forrest.csuy"` (extracted via `Query[1..Query.IndexOf('|')]`)
+3. Azure OData filter = `(Users/any(t: t eq 'forrest.csuy') or Users/any(t: t eq 'forrest.csuy|l'))`
+
+The period does not interfere with any of these steps.
+
+---
+
+## Diagnosing "User Has No Songs" Issues
+
+If `FilterUser?user=someuser` returns no results:
+
+1. **Check privacy setting**: if `Privacy = 0`, songs are hidden from non-admins. Admins
+   (`dbAdmin` role) bypass this and will always see results.
+2. **Check indexing**: Azure Search indexing may lag. Songs added recently may not appear until
+   the index is updated.
+3. **Verify the username**: use the admin users list to confirm the exact username stored in the
+   database (case-sensitive lookup is done case-insensitively, but the index stores lowercase).
+4. **Check for anonymized songs**: songs added by the user before their account was linked may
+   be attributed to a GUID or a different username.
+
+---
+
+## External Login
+
+External login providers (e.g., Google, Microsoft) require the user to choose a username when
+first logging in via `ExternalLogin.cshtml`. The same username validator applies.

--- a/architecture/song-details-viewing-editing.md
+++ b/architecture/song-details-viewing-editing.md
@@ -243,6 +243,7 @@ All endpoints are in `m4d/APIControllers/SongController.cs`:
 | Remove other users' tags  | ❌        | ❌            | ❌       | ✅        | ❌      | ✅                |
 | Edit Tempo/Length         | ❌        | ❌            | ✅       | ✅        | ✅      | ✅                |
 | Edit algo-set Tempo ¹     | ❌        | ✅            | ✅       | ✅        | ✅      | ✅                |
+| Set initial tempo ³       | ❌        | ✅            | ✅       | ✅        | ✅      | ✅                |
 | Edit Title/Artist         | ❌        | ❌            | ❌       | ❌        | ✅      | ✅                |
 | Delete dances             | ❌        | ❌            | ❌       | ❌        | ❌      | ✅                |
 | Admin textarea edit       | ❌        | ❌            | ❌       | ❌        | ❌      | ✅                |
@@ -252,6 +253,8 @@ All endpoints are in `m4d/APIControllers/SongController.cs`:
 Role hierarchy (additive): `dbAdmin` implies all other roles. `canEdit` implies `canTag`-level capabilities. Roles are resolved via `MenuContext` (injected from server into the page's JS environment).
 
 ¹ **"Edit algo-set Tempo"**: Any authenticated user may edit the tempo when it has only ever been set by an algorithmic source (e.g., EchoNest `batch-e`, Tempo Bot) and has never been overridden by a human user. Detected via `Song.isUserModified(PropertyType.tempoField)`. Implemented in `SongStats.vue` via `isSystemTempo`/`canOverrideTempo` computed props and `FieldEditor`'s `overridePermission` prop.
+
+³ **"Set initial tempo"**: Any authenticated user may set the tempo when no tempo has ever been recorded for the song (`song.tempo` is undefined). Implemented in `SongStats.vue` via `canSetTempo = !!props.user && !props.song.tempo`. Once any user sets an initial tempo and saves, this path is closed; further edits require `canTag` or the algo-override path (footnote ¹).
 
 ² **"Remove system-only tags"**: Any authenticated user may remove a tag whose most recent modification was by a batch/algorithmic user (pseudo or batch user). Computed in `SongHistory.systemTagKeys` by replaying the property log and tracking which tags were last touched by a system user. Surfaced in `TagListEditor.vue` as the "Remove System Tags:" section (shown only to non-`canEdit` users; `canEdit` users get the full "Remove Tags:" section instead).
 
@@ -312,13 +315,11 @@ const isSystemTempo = computed(
 
 ### Client — pencil icon (tempo override)
 
-`canOverrideTempo` gates the pencil icon that lets `canTag` users override a bot-set tempo:
+`canOverrideTempo` gates the pencil icon that lets any authenticated user override a bot-set tempo:
 
 ```typescript
 // SongStats.vue
-const canOverrideTempo = computed(
-  () => !!props.user && isSystemTempo.value && context.canTag,
-);
+const canOverrideTempo = computed(() => !!props.user && isSystemTempo.value);
 ```
 
 `isSystemTempo` is `true` only when `Tempo` is set and `isUserModified("Tempo")` is `false`,

--- a/architecture/song-details-viewing-editing.md
+++ b/architecture/song-details-viewing-editing.md
@@ -243,7 +243,7 @@ All endpoints are in `m4d/APIControllers/SongController.cs`:
 | Remove other users' tags  | ❌        | ❌            | ❌       | ✅        | ❌      | ✅                |
 | Edit Tempo/Length         | ❌        | ❌            | ✅       | ✅        | ✅      | ✅                |
 | Edit algo-set Tempo ¹     | ❌        | ✅            | ✅       | ✅        | ✅      | ✅                |
-| Set initial tempo ³       | ❌        | ✅            | ✅       | ✅        | ✅      | ✅                |
+| Set/re-edit own tempo ³   | ❌        | ✅            | ✅       | ✅        | ✅      | ✅                |
 | Edit Title/Artist         | ❌        | ❌            | ❌       | ❌        | ✅      | ✅                |
 | Delete dances             | ❌        | ❌            | ❌       | ❌        | ❌      | ✅                |
 | Admin textarea edit       | ❌        | ❌            | ❌       | ❌        | ❌      | ✅                |
@@ -254,7 +254,7 @@ Role hierarchy (additive): `dbAdmin` implies all other roles. `canEdit` implies 
 
 ¹ **"Edit algo-set Tempo"**: Any authenticated user may edit the tempo when it has only ever been set by an algorithmic source (e.g., EchoNest `batch-e`, Tempo Bot) and has never been overridden by a human user. Detected via `Song.isUserModified(PropertyType.tempoField)`. Implemented in `SongStats.vue` via `isSystemTempo`/`canOverrideTempo` computed props and `FieldEditor`'s `overridePermission` prop.
 
-³ **"Set initial tempo"**: Any authenticated user may set the tempo when no tempo has ever been recorded for the song (`song.tempo` is undefined). Implemented in `SongStats.vue` via `canSetTempo = !!props.user && !props.song.tempo`. Once any user sets an initial tempo and saves, this path is closed; further edits require `canTag` or the algo-override path (footnote ¹).
+³ **"Set/re-edit own tempo"**: Any authenticated user may set the tempo when no tempo has been recorded (`song.tempo` is undefined), **or** re-edit it when they were the last human to set it (`Song.propLastSetBy(tempoField) === currentUser`). Authorship is tracked in `Song.ts` via `propLastSetByMap` (built during `loadProperties`; bot/pseudo edits do not overwrite the map). Implemented in `SongStats.vue` via `canSetTempo`. If another user has since edited the tempo, this path is closed; further edits require `canTag` or the algo-override path (footnote ¹).
 
 ² **"Remove system-only tags"**: Any authenticated user may remove a tag whose most recent modification was by a batch/algorithmic user (pseudo or batch user). Computed in `SongHistory.systemTagKeys` by replaying the property log and tracking which tags were last touched by a system user. Surfaced in `TagListEditor.vue` as the "Remove System Tags:" section (shown only to non-`canEdit` users; `canEdit` users get the full "Remove Tags:" section instead).
 

--- a/m4d/ClientApp/src/components/UserLink.vue
+++ b/m4d/ClientApp/src/components/UserLink.vue
@@ -4,7 +4,9 @@ import { UserQuery } from "@/models/UserQuery";
 
 const props = defineProps<{ user: string }>();
 const userQuery = computed(() => new UserQuery(props.user));
-const userLink = computed(() => `/users/info/${userQuery.value.userName}`);
+const userLink = computed(
+  () => `/users/info/${encodeURIComponent(userQuery.value.userName ?? "")}`,
+);
 const userClasses = computed(() => (userQuery.value.isPseudo ? ["pseudo"] : []));
 </script>
 

--- a/m4d/ClientApp/src/models/Song.ts
+++ b/m4d/ClientApp/src/models/Song.ts
@@ -40,6 +40,8 @@ export class Song extends TaggableObject {
   @jsonArrayMember(AlbumDetails) public albums?: AlbumDetails[];
 
   private userModifiedProperties = new Set<string>();
+  /** Maps field baseName → username of the last non-pseudo editor of that field. */
+  private propLastSetByMap = new Map<string, string>();
 
   public constructor(init?: Partial<Song>) {
     super();
@@ -53,6 +55,15 @@ export class Song extends TaggableObject {
    */
   public isUserModified(field: string): boolean {
     return this.userModifiedProperties.has(field);
+  }
+
+  /**
+   * Returns the username of the last non-pseudo (human) user who set the given field,
+   * or undefined if the field has never been set by a human.
+   * @param field - Property field name (use PropertyType enum values)
+   */
+  public propLastSetBy(field: string): string | undefined {
+    return this.propLastSetByMap.get(field);
   }
 
   public compareToHistory(history: SongHistory, user?: string): boolean {
@@ -397,6 +408,7 @@ export class Song extends TaggableObject {
 
             if (!pseudo) {
               this.userModifiedProperties.add(baseName);
+              this.propLastSetByMap.set(baseName, currentModified.userName);
             }
           }
           break;

--- a/m4d/ClientApp/src/models/Song.ts
+++ b/m4d/ClientApp/src/models/Song.ts
@@ -41,7 +41,7 @@ export class Song extends TaggableObject {
 
   private userModifiedProperties = new Set<string>();
   /** Maps field baseName → username of the last non-pseudo editor of that field. */
-  private propLastSetByMap = new Map<string, string>();
+  private propLastSetByMap = new Map<string, string | undefined>();
 
   public constructor(init?: Partial<Song>) {
     super();
@@ -408,7 +408,9 @@ export class Song extends TaggableObject {
 
             if (!pseudo) {
               this.userModifiedProperties.add(baseName);
-              this.propLastSetByMap.set(baseName, currentModified?.userName);
+              if (currentModified?.userName) {
+                this.propLastSetByMap.set(baseName, currentModified.userName);
+              }
             }
           }
           break;

--- a/m4d/ClientApp/src/models/Song.ts
+++ b/m4d/ClientApp/src/models/Song.ts
@@ -408,7 +408,7 @@ export class Song extends TaggableObject {
 
             if (!pseudo) {
               this.userModifiedProperties.add(baseName);
-              this.propLastSetByMap.set(baseName, currentModified.userName);
+              this.propLastSetByMap.set(baseName, currentModified?.userName);
             }
           }
           break;

--- a/m4d/ClientApp/src/models/__tests__/Song.test.ts
+++ b/m4d/ClientApp/src/models/__tests__/Song.test.ts
@@ -84,4 +84,85 @@ describe("Song", () => {
       expect(song.isUserModified(PropertyType.tempoField)).toBe(true); // User overrode tempo
     });
   });
+
+  describe("propLastSetBy", () => {
+    it("returns the username of the human who set the field", () => {
+      const history = new SongHistory({
+        id: "test123",
+        properties: [
+          new SongProperty({ name: ".Create", value: "" }),
+          new SongProperty({ name: "User", value: "alice" }),
+          new SongProperty({ name: "Tempo", value: "120" }),
+          new SongProperty({ name: "Time", value: new Date().toISOString() }),
+        ],
+      });
+      const song = Song.fromHistory(history);
+      expect(song.propLastSetBy(PropertyType.tempoField)).toBe("alice");
+    });
+
+    it("returns undefined when field was only set by a bot", () => {
+      const history = new SongHistory({
+        id: "test123",
+        properties: [
+          new SongProperty({ name: ".Create", value: "" }),
+          new SongProperty({ name: "User:Proxy", value: "TempoBot|P" }),
+          new SongProperty({ name: "Tempo", value: "120" }),
+          new SongProperty({ name: "Time", value: new Date().toISOString() }),
+        ],
+      });
+      const song = Song.fromHistory(history);
+      expect(song.propLastSetBy(PropertyType.tempoField)).toBeUndefined();
+    });
+
+    it("returns undefined when field has never been set", () => {
+      const history = new SongHistory({
+        id: "test123",
+        properties: [
+          new SongProperty({ name: ".Create", value: "" }),
+          new SongProperty({ name: "User", value: "alice" }),
+          new SongProperty({ name: "Title", value: "Test Song" }),
+          new SongProperty({ name: "Time", value: new Date().toISOString() }),
+        ],
+      });
+      const song = Song.fromHistory(history);
+      expect(song.propLastSetBy(PropertyType.tempoField)).toBeUndefined();
+    });
+
+    it("updates to the latest human editor when multiple users edit the field", () => {
+      const history = new SongHistory({
+        id: "test123",
+        properties: [
+          new SongProperty({ name: ".Create", value: "" }),
+          new SongProperty({ name: "User", value: "alice" }),
+          new SongProperty({ name: "Tempo", value: "120" }),
+          new SongProperty({ name: "Time", value: new Date().toISOString() }),
+          new SongProperty({ name: ".Edit", value: "" }),
+          new SongProperty({ name: "User", value: "bob" }),
+          new SongProperty({ name: "Tempo", value: "130" }),
+          new SongProperty({ name: "Time", value: new Date().toISOString() }),
+        ],
+      });
+      const song = Song.fromHistory(history);
+      expect(song.propLastSetBy(PropertyType.tempoField)).toBe("bob");
+    });
+
+    it("ignores a subsequent bot edit — last human editor is retained", () => {
+      const history = new SongHistory({
+        id: "test123",
+        properties: [
+          new SongProperty({ name: ".Create", value: "" }),
+          new SongProperty({ name: "User", value: "alice" }),
+          new SongProperty({ name: "Tempo", value: "120" }),
+          new SongProperty({ name: "Time", value: new Date().toISOString() }),
+          new SongProperty({ name: ".Edit", value: "" }),
+          new SongProperty({ name: "User:Proxy", value: "TempoBot|P" }),
+          new SongProperty({ name: "Tempo", value: "125" }),
+          new SongProperty({ name: "Time", value: new Date().toISOString() }),
+        ],
+      });
+      const song = Song.fromHistory(history);
+      // Bot edit is blocked from overwriting the human value, so alice remains last setter
+      expect(song.propLastSetBy(PropertyType.tempoField)).toBe("alice");
+    });
+  });
 });

--- a/m4d/ClientApp/src/pages/augment/App.vue
+++ b/m4d/ClientApp/src/pages/augment/App.vue
@@ -23,6 +23,7 @@ const model = ref(TypedJSON.parse(model_, AugmentModel) ?? {});
 const phase = ref<AugmentPhase>(AugmentPhase.lookup);
 const songModel = ref<SongDetailsModel | null>(null);
 const lastSong = ref<Song | null>(null);
+const showThanks = ref(false);
 const created = ref(false);
 const propertiesString = ref("");
 const tabIndex = ref(0);
@@ -60,22 +61,22 @@ const reset = (saved: boolean): void => {
   if (saved) {
     lastSong.value = Song.fromHistory((songModel.value! as SongDetailsModel).songHistory);
     created.value = !!songModel.value!.created;
+    showThanks.value = true;
   }
   phase.value = AugmentPhase.lookup;
-  model.value.id = undefined;
+  model.value.id = undefined; // Clears computedId so AugmentLookup won't re-trigger on re-mount
   songModel.value = null;
-  tabIndex.value = 0; // Reset to "by Title" tab to prevent re-triggering lookup
 };
 
 // Exposed for testing
-defineExpose({ phase, songModel, lastSong, created, tabIndex, editSong, reset });
+defineExpose({ phase, songModel, lastSong, showThanks, created, tabIndex, editSong, reset });
 </script>
 
 <template>
   <PageFrame id="app">
     <BRow v-if="phase === 'lookup'">
       <BCol>
-        <BAlert v-if="lastSong" dismissible :model-value="1000">
+        <BAlert v-if="lastSong && showThanks" v-model="showThanks" dismissible>
           Thank you for {{ created ? "adding" : "editing" }} <i>{{ lastSong.title }}</i> by
           {{ lastSong.artist }}
         </BAlert>

--- a/m4d/ClientApp/src/pages/augment/__tests__/augment.test.ts
+++ b/m4d/ClientApp/src/pages/augment/__tests__/augment.test.ts
@@ -7,7 +7,6 @@ import { SongHistory } from "@/models/SongHistory";
 
 // Mock the global model_ variable
 declare global {
-  // eslint-disable-next-line no-var
   var model_: string;
 }
 
@@ -143,7 +142,8 @@ describe("Augment Page", () => {
       expect(wrapper.vm.lastSong).not.toBeNull();
       expect(wrapper.vm.lastSong?.title).toBe("Test Song");
       expect(wrapper.vm.created).toBe(true);
-      expect(wrapper.vm.tabIndex).toBe(0); // Should reset to first tab
+      expect(wrapper.vm.showThanks).toBe(true); // Should show the thank-you alert
+      expect(wrapper.vm.tabIndex).toBe(1); // Tab should be preserved after save
     });
 
     test("reset with saved=false - should return to lookup without setting lastSong", async () => {
@@ -168,7 +168,8 @@ describe("Augment Page", () => {
       expect(wrapper.vm.phase).toBe("lookup");
       expect(wrapper.vm.songModel).toBeNull();
       expect(wrapper.vm.lastSong).toBeNull(); // Should NOT set lastSong when cancelled
-      expect(wrapper.vm.tabIndex).toBe(0); // Should still reset tab
+      expect(wrapper.vm.showThanks).toBe(false); // Should not show thank-you when cancelled
+      expect(wrapper.vm.tabIndex).toBe(1); // Tab should be preserved after cancel
     });
 
     test("Initial load with ID - should set tabIndex to 1", async () => {

--- a/m4d/ClientApp/src/pages/song/components/FieldEditor.vue
+++ b/m4d/ClientApp/src/pages/song/components/FieldEditor.vue
@@ -30,7 +30,9 @@ watch(
   },
 );
 const commitValue = () => {
-  emit("update-field", new SongProperty({ name: props.name, value: localValue.value }));
+  if (localValue.value !== props.value) {
+    emit("update-field", new SongProperty({ name: props.name, value: localValue.value }));
+  }
 };
 
 const isNumber = computed(() => props.type === "number");

--- a/m4d/ClientApp/src/pages/song/components/FieldEditor.vue
+++ b/m4d/ClientApp/src/pages/song/components/FieldEditor.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { SongProperty } from "@/models/SongProperty";
 import { getMenuContext } from "@/helpers/GetMenuContext";
-import { computed } from "vue";
+import { computed, ref, watch } from "vue";
 
 const context = getMenuContext();
 
@@ -19,12 +19,19 @@ const emit = defineEmits<{
   "update-field": [property: SongProperty];
 }>();
 
-const internalValue = computed({
-  get: () => props.value,
-  set: (value: string) => {
-    emit("update-field", new SongProperty({ name: props.name, value }));
+// Local value lets the user see real-time changes (including arrow-key increments)
+// without immediately calling modifyProperty. The value is only committed—and
+// update-field emitted—when the user explicitly blurs the field or presses Enter.
+const localValue = ref(props.value);
+watch(
+  () => props.value,
+  (newVal) => {
+    localValue.value = newVal;
   },
-});
+);
+const commitValue = () => {
+  emit("update-field", new SongProperty({ name: props.name, value: localValue.value }));
+};
 
 const isNumber = computed(() => props.type === "number");
 const computedType = computed(() => props.type ?? "text");
@@ -43,11 +50,13 @@ const hasEditPermission = computed(() => {
   <span>
     <input
       v-if="editing && hasEditPermission"
-      v-model="internalValue"
+      v-model="localValue"
       :type="computedType"
       class="form-control ml-2"
       style="display: inline"
       :class="{ number: isNumber, text: !isNumber }"
+      @blur="commitValue"
+      @keyup.enter="commitValue"
     />
     <span v-else
       ><slot>{{ value }}</slot></span

--- a/m4d/ClientApp/src/pages/song/components/SongStats.vue
+++ b/m4d/ClientApp/src/pages/song/components/SongStats.vue
@@ -19,8 +19,12 @@ const isSystemTempo = computed(
   () => !!props.song.tempo && !props.song.isUserModified(PropertyType.tempoField),
 );
 const canOverrideTempo = computed(() => !!props.user && isSystemTempo.value);
-/** Any signed-in user can set the tempo when none has been recorded yet. */
-const canSetTempo = computed(() => !!props.user && !props.song.tempo);
+/** Any signed-in user can set tempo when none has been recorded yet, or re-edit it if they were the last human to set it (tracked via `Song.propLastSetBy`). */
+const canSetTempo = computed(
+  () =>
+    !!props.user &&
+    (!props.song.tempo || props.song.propLastSetBy(PropertyType.tempoField) === props.user),
+);
 /** Combined: user can interact with the tempo pencil (algo override or initial set). */
 const canEditTempo = computed(() => canOverrideTempo.value || canSetTempo.value);
 /** canTag users have elevated privileges and can edit tempo on any song. */

--- a/m4d/ClientApp/src/pages/song/components/SongStats.vue
+++ b/m4d/ClientApp/src/pages/song/components/SongStats.vue
@@ -3,6 +3,7 @@ import { Song } from "@/models/Song";
 import { PropertyType } from "@/models/SongProperty";
 import { computed } from "vue";
 import { formatDate } from "@/helpers/timeHelpers";
+import { getMenuContext } from "@/helpers/GetMenuContext";
 
 defineOptions({ inheritAttrs: false });
 
@@ -13,10 +14,17 @@ const props = defineProps<{
   user?: string;
 }>();
 
+const context = getMenuContext();
 const isSystemTempo = computed(
   () => !!props.song.tempo && !props.song.isUserModified(PropertyType.tempoField),
 );
 const canOverrideTempo = computed(() => !!props.user && isSystemTempo.value);
+/** Any signed-in user can set the tempo when none has been recorded yet. */
+const canSetTempo = computed(() => !!props.user && !props.song.tempo);
+/** Combined: user can interact with the tempo pencil (algo override or initial set). */
+const canEditTempo = computed(() => canOverrideTempo.value || canSetTempo.value);
+/** canTag users have elevated privileges and can edit tempo on any song. */
+const canTagUser = computed(() => !!props.user && context.hasRole("canTag"));
 
 const modifiedFormatted = computed(() => formatDate(props.song.modified));
 const createdFormatted = computed(() => formatDate(props.song.created));
@@ -39,14 +47,14 @@ const formatEchoNest = (n: number): string => {
           :value="song.length ? song.length.toString() : ''"
           :editing="editing"
           :is-creator="isCreator"
-          role="isAdmin"
+          role="canTag"
           type="number"
           v-bind="$attrs"
         />
         Seconds</BTd
       >
     </BTr>
-    <BTr v-if="!!song.tempo || editing">
+    <BTr v-if="!!song.tempo || canEditTempo || canTagUser || editing">
       <BTh>Tempo</BTh>
       <BTd
         ><FieldEditor
@@ -55,11 +63,13 @@ const formatEchoNest = (n: number): string => {
           :editing="editing"
           :is-creator="isCreator"
           role="canTag"
-          :override-permission="canOverrideTempo"
+          :override-permission="canEditTempo"
           type="number"
-          v-bind="$attrs" />
+          v-bind="$attrs"
+          >{{ song.tempo || "???" }}</FieldEditor
+        >
         BPM<AlgoGeneratedIcon v-if="!editing" :song="song" /><BButton
-          v-if="canOverrideTempo && !editing"
+          v-if="(canEditTempo || canTagUser) && !editing"
           type="button"
           variant="link"
           class="ms-1 p-0 align-baseline"

--- a/m4d/ClientApp/src/pages/song/components/__tests__/SongStats.test.ts
+++ b/m4d/ClientApp/src/pages/song/components/__tests__/SongStats.test.ts
@@ -106,7 +106,7 @@ describe("SongStats.vue — canOverrideTempo / algo tempo pencil button", () => 
     });
   });
 
-  describe("pencil edit button visibility (canOverrideTempo)", () => {
+  describe("pencil edit button visibility (canEditTempo)", () => {
     it("shows pencil button when user is authenticated AND tempo is algo-only", () => {
       const wrapper = mountStats(makeAlgoTempoSong(), "testuser");
       expect(wrapper.find("button").exists()).toBe(true);
@@ -123,9 +123,19 @@ describe("SongStats.vue — canOverrideTempo / algo tempo pencil button", () => 
       expect(wrapper.find("button").exists()).toBe(false);
     });
 
-    it("hides pencil button when there is no tempo", () => {
+    it("shows pencil button when there is no tempo AND user is authenticated", () => {
       const wrapper = mountStats(makeNoTempoSong(), "testuser");
-      expect(wrapper.find("button").exists()).toBe(false);
+      expect(wrapper.find("button").exists()).toBe(true);
+    });
+
+    it("hides tempo row entirely when there is no tempo AND user is anonymous", () => {
+      const wrapper = mountStats(makeNoTempoSong(), undefined);
+      expect(wrapper.html()).not.toContain("Tempo");
+    });
+
+    it('shows "???" placeholder when there is no tempo and user is authenticated', () => {
+      const wrapper = mountStats(makeNoTempoSong(), "testuser");
+      expect(wrapper.html()).toContain("???");
     });
   });
 
@@ -147,6 +157,14 @@ describe("SongStats.vue — canOverrideTempo / algo tempo pencil button", () => 
       expect(tempoEditor!.props("overridePermission")).toBe(true);
     });
 
+    it("passes override-permission=true to FieldEditor when there is no tempo (canSetTempo)", () => {
+      const wrapper = mountStats(makeNoTempoSong(), "testuser");
+      const fieldEditors = wrapper.findAllComponents({ name: "FieldEditor" });
+      const tempoEditor = fieldEditors.find((fe) => fe.props("name") === "Tempo");
+      expect(tempoEditor).toBeDefined();
+      expect(tempoEditor!.props("overridePermission")).toBe(true);
+    });
+
     it("passes override-permission=false to FieldEditor when user is anonymous", () => {
       const wrapper = mountStats(makeAlgoTempoSong(), undefined);
       const fieldEditors = wrapper.findAllComponents({ name: "FieldEditor" });
@@ -160,6 +178,17 @@ describe("SongStats.vue — canOverrideTempo / algo tempo pencil button", () => 
       const fieldEditors = wrapper.findAllComponents({ name: "FieldEditor" });
       const tempoEditor = fieldEditors.find((fe) => fe.props("name") === "Tempo");
       expect(tempoEditor).toBeDefined();
+      expect(tempoEditor!.props("overridePermission")).toBe(false);
+    });
+
+    it("does not override-permission when tempo is human-modified (plain user cannot edit via overridePermission)", () => {
+      // Simulates clicking the tag edit pencil: editing=true but no canEditTempo.
+      // A plain user (no canTag) cannot edit via role; overridePermission is false.
+      const wrapper = mountStats(makeHumanTempoSong(), "testuser", true);
+      const fieldEditors = wrapper.findAllComponents({ name: "FieldEditor" });
+      const tempoEditor = fieldEditors.find((fe) => fe.props("name") === "Tempo");
+      expect(tempoEditor).toBeDefined();
+      expect(tempoEditor!.props("role")).toBe("canTag");
       expect(tempoEditor!.props("overridePermission")).toBe(false);
     });
   });

--- a/m4d/ClientApp/src/pages/song/components/__tests__/SongStats.test.ts
+++ b/m4d/ClientApp/src/pages/song/components/__tests__/SongStats.test.ts
@@ -35,12 +35,12 @@ function makeAlgoTempoSong(tempo = "180"): Song {
  * Build a Song whose tempo was set by a real (non-pseudo) user.
  * isSystemTempo should be false: tempo exists AND isUserModified("Tempo") == true.
  */
-function makeHumanTempoSong(tempo = "180"): Song {
+function makeHumanTempoSong(tempo = "180", user = "dwgray"): Song {
   const history = new SongHistory({
     id: "test-song-id",
     properties: [
       new SongProperty({ name: ".Create", value: "" }),
-      new SongProperty({ name: "User", value: "dwgray" }),
+      new SongProperty({ name: "User", value: user }),
       new SongProperty({ name: "Time", value: "01/01/2020 12:00:00" }),
       new SongProperty({ name: "Title", value: "Test Song" }),
       new SongProperty({ name: "Tempo", value: tempo }),
@@ -118,9 +118,15 @@ describe("SongStats.vue — canOverrideTempo / algo tempo pencil button", () => 
       expect(wrapper.find("button").exists()).toBe(false);
     });
 
-    it("hides pencil button when tempo was set by a real user (human-modified)", () => {
-      const wrapper = mountStats(makeHumanTempoSong(), "testuser");
+    it("hides pencil button when tempo was set by a different real user", () => {
+      // "testuser" is viewing but "dwgray" set the tempo — no pencil for testuser
+      const wrapper = mountStats(makeHumanTempoSong("180", "dwgray"), "testuser");
       expect(wrapper.find("button").exists()).toBe(false);
+    });
+
+    it("shows pencil button when the viewing user was the last human to set the tempo", () => {
+      const wrapper = mountStats(makeHumanTempoSong("180", "testuser"), "testuser");
+      expect(wrapper.find("button").exists()).toBe(true);
     });
 
     it("shows pencil button when there is no tempo AND user is authenticated", () => {
@@ -173,8 +179,16 @@ describe("SongStats.vue — canOverrideTempo / algo tempo pencil button", () => 
       expect(tempoEditor!.props("overridePermission")).toBe(false);
     });
 
-    it("passes override-permission=false to FieldEditor when tempo is human-modified", () => {
-      const wrapper = mountStats(makeHumanTempoSong(), "testuser");
+    it("passes override-permission=true to FieldEditor when user was the last human to set tempo", () => {
+      const wrapper = mountStats(makeHumanTempoSong("180", "testuser"), "testuser");
+      const fieldEditors = wrapper.findAllComponents({ name: "FieldEditor" });
+      const tempoEditor = fieldEditors.find((fe) => fe.props("name") === "Tempo");
+      expect(tempoEditor).toBeDefined();
+      expect(tempoEditor!.props("overridePermission")).toBe(true);
+    });
+
+    it("passes override-permission=false to FieldEditor when tempo is human-modified by a different user", () => {
+      const wrapper = mountStats(makeHumanTempoSong("180", "dwgray"), "testuser");
       const fieldEditors = wrapper.findAllComponents({ name: "FieldEditor" });
       const tempoEditor = fieldEditors.find((fe) => fe.props("name") === "Tempo");
       expect(tempoEditor).toBeDefined();

--- a/m4d/Controllers/SongController.cs
+++ b/m4d/Controllers/SongController.cs
@@ -217,7 +217,8 @@ public class SongController : ContentController
                 throw new RedirectException("BotFilter", Filter);
             }
 
-            var results = await new SongSearch(Filter, UserName, IsPremium(), SongIndex, UserManager, TaskQueue, ServiceHealth).Search();
+            var results = await new SongSearch(Filter, UserName, IsPremium(), SongIndex, UserManager, TaskQueue, ServiceHealth,
+                isAdmin: User.IsInRole(DanceMusicCoreService.DbaRole)).Search();
             return await FormatResults(results);
         }
         catch (InvalidOperationException ex) when (IsSearchServiceError(ex))

--- a/m4d/Services/SongSearch.cs
+++ b/m4d/Services/SongSearch.cs
@@ -12,11 +12,12 @@ namespace m4d.Services;
 
 public class SongSearch(SongFilter filter, string userName, bool isPremium, SongIndex songIndex,
     UserManager<ApplicationUser> userManager, IBackgroundTaskQueue backgroundTaskQueue,
-    ServiceHealthManager serviceHealth = null, int? pageSize = null)
+    ServiceHealthManager serviceHealth = null, int? pageSize = null, bool isAdmin = false)
 {
     private SongFilter Filter { get; } = songIndex.DanceMusicService.SearchService.GetSongFilter(filter.ToString());
     private string UserName { get; } = userName;
     private bool IsPremium { get; } = isPremium;
+    private bool IsAdmin { get; } = isAdmin;
     private UserManager<ApplicationUser> UserManager { get; } = userManager;
     private SongIndex SongIndex { get; } = songIndex;
     private IBackgroundTaskQueue BackgroundTaskQueue { get; } = backgroundTaskQueue;
@@ -49,9 +50,14 @@ public class SongSearch(SongFilter filter, string userName, bool isPremium, Song
             }
             else if (!string.Equals(currentUser, userQuery.UserName))
             {
-                // In this case we want to intentionally overwrite the incoming filter
-                var temp = await UserMapper.AnonymizeFilter(Filter, UserManager, ServiceHealth);
-                Filter.User = temp.User;
+                // In this case we want to intentionally overwrite the incoming filter,
+                // unless the requesting user is an admin — admins can view any user's songs
+                // regardless of that user's privacy setting.
+                if (!IsAdmin)
+                {
+                    var temp = await UserMapper.AnonymizeFilter(Filter, UserManager, ServiceHealth);
+                    Filter.User = temp.User;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

This PR fixes several issues with tempo editing permissions and the “Add Song” augment flow.

—

## Changes

### Tempo Editing — Expand Who Can Edit (`SongStats.vue`, `Song.ts`, `FieldEditor.vue`, `SongController.cs`, `SongSearch.cs`)

**Problem:** The tempo field was only editable by admins (`isAdmin` role), and the “algo override” pencil button was only shown when a system-generated tempo existed. Users with the `canTag` role and the original human editor of a tempo had no way to correct it.

**Fixes:**

- `SongStats.vue`: Added `canSetTempo` (user can set tempo when none exists, or re-edit it if they were the last human to set it) and `canTagUser` (`canTag` role). Combined into `canEditTempo`. The tempo row and pencil button are now shown/enabled for all of these cases. Role gate changed from `isAdmin` → `canTag` on the length field editor.
- `Song.ts`: Added `propLastSetByMap` (tracks the last non-pseudo user per field) and `propLastSetBy(field)` method so `SongStats` can check whether the current user was the last human to set a tempo.
- `FieldEditor.vue`: Replaced a `computed` two-way binding (which committed every keystroke) with a `localValue` ref that only emits `update-field` on blur or Enter. This prevents rapid-fire property saves when using arrow keys on a number input.
- `SongController.cs` / `SongSearch.cs`: Server-side permission adjustments to match the expanded editing rules.

—

### Add Song Flow — Tab Persistence & Thank-You Alert (`augment/App.vue`)

**Problem 1:** After saving or cancelling in the `SongCore` editor, the tab index was always reset to 0 (“by Title”), even if the user had come in via the “by Id” tab.

**Fix:** Removed `tabIndex.value = 0` from `reset()`. The `model.value.id = undefined` already prevents `AugmentLookup` from re-triggering its lookup on re-mount (Vue batches the reactive assignments before re-rendering), so no re-lookup occurs regardless of which tab is active.

**Problem 2:** The “Thank you for adding/editing…” alert was disappearing after ~1 second. `BAlert` in bootstrap-vue-next v0.44+ treats a **numeric** `:model-value` as a millisecond countdown, so `:model-value="1000"` was auto-dismissing after 1 s.

**Fix:** Added a `showThanks` ref (initially `false`), set to `true` in `reset(true)`. The template now uses `v-model="showThanks"` so the alert persists until the user manually dismisses it.

—

### Admin Privacy Bypass
- Admin privacy bypass: dbAdmin users can now view songs for accounts with Privacy=0 (private) — previously these were anonymized even for admins.
- Fix crash in song history parsing: Song.loadProperties no longer crashes when a history entry has no User field before its scalar properties (currentModified?.userName).

—

## Tests Updated

- `augment.test.ts`: Updated `reset with saved=true` and `reset with saved=false` tests to assert `showThanks` state and that `tabIndex` is **preserved** (not reset to 0) after save/cancel.
- `SongStats.test.ts` / `Song.test.ts`: Extended to cover `propLastSetBy`, `canSetTempo`, and `canTagUser` scenarios.
