### PR TITLE
Per-User Dance Vote Cap

### DIFF
--- a/architecture/song-internal-format.md
+++ b/architecture/song-internal-format.md
@@ -1,0 +1,544 @@
+# Song Internal Format
+
+## Overview
+
+Every song in music4dance is persisted as an **append-only log of `SongProperty` records**. The
+log is stored as a flat, tab-delimited string in the database. Playback of the log (loading all
+properties in sequence) rebuilds the current state of the song. All edits, votes, tag changes, and
+comments are represented as additional property records appended to the same log.
+
+This document covers:
+
+- The serialized wire / storage format
+- The property name syntax
+- Every field name and what it means
+- How the log is structured into blocks (action + user + time + payload)
+- User identity in the log (real users, pseudo/proxy users, batch/algorithmic users)
+- The computed `Song` model that results from replaying the log
+
+Related documents:
+
+- **[SongUploadFormat.md](SongUploadFormat.md)** — bulk CSV/TSV upload field mapping
+- **[song-merge-algorithm.md](song-merge-algorithm.md)** — how duplicate songs are consolidated
+- **[VOTING_WITH_DANCE_FAMILIES.md](VOTING_WITH_DANCE_FAMILIES.md)** — style-family tag voting
+
+---
+
+## 1. Serialized Format
+
+### 1.1 Full Song String
+
+A song in storage looks like:
+
+```
+SongId={guid}\tProp1=Val1\tProp2=Val2\t...
+```
+
+Example:
+
+```
+SongId={b3f1a2c0-...}\t.Create=\tUser=alice\tTime=01/15/2024 2:30:00 PM\tTitle=Summertime\tArtist=Ella Fitzgerald\tTempo=60.0\tDanceRating=FXT+1\tTag+=Foxtrot:Dance\tTag+=Jazz:Music
+```
+
+The `SongId=` prefix is present when the song is stored or transmitted as a standalone string.
+When properties are stored as rows in the database, the song GUID is stored separately and the
+`SongId=` prefix is omitted from the property blob.
+
+### 1.2 SongProperty Encoding
+
+Each property is serialized as `Name=Value`. Special characters within `Value` are escaped:
+
+| Character     | Escape sequence |
+| ------------- | --------------- |
+| `\t` (tab)    | `\u001aT`       |
+| `\r\n` (CRLF) | `\u001aR`       |
+| `=`           | `\\<EQ>\\`      |
+
+Properties are joined by `\t` (tab) in the default format. A `\r\n`-delimited variant exists for
+diagnostic/export use.
+
+Command properties (starting with `.`) that have no value serialize as `.CommandName=` (no value
+after `=`) or simply `.CommandName` if no `=` was present during load.
+
+---
+
+## 2. Property Name Syntax
+
+```
+BaseName[:index[:qualifier]][:danceId]
+```
+
+| Segment      | Meaning                                                                                            |
+| ------------ | -------------------------------------------------------------------------------------------------- |
+| `BaseName`   | Field identity (e.g. `Title`, `Tag+`, `DanceRating`)                                               |
+| `:index`     | Zero-based, 2-digit decimal index for multi-valued fields (albums, purchases). `-1` = single-value |
+| `:qualifier` | Optional per-field qualifier — currently used for purchase type (e.g. `AS`, `IS`)                  |
+| `:danceId`   | On `Tag+`/`Tag-`, the 3-letter dance ID this tag applies to (dance-scoped tag)                     |
+
+Examples:
+
+| Name             | Meaning                                  |
+| ---------------- | ---------------------------------------- |
+| `Title`          | Song title (simple scalar)               |
+| `Album:00`       | First album name                         |
+| `Album:01`       | Second album name                        |
+| `Purchase:00:AS` | Amazon album purchase ID for first album |
+| `Purchase:00:IS` | iTunes purchase ID for first album       |
+| `Tag+`           | Song-level tag addition                  |
+| `Tag+:CHA`       | Cha Cha–scoped tag addition              |
+| `.Create`        | Action command (no index / qualifier)    |
+
+---
+
+## 3. Field Reference
+
+### 3.1 Scalar Fields
+
+These fields hold a single value; later writes by non-pseudo users win.
+
+| Name           | Type    | Notes                                                                                 |
+| -------------- | ------- | ------------------------------------------------------------------------------------- |
+| `Title`        | string  | Song title. Required — a song without a title is considered null/deleted              |
+| `Artist`       | string  | Performing artist                                                                     |
+| `Tempo`        | decimal | Beats per minute, stored as `F1` (one decimal place, e.g. `120.0`). Valid range 5–500 |
+| `Length`       | int     | Duration in seconds                                                                   |
+| `Sample`       | string  | URL of audio sample. Value `.` means "explicitly no sample"                           |
+| `Danceability` | float   | EchoNest/Spotify acoustic danceability score                                          |
+| `Energy`       | float   | EchoNest/Spotify energy score                                                         |
+| `Valence`      | float   | EchoNest/Spotify valence (emotional positivity) score                                 |
+
+**Bot override rule**: When loading properties, scalar field writes by pseudo users (`|P`) are
+silently ignored if the same field was already set by a real (non-pseudo) user. This means human
+edits always take precedence over service-imported metadata.
+
+### 3.2 Tag Fields
+
+Tags are key-value pairs stored as `value:Category`.
+
+| Name        | Meaning                                                                          |
+| ----------- | -------------------------------------------------------------------------------- |
+| `Tag+`      | Add one or more tags to the song (or dance, when `danceId` qualifier is present) |
+| `Tag-`      | Remove one or more tags from the song (or dance)                                 |
+| `DeleteTag` | Curator-level hard-delete of a tag even if it was added by a later block         |
+
+Tag values within a single property are pipe-delimited: `Pop:Music|Latin:Music|Uptempo:Other`.
+
+**Tag categories:**
+
+| Category | Used on | Meaning                                                                           |
+| -------- | ------- | --------------------------------------------------------------------------------- |
+| `Dance`  | Song    | Which dances the song is appropriate for (e.g., `Foxtrot:Dance`)                  |
+| `Music`  | Song    | Musical genre (e.g., `Jazz:Music`, `Pop:Music`)                                   |
+| `Other`  | Song    | General descriptors (e.g., `Instrumental:Other`, `2010s:Other`)                   |
+| `Tempo`  | Song    | Meter tags (e.g., `4/4:Tempo`, `3/4:Tempo`)                                       |
+| `Style`  | Dance   | Style family for a specific dance (e.g., `International:Style`, `American:Style`) |
+
+Dance-scoped tags (qualifier present, e.g. `Tag+:CHA`) apply only to the `CHA` `DanceRating`
+object, not to the song's global tag list.
+
+### 3.3 Dance Rating Fields
+
+| Name          | Value format | Meaning        |
+| ------------- | ------------ | -------------- | --------------------------------------------------- |
+| `DanceRating` | `{DanceId}{+ | -}{magnitude}` | Vote for/against a dance. Example: `CHA+1`, `FXT-1` |
+
+Each `DanceRating` property is a **delta**: positive = vote for, negative = vote against. Deltas
+accumulate; the net `Weight` on the `DanceRating` computed object is their sum. A dance rating
+with `Weight <= 0` is soft-deleted (removed from the active list) when the log is replayed.
+
+Standard delta magnitudes:
+
+| Constant               | Value | Usage                           |
+| ---------------------- | ----- | ------------------------------- |
+| `DanceRatingCreate`    | 1     | Initial rating on song creation |
+| `DanceRatingInitial`   | 1     | First vote by a user            |
+| `DanceRatingIncrement` | 1     | Upvote                          |
+| `DanceRatingDecrement` | -1    | Downvote                        |
+
+### 3.4 Comment Fields
+
+| Name       | Meaning                                                   |
+| ---------- | --------------------------------------------------------- |
+| `Comment+` | Add a comment text to the song (or dance, with qualifier) |
+| `Comment-` | Remove the most recent comment by the current user        |
+
+### 3.5 User & Session Fields
+
+These appear at the start of every edit block and establish attribution for the properties that follow.
+
+| Name        | Value format                    | Meaning                                                                            |
+| ----------- | ------------------------------- | ---------------------------------------------------------------------------------- |
+| `User`      | `{username}` or `{username}\|P` | Identifies the author of the following properties. `\|P` marks a pseudo/proxy user |
+| `UserProxy` | same as `User`                  | Variant used for some proxy scenarios (treated identically to `User` during load)  |
+| `Time`      | parseable DateTime string       | Timestamp of the edit block                                                        |
+
+### 3.6 Album Fields
+
+Albums are indexed (`:00`, `:01`, …) and each album can have multiple related properties.
+
+| Name                    | Value                   | Meaning                                                           |
+| ----------------------- | ----------------------- | ----------------------------------------------------------------- |
+| `Album:NN`              | Album name              | Name of the NN-th album                                           |
+| `Publisher:NN`          | Publisher name          | Label/publisher for album NN                                      |
+| `Track:NN`              | int                     | Track number within album NN                                      |
+| `Purchase:NN:qualifier` | service-specific ID     | Purchase link. Qualifier identifies the service and purchase type |
+| `PromoteAlbum`          | album index             | Mark an album as the preferred display album                      |
+| `OrderAlbums`           | comma-delimited indices | Override the display ordering of albums                           |
+
+Purchase qualifiers combine a service code and purchase type code. Examples:
+
+| Qualifier | Service      | Type             |
+| --------- | ------------ | ---------------- |
+| `AS`      | Amazon (`A`) | Song (`S`)       |
+| `AD`      | Amazon (`A`) | Album/disc (`D`) |
+| `IS`      | iTunes (`I`) | Song (`S`)       |
+| `IA`      | iTunes (`I`) | Album (`A`)      |
+
+### 3.7 User Preference Fields
+
+These are per-user properties stored within an edit block attributed to the user.
+
+| Name        | Value             | Meaning                                                             |
+| ----------- | ----------------- | ------------------------------------------------------------------- |
+| `Like`      | `true` or `false` | The current user's like/dislike flag for this song                  |
+| `OwnerHash` | hex int           | Hash of the user's local file path — indicates the user owns a copy |
+
+### 3.8 Command / Action Fields
+
+Commands start with `.` and mark the beginning of an edit block. They are not preceded by `=` in
+the raw stream if they have no value, though during serialization they use `Name=Value` format
+with an empty value.
+
+| Name            | Value                     | Meaning                                                                       |
+| --------------- | ------------------------- | ----------------------------------------------------------------------------- |
+| `.Create`       | empty                     | First creation of the song                                                    |
+| `.Edit`         | empty                     | A subsequent edit                                                             |
+| `.Delete`       | `true` or empty           | Marks the song as deleted; causes title and all scalars to be cleared on load |
+| `.Undo`         | empty                     | Undo the most recent edit                                                     |
+| `.Merge`        | semicolon-delimited GUIDs | Records that this song was merged from the listed source song IDs             |
+| `.NoMerge`      | —                         | Prevents this song from being merged with others                              |
+| `.FailedLookup` | service char code(s)      | Records that a music-service lookup failed for the given service(s)           |
+
+Pseudo-commands used only during serialization (never persisted in the primary log):
+
+| Name                            | Meaning                                           |
+| ------------------------------- | ------------------------------------------------- |
+| `.NoSongId`                     | Serialize properties without the `SongId=` prefix |
+| `.SerializeDeleted`             | Include even deleted (null-title) songs in output |
+| `.Success`, `.Fail`, `.Message` | API response envelope (not part of song log)      |
+
+---
+
+## 4. Edit Block Structure
+
+Properties are organized into **edit blocks**. Each block starts with a command property (`.Create`
+or `.Edit`) followed immediately by `User` and `Time` (in either order). The rest of the block is
+the payload for that edit.
+
+```
+.Create=  User=alice  Time=2024-01-15 14:30:00  Title=Summertime  Artist=Ella  Tempo=60.0  DanceRating=FXT+1  Tag+=Foxtrot:Dance  Tag+=Jazz:Music
+.Edit=    User=bob    Time=2024-03-01 10:00:00   DanceRating=FXT+1  Tag+=Foxtrot:Dance
+.Edit=    User=alice  Time=2024-03-05 09:15:00   Tempo=58.0
+```
+
+In the raw tab-delimited form, the fields above are tab-separated (whitespace shown above for
+readability only).
+
+**Valid header orders:**
+
+- `.Command=` → `User=` → `Time=`
+- `.Command=` → `Time=` → `User=`
+
+Both orderings are accepted during load and are validated by `CheckHeader()` in `Song.cs`.
+
+---
+
+## 5. User Identity and User Types
+
+Every edit block is attributed to a user. The `User` field value is `{username}` for real users and
+`{username}|P` for pseudo/proxy users.
+
+### 5.1 User Types
+
+| Type           | Pattern                                    | Description                                                                                                  |
+| -------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| Real user      | `alice`                                    | Confirmed human account                                                                                      |
+| Pseudo / proxy | `ArthurMurrays\|P`                         | A dance-studio or other entity acting as a proxy for real users; votes are counted but displayed differently |
+| `batch`        | `batch`                                    | The human-curated catalog import user. Not considered algorithmic                                            |
+| `batch\|P`     | `batch\|P`                                 | Pseudo-flagged batch import. Has additional restrictions (see §5.3)                                          |
+| Service import | `batch-s`, `batch-a`, `batch-i`, `batch-x` | Automated imports from Spotify, Amazon, iTunes, Xbox Music                                                   |
+| Algorithmic    | `tempo-bot`                                | Automated tempo-correction bot                                                                               |
+
+**Display names** (used in history views):
+
+| UserName    | Displayed As     |
+| ----------- | ---------------- |
+| `batch`     | Anonymous Import |
+| `batch-s`   | Spotify          |
+| `batch-a`   | Amazon Music     |
+| `batch-i`   | iTunes           |
+| `batch-x`   | Xbox Music       |
+| `batch-e`   | EchoNest         |
+| `tempo-bot` | Tempo Bot        |
+
+### 5.2 `IsPseudo` Flag
+
+A user is _pseudo_ if their decorated name ends with `|P`. In `ApplicationUser`, this is
+indicated by an email address at `@music4dance.net`. Pseudo users represent human votes proxied
+through an organization (e.g. a dance school submitting votes on behalf of its students).
+
+Key behaviors of pseudo users:
+
+- **Scalar field suppression**: writes to scalar fields (`Title`, `Artist`, `Tempo`, etc.) by
+  pseudo users are ignored if the field has already been set by a real user.
+- **Visible in history**: `SongChange.isPseudo` is true, but pseudo users are _included_ in the
+  default history view (`userChanges`). Only the `humanOnly` filter in
+  `SongHistory.filterChanges` excludes batch/algorithmic users.
+- **`|P` suffix in log**: Stored as `Alice|P` in the `User` property value.
+
+### 5.3 Batch / Algorithmic Users
+
+Batch and algorithmic users (`batch-*`, `tempo-bot`) are **excluded** from the default
+`userChanges` history view and from the `humanOnly` history filter.
+
+`batch|P` is additionally considered "invalid" if it carries a `DanceRating` property
+(`ChunkedSong.HasInvalidBatch()`). Dance ratings from `batch|P` blocks are removed during catalog
+cleanup (`RemoveInvalidBatches()`). The rationale: vote weights should only come from real users
+or legitimate service imports.
+
+### 5.4 Decorated Name
+
+The string stored in the `User` property is the _decorated name_:
+
+```
+realUser     → "alice"
+pseudoUser   → "alice|P"
+```
+
+When properties are loaded, the `ModifiedRecord` constructor parses the `|P` flag:
+
+```csharp
+var parts = value.Split('|');
+UserName = parts[0];           // "alice"
+IsPseudo = parts[1] == "P";   // true
+```
+
+---
+
+## 6. Computed Song Object
+
+Replaying the property log produces the `Song` object:
+
+| Property                            | Source                                                        | Notes                                            |
+| ----------------------------------- | ------------------------------------------------------------- | ------------------------------------------------ |
+| `SongId`                            | GUID stored separately or as `SongId=`                        | Immutable once assigned                          |
+| `Title`                             | Last `Title` write by non-pseudo user                         | Falls back to last write by any user if none     |
+| `Artist`                            | Same as Title                                                 |                                                  |
+| `Tempo`                             | Same as Title                                                 | Decimal, stored as `F1`                          |
+| `Length`                            | Same as Title                                                 | Seconds                                          |
+| `Sample`                            | Same as Title                                                 | URL                                              |
+| `Danceability`, `Energy`, `Valence` | Same as Title                                                 | Float, from EchoNest/Spotify                     |
+| `Created`                           | First `Time` value in the log                                 |                                                  |
+| `Modified`                          | Last `Time` value in the log                                  |                                                  |
+| `Edited`                            | Last `Time` from a non-pseudo user                            | Tracks when a human last changed the song        |
+| `DanceRatings`                      | Accumulated `DanceRating` deltas                              | Objects with `DanceId`, `Weight`, tags           |
+| `ModifiedBy`                        | One `ModifiedRecord` per unique username                      | Contains `IsPseudo`, `Owned`, `Like`             |
+| `Albums`                            | Grouped by index from `Album:NN`, `Track:NN`, `Purchase:NN:Q` | Rebuilt on every load                            |
+| `SongProperties`                    | Raw log (all properties)                                      | The source of truth; everything above is derived |
+| `TagSummary`                        | Built from `Tag+` / `Tag-` operations                         | Indexed tag sets by category                     |
+
+### 6.1 Dance Rating Computation
+
+- Each `DanceRating=DID+N` or `DanceRating=DID-N` property contributes a delta to the running
+  total for dance `DID`.
+- If the accumulated `Weight` drops to ≤ 0, the `DanceRating` is soft-deleted (removed from
+  `DanceRatings` and a negative `Dance` tag is injected: `!DanceName:Dance`).
+- Dance-scoped tags (`Tag+:CHA=International:Style`) are stored on the `DanceRating` object for
+  `CHA`, not on the song-level `TagSummary`.
+
+### 6.2 `ModifiedRecord` and Ownership
+
+`ModifiedRecord` accumulates per-user metadata across all edit blocks attributed to that user:
+
+| Field       | Set by                        | Meaning                                              |
+| ----------- | ----------------------------- | ---------------------------------------------------- | ---------------------------- |
+| `UserName`  | `User` property               | Canonical username                                   |
+| `IsPseudo`  | `                             | P` suffix                                            | Whether this is a proxy user |
+| `Owned`     | `OwnerHash` property          | Whether (and which) local file is owned by this user |
+| `Like`      | `Like` property               | The user's like/dislike flag                         |
+| `IsCreator` | Position in `ModifiedBy` list | `true` for the first entry (original creator)        |
+
+### 6.3 Deleted Songs
+
+A `.Delete=` property (or `.Delete=true`) in any block causes the song to be treated as deleted:
+all scalar fields are cleared and `IsNull` returns `true`. A deleted song still has a log and a
+GUID, allowing undeletion via `.Undo`.
+
+---
+
+## 7. Block-Level Operations
+
+### 7.1 ChunkedSong
+
+The `ChunkedSong` helper splits the flat property log into named `SongChunk` objects, one per
+edit block. This is used for validation and for per-user analysis:
+
+```csharp
+var chunked = new ChunkedSong(song);
+// chunked.Chunks     — all blocks in order
+// chunked.UserChunks — dictionary keyed by decorated username
+```
+
+Each `SongChunk` exposes the command, user, timestamp, and payload properties of one block.
+
+### 7.2 SongPropertyBlockParser
+
+`SongPropertyBlockParser.ParseBlocks()` is a lower-level alternative used for date-range queries
+and admin modifications. It returns `SongPropertyBlock` objects that preserve the action command,
+user, timestamp, and a mutable property list for that block.
+
+---
+
+## 8. History Model
+
+The `SongHistory` class (client-side TypeScript) provides a view over the same property log. It
+groups properties into `SongChange` objects that represent one edit block each.
+
+### 8.1 `SongChange`
+
+| Field           | Meaning                                                   |
+| --------------- | --------------------------------------------------------- | ------------------------------------ |
+| `action`        | The command name (without `.`), e.g. `"Create"`, `"Edit"` |
+| `user`          | Decorated username (with `                                | P` if pseudo)                        |
+| `date`          | Block timestamp                                           |
+| `properties`    | Payload properties (excludes command, user, time)         |
+| `isBatch`       | `user === "batch\|P"` or `user.startsWith("batch-")`      |
+| `isPseudo`      | `user` contains `                                         | [p]`in the`UserQuery` representation |
+| `isAlgorithmic` | `user` is one of the known service/bot names              |
+
+### 8.2 History Filters
+
+| Getter             | Includes                                                        |
+| ------------------ | --------------------------------------------------------------- |
+| `userChanges`      | Human and pseudo users only; excludes `batch-*` and `tempo-bot` |
+| `inclusiveChanges` | All users (human, pseudo, batch, algorithmic)                   |
+| `systemTagKeys`    | Tag keys whose last modification was by a non-human user        |
+
+### 8.3 TypeScript vs. C# Property Names
+
+TypeScript uses camelCase (`PropertyType` enum), C# uses PascalCase constants (`Song.UserField`).
+They map to the same string values:
+
+| TypeScript `PropertyType` | C# `Song.*` constant | String value    |
+| ------------------------- | -------------------- | --------------- |
+| `userField`               | `UserField`          | `"User"`        |
+| `timeField`               | `TimeField`          | `"Time"`        |
+| `titleField`              | `TitleField`         | `"Title"`       |
+| `artistField`             | `ArtistField`        | `"Artist"`      |
+| `tempoField`              | `TempoField`         | `"Tempo"`       |
+| `lengthField`             | `LengthField`        | `"Length"`      |
+| `addedTags`               | `AddedTags`          | `"Tag+"`        |
+| `removedTags`             | `RemovedTags`        | `"Tag-"`        |
+| `danceRatingField`        | `DanceRatingField`   | `"DanceRating"` |
+| `likeTag`                 | `LikeTag`            | `"Like"`        |
+| `userProxy`               | `UserProxy`          | `"UserProxy"`   |
+| `createCommand`           | `CreateCommand`      | `".Create"`     |
+| `editCommand`             | `EditCommand`        | `".Edit"`       |
+| `deleteCommand`           | `DeleteCommand`      | `".Delete"`     |
+| `mergeCommand`            | `MergeCommand`       | `".Merge"`      |
+| `addCommentField`         | `AddCommentField`    | `"Comment+"`    |
+| `removeCommentField`      | `RemoveCommentField` | `"Comment-"`    |
+| `ownerHash`               | `OwnerHash`          | `"OwnerHash"`   |
+
+---
+
+## 9. Annotated Examples
+
+### 9.1 Simple Song Creation
+
+```
+SongId={guid}
+.Create=
+User=alice
+Time=01/15/2024 2:30:00 PM
+Title=Summertime
+Artist=Ella Fitzgerald
+Tempo=60.0
+DanceRating=FXT+1
+Tag+=Foxtrot:Dance
+Tag+=Jazz:Music
+Tag+=4/4:Tempo
+```
+
+### 9.2 Edit by a Second User
+
+```
+...continuation of §9.1...
+.Edit=
+User=bob
+Time=03/01/2024 10:00:00 AM
+DanceRating=FXT+1
+Tag+=Foxtrot:Dance
+```
+
+### 9.3 Service Import + Human Edit (Pseudo User)
+
+```
+.Create=
+User=alice
+Time=01/15/2024 2:30:00 PM
+Like=true
+.Edit=
+User=batch-s
+Time=01/15/2024 2:30:00 PM
+Title=Summertime
+Artist=Ella Fitzgerald
+Album:00=Ella & Louis
+Track:00=3
+Purchase:00:AS=B00123456
+```
+
+Here `batch-s` (Spotify) imports metadata. If `alice` later edits `Title`, the human value wins
+because `batch-s` is algorithmic (pseudo by email convention) and the bot override rule applies.
+
+### 9.4 Style-Family Vote (Dance Families Feature)
+
+```
+.Edit=
+User=charlie
+Time=04/10/2024 9:00:00 AM
+DanceRating=CHA+1
+Tag+=Cha Cha:Dance
+Tag+:CHA=American:Style|International:Style
+```
+
+The `Tag+:CHA=American:Style|International:Style` property adds style-family tags scoped
+specifically to the Cha Cha dance rating for this user's vote. The dance rating itself (`CHA+1`)
+remains dance-level — it contributes to the total Cha Cha vote count regardless of style family.
+
+### 9.5 Proxy (Pseudo) User Vote
+
+```
+.Edit=
+User=ArthurMurrays|P
+Time=07/30/2023 9:48:04 AM
+DanceRating=CHA+1
+Tag+=Cha Cha:Dance
+Tag+:CHA=American:Style
+```
+
+The `|P` suffix marks this as a proxy vote from the Arthur Murray dance studio organization. The
+vote counts toward the global dance rating. In the history UI, this appears under `userChanges`
+(not filtered out) but `SongChange.isPseudo === true`.
+
+---
+
+## 10. Validation Invariants
+
+The following are enforced by `Song.CheckPropertiesInternal()`:
+
+1. Every `.Create` or `.Edit` block must be followed immediately by `User` and `Time` (in either order).
+2. Dance rating deltas must have magnitude 1 or 2 (values `+1`, `-1`, `+2`, `-2`).
+3. No `DanceRating` on a song-level `batch|P` block (that is a corrupt import).
+4. No genre (`:Music`) tags directly on a `DanceRating` — those belong on the song level.
+5. No competition group IDs (e.g. `SWG`, `FXT`) as actual dance ratings — only individual dance types.

--- a/architecture/song-internal-format.md
+++ b/architecture/song-internal-format.md
@@ -356,6 +356,27 @@ Replaying the property log produces the `Song` object:
 - Dance-scoped tags (`Tag+:CHA=International:Style`) are stored on the `DanceRating` object for
   `CHA`, not on the song-level `TagSummary`.
 
+#### Per-User ±1 Net Vote Cap
+
+When replaying the log, a **±1 net cap** is enforced per (user, dance) pair for all non-batch
+users — this includes both real users and pseudo (`|P`) users. The cap prevents any single user
+from contributing more than ±1 net to a dance's `Weight`.
+
+**Exempt from the cap** (may accumulate any magnitude):
+
+- Usernames starting with `batch` (bulk import accounts)
+- `tempo-bot` (algorithmic tempo service)
+- Null user (legacy/system records with no attributed author)
+
+**Effect on raw property values**: The raw `SongProperties` log stores deltas exactly as written
+(e.g., a raw value of `CHA+2` is possible if a user downvoted then upvoted the same dance,
+producing intermediate deltas of `-1, +1, +1` in the log). The cap applies only during
+computation of the in-memory `DanceRatings` list, not to the stored log entries.
+
+**Why this matters for serialization**: When two rows with the same title/artist are merged via
+`MergeRow`, the merge reads from the computed `DanceRatings` (cap-applied) rather than raw
+properties. Serialized output from a merged song therefore reflects capped values.
+
 ### 6.2 `ModifiedRecord` and Ownership
 
 `ModifiedRecord` accumulates per-user metadata across all edit blocks attributed to that user:

--- a/architecture/song-internal-format.md
+++ b/architecture/song-internal-format.md
@@ -138,9 +138,9 @@ object, not to the song's global tag list.
 
 ### 3.3 Dance Rating Fields
 
-| Name          | Value format | Meaning        |
-| ------------- | ------------ | -------------- | --------------------------------------------------- |
-| `DanceRating` | `{DanceId}{+ | -}{magnitude}` | Vote for/against a dance. Example: `CHA+1`, `FXT-1` |
+| Name          | Value format                 | Meaning                                             |
+| ------------- | ---------------------------- | --------------------------------------------------- |
+| `DanceRating` | `{DanceId}{+\|-}{magnitude}` | Vote for/against a dance. Example: `CHA+1`, `FXT-1` |
 
 Each `DanceRating` property is a **delta**: positive = vote for, negative = vote against. Deltas
 accumulate; the net `Weight` on the `DanceRating` computed object is their sum. A dance rating
@@ -361,9 +361,9 @@ Replaying the property log produces the `Song` object:
 `ModifiedRecord` accumulates per-user metadata across all edit blocks attributed to that user:
 
 | Field       | Set by                        | Meaning                                              |
-| ----------- | ----------------------------- | ---------------------------------------------------- | ---------------------------- |
+| ----------- | ----------------------------- | ---------------------------------------------------- |
 | `UserName`  | `User` property               | Canonical username                                   |
-| `IsPseudo`  | `                             | P` suffix                                            | Whether this is a proxy user |
+| `IsPseudo`  | `\|P` suffix on `User` value  | Whether this is a proxy/pseudo user                  |
 | `Owned`     | `OwnerHash` property          | Whether (and which) local file is owned by this user |
 | `Like`      | `Like` property               | The user's like/dislike flag                         |
 | `IsCreator` | Position in `ModifiedBy` list | `true` for the first entry (original creator)        |
@@ -406,15 +406,15 @@ groups properties into `SongChange` objects that represent one edit block each.
 
 ### 8.1 `SongChange`
 
-| Field           | Meaning                                                   |
-| --------------- | --------------------------------------------------------- | ------------------------------------ |
-| `action`        | The command name (without `.`), e.g. `"Create"`, `"Edit"` |
-| `user`          | Decorated username (with `                                | P` if pseudo)                        |
-| `date`          | Block timestamp                                           |
-| `properties`    | Payload properties (excludes command, user, time)         |
-| `isBatch`       | `user === "batch\|P"` or `user.startsWith("batch-")`      |
-| `isPseudo`      | `user` contains `                                         | [p]`in the`UserQuery` representation |
-| `isAlgorithmic` | `user` is one of the known service/bot names              |
+| Field           | Meaning                                                                     |
+| --------------- | --------------------------------------------------------------------------- |
+| `action`        | The command name (without `.`), e.g. `"Create"`, `"Edit"`                   |
+| `user`          | Decorated username (e.g. `"alice"` or `"ArthurMurrays\|P"` if pseudo)       |
+| `date`          | Block timestamp                                                             |
+| `properties`    | Payload properties (excludes command, user, time)                           |
+| `isBatch`       | `true` when `user === "batch\|P"` or `user.startsWith("batch-")`            |
+| `isPseudo`      | `true` when the user value contains `\|P` (pseudo/proxy account)            |
+| `isAlgorithmic` | `true` when `user` is one of the known service/bot names (`tempo-bot` etc.) |
 
 ### 8.2 History Filters
 

--- a/m4d/ClientApp/src/models/Song.ts
+++ b/m4d/ClientApp/src/models/Song.ts
@@ -301,6 +301,10 @@ export class Song extends TaggableObject {
     let deleted = false;
     let pseudo = false;
 
+    // Track each non-service user's net contribution per dance to enforce a ±1 cap.
+    // Batch and service accounts (batch*, tempo-bot) are exempt and may use any delta.
+    const userDanceContributions = new Map<string, number>();
+
     properties.forEach((property) => {
       const baseName = property.baseName;
 
@@ -311,9 +315,24 @@ export class Song extends TaggableObject {
           currentModified = this.addModified(user, creator);
           pseudo = currentModified.isPseudo;
           break;
-        case PropertyType.danceRatingField:
-          this.addDanceRating(property.value);
+        case PropertyType.danceRatingField: {
+          const drd = DanceRatingDelta.fromString(property.value);
+          const userName = currentModified?.userName;
+          const isBatchUser = !userName || userName.startsWith("batch") || userName === "tempo-bot";
+          if (!isBatchUser) {
+            const key = `${userName}:${drd.danceId}`;
+            const currentNet = userDanceContributions.get(key) ?? 0;
+            const effectiveNet = Math.max(-1, Math.min(1, currentNet + drd.delta));
+            const effectiveDelta = effectiveNet - currentNet;
+            if (effectiveDelta !== 0) {
+              userDanceContributions.set(key, effectiveNet);
+              this.addDanceRating(effectiveDelta, drd.danceId);
+            }
+          } else {
+            this.addDanceRating(drd.delta, drd.danceId);
+          }
           break;
+        }
         case PropertyType.addedTags:
           {
             const toAdd = this.getTaggableObject(property);
@@ -438,20 +457,19 @@ export class Song extends TaggableObject {
     return record;
   }
 
-  private addDanceRating(value: string): void {
-    const drd = DanceRatingDelta.fromString(value);
+  private addDanceRating(delta: number, danceId: string): void {
     const ratings = this.danceRatings ?? [];
-    const idx = ratings.findIndex((r) => r.id === drd.danceId);
+    const idx = ratings.findIndex((r) => r.id === danceId);
     if (idx != -1) {
       const dr = ratings[idx];
       if (dr) {
-        dr.weight += drd.delta;
+        dr.weight += delta;
         if (dr.weight <= 0) {
           ratings.splice(idx, 1);
         }
       }
-    } else if (drd.delta > 0) {
-      const dr = new DanceRating({ danceId: drd.danceId, weight: drd.delta });
+    } else if (delta > 0) {
+      const dr = new DanceRating({ danceId, weight: delta });
       if (this.danceRatings) {
         this.danceRatings.push(dr);
       } else {

--- a/m4d/ClientApp/src/models/__tests__/Song.test.ts
+++ b/m4d/ClientApp/src/models/__tests__/Song.test.ts
@@ -165,4 +165,170 @@ describe("Song", () => {
       expect(song.propLastSetBy(PropertyType.tempoField)).toBe("alice");
     });
   });
+
+  describe("dance rating per-user cap", () => {
+    function makeHistory(properties: SongProperty[]): SongHistory {
+      return new SongHistory({ id: "test", properties });
+    }
+
+    it("caps a pseudo user at +1 for the same dance (two votes)", () => {
+      const song = Song.fromHistory(
+        makeHistory([
+          new SongProperty({ name: ".Create", value: "" }),
+          new SongProperty({ name: "User", value: "ArthurMurrays|P" }),
+          new SongProperty({ name: "Time", value: "2024-01-01T00:00:00.000Z" }),
+          new SongProperty({ name: "Title", value: "Test Song" }),
+          new SongProperty({ name: "Artist", value: "Test Artist" }),
+          new SongProperty({ name: "DanceRating", value: "CHA+1" }),
+          new SongProperty({ name: "Tag+", value: "Cha Cha:Dance" }),
+          new SongProperty({ name: ".Edit", value: "" }),
+          new SongProperty({ name: "User", value: "ArthurMurrays|P" }),
+          new SongProperty({ name: "Time", value: "2024-02-01T00:00:00.000Z" }),
+          new SongProperty({ name: "DanceRating", value: "CHA+1" }),
+        ]),
+      );
+      expect(song.findDanceRatingById("CHA")?.weight).toBe(1);
+    });
+
+    it("caps a pseudo user at +1 for the same dance (three votes)", () => {
+      const song = Song.fromHistory(
+        makeHistory([
+          new SongProperty({ name: ".Create", value: "" }),
+          new SongProperty({ name: "User", value: "Studio|P" }),
+          new SongProperty({ name: "Time", value: "2024-01-01T00:00:00.000Z" }),
+          new SongProperty({ name: "Title", value: "Test Song" }),
+          new SongProperty({ name: "Artist", value: "Test Artist" }),
+          new SongProperty({ name: "DanceRating", value: "CHA+1" }),
+          new SongProperty({ name: "Tag+", value: "Cha Cha:Dance" }),
+          new SongProperty({ name: ".Edit", value: "" }),
+          new SongProperty({ name: "User", value: "Studio|P" }),
+          new SongProperty({ name: "Time", value: "2024-02-01T00:00:00.000Z" }),
+          new SongProperty({ name: "DanceRating", value: "CHA+1" }),
+          new SongProperty({ name: ".Edit", value: "" }),
+          new SongProperty({ name: "User", value: "Studio|P" }),
+          new SongProperty({ name: "Time", value: "2024-03-01T00:00:00.000Z" }),
+          new SongProperty({ name: "DanceRating", value: "CHA+1" }),
+        ]),
+      );
+      expect(song.findDanceRatingById("CHA")?.weight).toBe(1);
+    });
+
+    it("caps a real user at +1 for the same dance", () => {
+      const song = Song.fromHistory(
+        makeHistory([
+          new SongProperty({ name: ".Create", value: "" }),
+          new SongProperty({ name: "User", value: "alice" }),
+          new SongProperty({ name: "Time", value: "2024-01-01T00:00:00.000Z" }),
+          new SongProperty({ name: "Title", value: "Test Song" }),
+          new SongProperty({ name: "Artist", value: "Test Artist" }),
+          new SongProperty({ name: "DanceRating", value: "CHA+1" }),
+          new SongProperty({ name: "Tag+", value: "Cha Cha:Dance" }),
+          new SongProperty({ name: ".Edit", value: "" }),
+          new SongProperty({ name: "User", value: "alice" }),
+          new SongProperty({ name: "Time", value: "2024-02-01T00:00:00.000Z" }),
+          new SongProperty({ name: "DanceRating", value: "CHA+1" }),
+        ]),
+      );
+      expect(song.findDanceRatingById("CHA")?.weight).toBe(1);
+    });
+
+    it("allows two different users to each contribute +1", () => {
+      const song = Song.fromHistory(
+        makeHistory([
+          new SongProperty({ name: ".Create", value: "" }),
+          new SongProperty({ name: "User", value: "alice" }),
+          new SongProperty({ name: "Time", value: "2024-01-01T00:00:00.000Z" }),
+          new SongProperty({ name: "Title", value: "Test Song" }),
+          new SongProperty({ name: "Artist", value: "Test Artist" }),
+          new SongProperty({ name: "DanceRating", value: "CHA+1" }),
+          new SongProperty({ name: "Tag+", value: "Cha Cha:Dance" }),
+          new SongProperty({ name: ".Edit", value: "" }),
+          new SongProperty({ name: "User", value: "bob" }),
+          new SongProperty({ name: "Time", value: "2024-02-01T00:00:00.000Z" }),
+          new SongProperty({ name: "DanceRating", value: "CHA+1" }),
+        ]),
+      );
+      expect(song.findDanceRatingById("CHA")?.weight).toBe(2);
+    });
+
+    it("removes the dance when upvote is followed by downvote", () => {
+      const song = Song.fromHistory(
+        makeHistory([
+          new SongProperty({ name: ".Create", value: "" }),
+          new SongProperty({ name: "User", value: "alice" }),
+          new SongProperty({ name: "Time", value: "2024-01-01T00:00:00.000Z" }),
+          new SongProperty({ name: "Title", value: "Test Song" }),
+          new SongProperty({ name: "Artist", value: "Test Artist" }),
+          new SongProperty({ name: "DanceRating", value: "CHA+1" }),
+          new SongProperty({ name: "Tag+", value: "Cha Cha:Dance" }),
+          new SongProperty({ name: ".Edit", value: "" }),
+          new SongProperty({ name: "User", value: "alice" }),
+          new SongProperty({ name: "Time", value: "2024-02-01T00:00:00.000Z" }),
+          new SongProperty({ name: "DanceRating", value: "CHA-1" }),
+        ]),
+      );
+      expect(song.findDanceRatingById("CHA")).toBeUndefined();
+    });
+
+    it("allows up-down-up sequence resulting in net +1", () => {
+      const song = Song.fromHistory(
+        makeHistory([
+          new SongProperty({ name: ".Create", value: "" }),
+          new SongProperty({ name: "User", value: "alice" }),
+          new SongProperty({ name: "Time", value: "2024-01-01T00:00:00.000Z" }),
+          new SongProperty({ name: "Title", value: "Test Song" }),
+          new SongProperty({ name: "Artist", value: "Test Artist" }),
+          new SongProperty({ name: "DanceRating", value: "CHA+1" }),
+          new SongProperty({ name: "Tag+", value: "Cha Cha:Dance" }),
+          new SongProperty({ name: ".Edit", value: "" }),
+          new SongProperty({ name: "User", value: "alice" }),
+          new SongProperty({ name: "Time", value: "2024-02-01T00:00:00.000Z" }),
+          new SongProperty({ name: "DanceRating", value: "CHA-1" }),
+          new SongProperty({ name: ".Edit", value: "" }),
+          new SongProperty({ name: "User", value: "alice" }),
+          new SongProperty({ name: "Time", value: "2024-03-01T00:00:00.000Z" }),
+          new SongProperty({ name: "DanceRating", value: "CHA+1" }),
+          new SongProperty({ name: "Tag+", value: "Cha Cha:Dance" }),
+        ]),
+      );
+      expect(song.findDanceRatingById("CHA")?.weight).toBe(1);
+    });
+
+    it("does not cap batch user high-delta votes", () => {
+      const song = Song.fromHistory(
+        makeHistory([
+          new SongProperty({ name: ".Create", value: "" }),
+          new SongProperty({ name: "User", value: "batch" }),
+          new SongProperty({ name: "Time", value: "2024-01-01T00:00:00.000Z" }),
+          new SongProperty({ name: "Title", value: "Test Song" }),
+          new SongProperty({ name: "Artist", value: "Test Artist" }),
+          new SongProperty({ name: "DanceRating", value: "SFT+5" }),
+          new SongProperty({ name: "Tag+", value: "Slow Foxtrot:Dance" }),
+        ]),
+      );
+      expect(song.findDanceRatingById("SFT")?.weight).toBe(5);
+    });
+
+    it("applies cap per dance independently", () => {
+      const song = Song.fromHistory(
+        makeHistory([
+          new SongProperty({ name: ".Create", value: "" }),
+          new SongProperty({ name: "User", value: "Studio|P" }),
+          new SongProperty({ name: "Time", value: "2024-01-01T00:00:00.000Z" }),
+          new SongProperty({ name: "Title", value: "Test Song" }),
+          new SongProperty({ name: "Artist", value: "Test Artist" }),
+          new SongProperty({ name: "DanceRating", value: "CHA+1" }),
+          new SongProperty({ name: "DanceRating", value: "SLS+1" }),
+          new SongProperty({ name: "Tag+", value: "Cha Cha:Dance" }),
+          new SongProperty({ name: ".Edit", value: "" }),
+          new SongProperty({ name: "User", value: "Studio|P" }),
+          new SongProperty({ name: "Time", value: "2024-02-01T00:00:00.000Z" }),
+          new SongProperty({ name: "DanceRating", value: "CHA+1" }),
+          new SongProperty({ name: "DanceRating", value: "SLS+1" }),
+        ]),
+      );
+      expect(song.findDanceRatingById("CHA")?.weight).toBe(1);
+      expect(song.findDanceRatingById("SLS")?.weight).toBe(1);
+    });
+  });
 });

--- a/m4d/ClientApp/src/models/__tests__/Song.test.ts
+++ b/m4d/ClientApp/src/models/__tests__/Song.test.ts
@@ -330,5 +330,39 @@ describe("Song", () => {
       expect(song.findDanceRatingById("CHA")?.weight).toBe(1);
       expect(song.findDanceRatingById("SLS")?.weight).toBe(1);
     });
+
+    it("does not cap tempo-bot high-delta votes", () => {
+      const song = Song.fromHistory(
+        makeHistory([
+          new SongProperty({ name: ".Create", value: "" }),
+          new SongProperty({ name: "User", value: "tempo-bot" }),
+          new SongProperty({ name: "Time", value: "2024-01-01T00:00:00.000Z" }),
+          new SongProperty({ name: "Title", value: "Test Song" }),
+          new SongProperty({ name: "Artist", value: "Test Artist" }),
+          new SongProperty({ name: "DanceRating", value: "FXT+5" }),
+          new SongProperty({ name: "Tag+", value: "Slow Foxtrot:Dance" }),
+        ]),
+      );
+      expect(song.findDanceRatingById("FXT")?.weight).toBe(5);
+    });
+
+    it("does not cap tempo-bot repeated votes on the same dance", () => {
+      const song = Song.fromHistory(
+        makeHistory([
+          new SongProperty({ name: ".Create", value: "" }),
+          new SongProperty({ name: "User", value: "tempo-bot" }),
+          new SongProperty({ name: "Time", value: "2024-01-01T00:00:00.000Z" }),
+          new SongProperty({ name: "Title", value: "Test Song" }),
+          new SongProperty({ name: "Artist", value: "Test Artist" }),
+          new SongProperty({ name: "DanceRating", value: "FXT+3" }),
+          new SongProperty({ name: "Tag+", value: "Slow Foxtrot:Dance" }),
+          new SongProperty({ name: ".Edit", value: "" }),
+          new SongProperty({ name: "User", value: "tempo-bot" }),
+          new SongProperty({ name: "Time", value: "2024-02-01T00:00:00.000Z" }),
+          new SongProperty({ name: "DanceRating", value: "FXT+2" }),
+        ]),
+      );
+      expect(song.findDanceRatingById("FXT")?.weight).toBe(5);
+    });
   });
 });

--- a/m4d/ClientApp/src/pages/album/__tests__/__snapshots__/album.test.ts.snap
+++ b/m4d/ClientApp/src/pages/album/__tests__/__snapshots__/album.test.ts.snap
@@ -553,7 +553,7 @@ exports[`Album > renders an album page 1`] = `
                       <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
                       <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
                     </g>
-                  </svg> Bolero <span class="badge text-bg-light">11</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
+                  </svg> Bolero <span class="badge text-bg-light">9</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button><button data-v-a7ef304f="" class="btn btn-sm btn-dance" type="button" title="Rumba" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
                     <g fill="currentColor">

--- a/m4d/ClientApp/src/pages/artist/__tests__/__snapshots__/artist.test.ts.snap
+++ b/m4d/ClientApp/src/pages/artist/__tests__/__snapshots__/artist.test.ts.snap
@@ -1808,7 +1808,7 @@ exports[`Artist > renders an artist page 1`] = `
                       <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
                       <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
                     </g>
-                  </svg> Bolero <span class="badge text-bg-light">11</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
+                  </svg> Bolero <span class="badge text-bg-light">9</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button><button data-v-a7ef304f="" class="btn btn-sm btn-dance" type="button" title="Rumba" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
                     <g fill="currentColor">
@@ -4572,7 +4572,7 @@ exports[`Artist > renders an artist page 1`] = `
                       <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
                       <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
                     </g>
-                  </svg> Salsa <span class="badge text-bg-light">3</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
+                  </svg> Salsa <span class="badge text-bg-light">2</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
                 <!--v-if-->

--- a/m4d/ClientApp/src/pages/custom-search/__tests__/__snapshots__/custom-search.test.ts.snap
+++ b/m4d/ClientApp/src/pages/custom-search/__tests__/__snapshots__/custom-search.test.ts.snap
@@ -766,7 +766,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                         <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
                         <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
                       </g>
-                    </svg> Motown <span class="badge text-bg-light">2</span>
+                    </svg> Motown <span class="badge text-bg-light">1</span>
                     <!--v-if-->
                   </button><button data-v-a7ef304f="" class="btn btn-sm btn-dance" type="button" title="Rumba" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
                       <g fill="currentColor">
@@ -1407,7 +1407,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                         <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
                         <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
                       </g>
-                    </svg> Slow Foxtrot <span class="badge text-bg-light">3</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
+                    </svg> Slow Foxtrot <span class="badge text-bg-light">2</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                       <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                     </svg></button>
                   <!--v-if-->
@@ -1830,7 +1830,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                         <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
                         <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
                       </g>
-                    </svg> Slow Waltz <span class="badge text-bg-light">5</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
+                    </svg> Slow Waltz <span class="badge text-bg-light">2</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                       <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                     </svg></button>
                   <!--v-if-->
@@ -3281,7 +3281,7 @@ exports[`Custom Search > renders a custom search page 1`] = `
                         <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
                         <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
                       </g>
-                    </svg> Slow Waltz <span class="badge text-bg-light">10</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
+                    </svg> Slow Waltz <span class="badge text-bg-light">4</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                       <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                     </svg></button>
                   <!--v-if-->

--- a/m4d/ClientApp/src/pages/dance-details/__tests__/__snapshots__/dance-details.test.ts.snap
+++ b/m4d/ClientApp/src/pages/dance-details/__tests__/__snapshots__/dance-details.test.ts.snap
@@ -187,12 +187,12 @@ The Bolero is generally danced as the fourth dance of [American Rhythm](/dances/
                             </div>
                           </div>
                         </transition-stub></span>
-                        <div data-v-d0b4fb7f="" class="vote-number">11</div><span><span id="__m4d__000002_placeholder" style="display: none;"></span>
+                        <div data-v-d0b4fb7f="" class="vote-number">9</div><span><span id="__m4d__000002_placeholder" style="display: none;"></span>
                         <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
                           <div id="__m4d__000002" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
                             <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
                             <div class="overflow-auto b-floating-size">
-                              <div class="position-sticky top-0 tooltip-inner">This song has 11 votes. The most popular Bolero has 12 votes</div>
+                              <div class="position-sticky top-0 tooltip-inner">This song has 9 votes. The most popular Bolero has 12 votes</div>
                               <!---->
                             </div>
                           </div>
@@ -519,12 +519,12 @@ The Bolero is generally danced as the fourth dance of [American Rhythm](/dances/
                 </div>
               </div>
             </transition-stub></span>
-            <div data-v-d0b4fb7f="" class="vote-number">6</div><span><span id="__m4d__000014_placeholder" style="display: none;"></span>
+            <div data-v-d0b4fb7f="" class="vote-number">4</div><span><span id="__m4d__000014_placeholder" style="display: none;"></span>
             <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
               <div id="__m4d__000014" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
                 <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
                 <div class="overflow-auto b-floating-size">
-                  <div class="position-sticky top-0 tooltip-inner">This song has 6 votes. The most popular Bolero has 12 votes</div>
+                  <div class="position-sticky top-0 tooltip-inner">This song has 4 votes. The most popular Bolero has 12 votes</div>
                   <!---->
                 </div>
               </div>
@@ -647,12 +647,12 @@ The Bolero is generally danced as the fourth dance of [American Rhythm](/dances/
             </div>
           </div>
         </transition-stub></span>
-        <div data-v-d0b4fb7f="" class="vote-number">6</div><span><span id="__m4d__000020_placeholder" style="display: none;"></span>
+        <div data-v-d0b4fb7f="" class="vote-number">4</div><span><span id="__m4d__000020_placeholder" style="display: none;"></span>
         <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
           <div id="__m4d__000020" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
             <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
             <div class="overflow-auto b-floating-size">
-              <div class="position-sticky top-0 tooltip-inner">This song has 6 votes. The most popular Bolero has 12 votes</div>
+              <div class="position-sticky top-0 tooltip-inner">This song has 4 votes. The most popular Bolero has 12 votes</div>
               <!---->
             </div>
           </div>
@@ -981,12 +981,12 @@ The Bolero is generally danced as the fourth dance of [American Rhythm](/dances/
         </div>
       </div>
     </transition-stub></span>
-    <div data-v-d0b4fb7f="" class="vote-number">5</div><span><span id="__m4d__000032_placeholder" style="display: none;"></span>
+    <div data-v-d0b4fb7f="" class="vote-number">4</div><span><span id="__m4d__000032_placeholder" style="display: none;"></span>
     <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
       <div id="__m4d__000032" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
         <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
         <div class="overflow-auto b-floating-size">
-          <div class="position-sticky top-0 tooltip-inner">This song has 5 votes. The most popular Bolero has 12 votes</div>
+          <div class="position-sticky top-0 tooltip-inner">This song has 4 votes. The most popular Bolero has 12 votes</div>
           <!---->
         </div>
       </div>
@@ -1602,12 +1602,12 @@ The Bolero is generally danced as the fourth dance of [American Rhythm](/dances/
         </div>
       </div>
     </transition-stub></span>
-    <div data-v-d0b4fb7f="" class="vote-number">4</div><span><span id="__m4d__000056_placeholder" style="display: none;"></span>
+    <div data-v-d0b4fb7f="" class="vote-number">3</div><span><span id="__m4d__000056_placeholder" style="display: none;"></span>
     <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
       <div id="__m4d__000056" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
         <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
         <div class="overflow-auto b-floating-size">
-          <div class="position-sticky top-0 tooltip-inner">This song has 4 votes. The most popular Bolero has 12 votes</div>
+          <div class="position-sticky top-0 tooltip-inner">This song has 3 votes. The most popular Bolero has 12 votes</div>
           <!---->
         </div>
       </div>

--- a/m4d/ClientApp/src/pages/song-index/__tests__/__snapshots__/song-index.test.ts.snap
+++ b/m4d/ClientApp/src/pages/song-index/__tests__/__snapshots__/song-index.test.ts.snap
@@ -3214,7 +3214,7 @@ exports[`Song Index > renders a song index page 1`] = `
                       <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
                       <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
                     </g>
-                  </svg> Motown <span class="badge text-bg-light">2</span>
+                  </svg> Motown <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button><button data-v-a7ef304f="" class="btn btn-sm btn-dance" type="button" title="Rumba" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
                     <g fill="currentColor">
@@ -3538,7 +3538,7 @@ exports[`Song Index > renders a song index page 1`] = `
                       <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
                       <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
                     </g>
-                  </svg> Rumba <span class="badge text-bg-light">5</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
+                  </svg> Rumba <span class="badge text-bg-light">4</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button><button data-v-a7ef304f="" class="btn btn-sm btn-dance" type="button" title="West Coast Swing" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
                     <g fill="currentColor">
@@ -3971,7 +3971,7 @@ exports[`Song Index > renders a song index page 1`] = `
                       <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
                       <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
                     </g>
-                  </svg> West Coast Swing <span class="badge text-bg-light">4</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
+                  </svg> West Coast Swing <span class="badge text-bg-light">3</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
                 <!--v-if-->
@@ -4306,7 +4306,7 @@ exports[`Song Index > renders a song index page 1`] = `
                       <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
                       <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
                     </g>
-                  </svg> Jive <span class="badge text-bg-light">5</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
+                  </svg> Jive <span class="badge text-bg-light">4</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
                     <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
                   </svg></button>
                 <!--v-if-->
@@ -4559,7 +4559,7 @@ exports[`Song Index > renders a song index page 1`] = `
                       <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
                       <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
                     </g>
-                  </svg> Cha Cha <span class="badge text-bg-light">2</span>
+                  </svg> Cha Cha <span class="badge text-bg-light">1</span>
                   <!--v-if-->
                 </button>
                 <!--v-if-->

--- a/m4dModels.Tests/DanceRatingCapTests.cs
+++ b/m4dModels.Tests/DanceRatingCapTests.cs
@@ -1,0 +1,139 @@
+namespace m4dModels.Tests;
+
+/// <summary>
+/// Tests that per-user dance rating contributions are capped at ±1 during song loading.
+/// This prevents pseudo users (playlist imports) from accumulating multiple votes for the
+/// same song/dance when the same playlist is imported more than once or a song appears in
+/// multiple playlists from the same source.
+///
+/// Batch/service accounts (usernames starting with "batch" or equal to "tempo-bot") are
+/// exempt from this cap and may use any delta value.
+/// </summary>
+[TestClass]
+public class DanceRatingCapTests
+{
+    [ClassInitialize]
+    public static async Task ClassInitialize(TestContext context)
+    {
+        await DanceMusicTester.LoadDances();
+    }
+
+    private static async Task<DanceMusicCoreService> GetService(string suffix) =>
+        await DanceMusicTester.CreateServiceWithUsers($"DanceRatingCap_{suffix}");
+
+    [TestMethod]
+    public async Task PseudoUser_TwoPositiveVotesSameDance_CappedAtOne()
+    {
+        var dms = await GetService("Pseudo2x");
+        var song = await Song.Create(
+            ".Create=\tUser=ArthurMurrays|P\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=CHA+1\tTag+=Cha Cha:Dance\t" +
+            ".Edit=\tUser=ArthurMurrays|P\tTime=02/01/2024 10:00:00 AM\tDanceRating=CHA+1\tTag+=Cha Cha:Dance",
+            dms);
+
+        var rating = song.FindRating("CHA");
+        Assert.IsNotNull(rating, "Dance rating should exist after first vote");
+        Assert.AreEqual(1, rating.Weight, "Pseudo user second +1 vote should be ignored (capped at 1)");
+    }
+
+    [TestMethod]
+    public async Task PseudoUser_ThreePositiveVotesSameDance_CappedAtOne()
+    {
+        var dms = await GetService("Pseudo3x");
+        var song = await Song.Create(
+            ".Create=\tUser=Studio|P\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=CHA+1\tTag+=Cha Cha:Dance\t" +
+            ".Edit=\tUser=Studio|P\tTime=02/01/2024 10:00:00 AM\tDanceRating=CHA+1\t" +
+            ".Edit=\tUser=Studio|P\tTime=03/01/2024 10:00:00 AM\tDanceRating=CHA+1",
+            dms);
+
+        var rating = song.FindRating("CHA");
+        Assert.IsNotNull(rating, "Dance rating should exist");
+        Assert.AreEqual(1, rating.Weight, "Three votes from same pseudo user should still be capped at 1");
+    }
+
+    [TestMethod]
+    public async Task RealUser_TwoPositiveVotesSameDance_CappedAtOne()
+    {
+        var dms = await GetService("Real2x");
+        var song = await Song.Create(
+            ".Create=\tUser=alice\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=CHA+1\tTag+=Cha Cha:Dance\t" +
+            ".Edit=\tUser=alice\tTime=02/01/2024 10:00:00 AM\tDanceRating=CHA+1",
+            dms);
+
+        var rating = song.FindRating("CHA");
+        Assert.IsNotNull(rating, "Dance rating should exist");
+        Assert.AreEqual(1, rating.Weight, "Real user second +1 vote should be ignored (capped at 1)");
+    }
+
+    [TestMethod]
+    public async Task TwoDifferentUsers_OneVoteEach_TotalIsTwo()
+    {
+        var dms = await GetService("TwoUsers");
+        var song = await Song.Create(
+            ".Create=\tUser=alice\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=CHA+1\tTag+=Cha Cha:Dance\t" +
+            ".Edit=\tUser=bob\tTime=02/01/2024 10:00:00 AM\tDanceRating=CHA+1",
+            dms);
+
+        var rating = song.FindRating("CHA");
+        Assert.IsNotNull(rating, "Dance rating should exist");
+        Assert.AreEqual(2, rating.Weight, "Two different users each voting once should sum to 2");
+    }
+
+    [TestMethod]
+    public async Task User_UpvoteThenDownvote_DanceRemoved()
+    {
+        var dms = await GetService("UpDown");
+        var song = await Song.Create(
+            ".Create=\tUser=alice\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=CHA+1\tTag+=Cha Cha:Dance\t" +
+            ".Edit=\tUser=alice\tTime=02/01/2024 10:00:00 AM\tDanceRating=CHA-1",
+            dms);
+
+        var rating = song.FindRating("CHA");
+        Assert.IsNull(rating, "Net zero rating should remove the dance");
+    }
+
+    [TestMethod]
+    public async Task User_UpvoteDownvoteUpvote_NetOne()
+    {
+        var dms = await GetService("UpDownUp");
+        var song = await Song.Create(
+            ".Create=\tUser=alice\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=CHA+1\tTag+=Cha Cha:Dance\t" +
+            ".Edit=\tUser=alice\tTime=02/01/2024 10:00:00 AM\tDanceRating=CHA-1\t" +
+            ".Edit=\tUser=alice\tTime=03/01/2024 10:00:00 AM\tDanceRating=CHA+1\tTag+=Cha Cha:Dance",
+            dms);
+
+        var rating = song.FindRating("CHA");
+        Assert.IsNotNull(rating, "Dance rating should exist after up-down-up sequence");
+        Assert.AreEqual(1, rating.Weight, "Up-down-up sequence should result in net +1");
+    }
+
+    [TestMethod]
+    public async Task BatchUser_HighDeltaVote_NotCapped()
+    {
+        var dms = await GetService("Batch");
+        var song = await Song.Create(
+            ".Create=\tUser=batch\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=SFT+5\tTag+=Slow Foxtrot:Dance",
+            dms);
+
+        var rating = song.FindRating("SFT");
+        Assert.IsNotNull(rating, "Dance rating should exist");
+        Assert.AreEqual(5, rating.Weight, "Batch user high-delta vote should not be capped");
+    }
+
+    [TestMethod]
+    public async Task PseudoUser_CapAppliesPerDance_NotCrossContaminated()
+    {
+        // Verify the cap is per-dance: capping CHA does not affect SLS
+        var dms = await GetService("PerDance");
+        var song = await Song.Create(
+            ".Create=\tUser=Studio|P\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=CHA+1\tDanceRating=SLS+1\tTag+=Cha Cha:Dance\t" +
+            ".Edit=\tUser=Studio|P\tTime=02/01/2024 10:00:00 AM\tDanceRating=CHA+1\tDanceRating=SLS+1",
+            dms);
+
+        var chaRating = song.FindRating("CHA");
+        var slsRating = song.FindRating("SLS");
+        Assert.IsNotNull(chaRating, "CHA rating should exist");
+        Assert.IsNotNull(slsRating, "SLS rating should exist");
+        Assert.AreEqual(1, chaRating.Weight, "CHA should be capped at 1");
+        Assert.AreEqual(1, slsRating.Weight, "SLS should be capped at 1");
+    }
+}

--- a/m4dModels.Tests/DanceRatingCapTests.cs
+++ b/m4dModels.Tests/DanceRatingCapTests.cs
@@ -136,4 +136,51 @@ public class DanceRatingCapTests
         Assert.AreEqual(1, chaRating.Weight, "CHA should be capped at 1");
         Assert.AreEqual(1, slsRating.Weight, "SLS should be capped at 1");
     }
+
+    [TestMethod]
+    public async Task TempoBot_HighDeltaVote_NotCapped()
+    {
+        // tempo-bot is a service account and must be exempt from the ±1 cap
+        var dms = await GetService("TempoBot");
+        var song = await Song.Create(
+            ".Create=\tUser=tempo-bot\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=FXT+5\tTag+=Slow Foxtrot:Dance",
+            dms);
+
+        var rating = song.FindRating("FXT");
+        Assert.IsNotNull(rating, "Dance rating should exist");
+        Assert.AreEqual(5, rating.Weight, "tempo-bot high-delta vote should not be capped");
+    }
+
+    [TestMethod]
+    public async Task TempoBot_RepeatedVotesSameDance_NotCapped()
+    {
+        // tempo-bot voting the same dance twice should accumulate freely
+        var dms = await GetService("TempoBotRepeat");
+        var song = await Song.Create(
+            ".Create=\tUser=tempo-bot\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=FXT+3\tTag+=Slow Foxtrot:Dance\t" +
+            ".Edit=\tUser=tempo-bot\tTime=02/01/2024 10:00:00 AM\tDanceRating=FXT+2",
+            dms);
+
+        var rating = song.FindRating("FXT");
+        Assert.IsNotNull(rating, "Dance rating should exist");
+        Assert.AreEqual(5, rating.Weight, "tempo-bot repeated votes should accumulate without cap");
+    }
+
+    [TestMethod]
+    public async Task SetRatingsFromProperties_EnforcesSameCap()
+    {
+        // SetRatingsFromProperties should apply the same ±1 cap as LoadProperties
+        var dms = await GetService("SetRatings");
+        var song = await Song.Create(
+            ".Create=\tUser=alice\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=CHA+1\tTag+=Cha Cha:Dance\t" +
+            ".Edit=\tUser=alice\tTime=02/01/2024 10:00:00 AM\tDanceRating=CHA+1",
+            dms);
+
+        // Simulate a recalculation (e.g. the dbAdmin UpdateRatings action)
+        song.SetRatingsFromProperties();
+
+        var rating = song.FindRating("CHA");
+        Assert.IsNotNull(rating, "Dance rating should exist after recalculation");
+        Assert.AreEqual(1, rating.Weight, "SetRatingsFromProperties should also cap at 1");
+    }
 }

--- a/m4dModels.Tests/SongDetailTests.cs
+++ b/m4dModels.Tests/SongDetailTests.cs
@@ -96,7 +96,7 @@ public class SongDetailTests
     [
         @".Create=	User=dwgray	Time=00/00/0000 0:00:00 PM	Tag+=English:Other|Foxtrot:Dance|Pop:Music|Rock:Music	DanceRating=FXT+5	Title=Glam	Tempo=120.0	Length=200	Artist=Dimie Cat	Tag+:FXT=David:Other|Goliath:Other|Traditional:Style",
         @".Create=	User=dwgray	Time=00/00/0000 0:00:00 PM	Tag+=Samba:Dance|Spanish:Other	DanceRating=SMB+3	Title=Drop It On Me (Ft Daddy Yankee)	Tempo=100.0	Length=234	Artist=Ricky Martin",
-        @".Create=	User=dwgray	Time=00/00/0000 0:00:00 PM	Tag+=Cha Cha:Dance|Mambo:Dance|Salsa:Dance	DanceRating=MBO+4	DanceRating=SLS+4	Title=Bailemos Otra Vez	Tempo=195.0	Artist=Jose Alberto El Canario	Tag+:MBO=Traditional:Style	Tag+:SLS=Traditional:Style	Length=308	DanceRating=CHA+3"
+        @".Create=	User=dwgray	Time=00/00/0000 0:00:00 PM	Tag+=Cha Cha:Dance|Mambo:Dance|Salsa:Dance	DanceRating=MBO+4	DanceRating=SLS+4	Title=Bailemos Otra Vez	Tempo=195.0	Artist=Jose Alberto El Canario	Tag+:MBO=Traditional:Style	Tag+:SLS=Traditional:Style	Length=308	DanceRating=CHA+1"
     ];
 
     private static readonly string[] StarsRows =

--- a/m4dModels/Song.cs
+++ b/m4dModels/Song.cs
@@ -1559,21 +1559,13 @@ public class Song : TaggableObject
                 case DanceRatingField:
                     {
                         var drd = new DanceRatingDelta(prop.Value);
-                        var isBatchUser = user == null || user.StartsWith("batch") || user == "tempo-bot";
-                        if (!isBatchUser)
+                        if (TryGetCappedDelta(drd, user, userDanceContributions, out var effective))
                         {
-                            var key = (user, drd.DanceId);
-                            userDanceContributions.TryGetValue(key, out var currentNet);
-                            var effectiveNet = Math.Clamp(currentNet + drd.Delta, -1, 1);
-                            var effectiveDelta = effectiveNet - currentNet;
-                            if (effectiveDelta == 0) break;
-                            userDanceContributions[key] = effectiveNet;
-                            drd = new DanceRatingDelta(drd.DanceId, effectiveDelta);
-                        }
-                        var del = SoftUpdateDanceRating(drd);
-                        if (del != null)
-                        {
-                            drDelete.Add(del);
+                            var del = SoftUpdateDanceRating(effective);
+                            if (del != null)
+                            {
+                                drDelete.Add(del);
+                            }
                         }
                     }
                     break;
@@ -4090,14 +4082,68 @@ public class Song : TaggableObject
             dr.Weight = 0;
         }
 
-        foreach (var prop in SongProperties.Where(p => p.Name == DanceRatingField))
+        // Replay the property log, tracking user context so the same ±1 per-user cap
+        // applied during LoadProperties is also enforced here.
+        var userDanceContributions = new Dictionary<(string, string), int>();
+        string user = null;
+
+        foreach (var prop in SongProperties)
         {
-            var rating = SoftUpdateDanceRating(prop.Value);
-            if (rating != null)
+            switch (prop.BaseName)
             {
-                _ = DanceRatings.Remove(rating);
+                case UserField:
+                case UserProxy:
+                    user = new ModifiedRecord(prop.Value).UserName;
+                    break;
+                case DanceRatingField:
+                {
+                    var drd = new DanceRatingDelta(prop.Value);
+                    if (TryGetCappedDelta(drd, user, userDanceContributions, out var effective))
+                    {
+                        var rating = SoftUpdateDanceRating(effective);
+                        if (rating != null)
+                        {
+                            _ = DanceRatings.Remove(rating);
+                        }
+                    }
+                    break;
+                }
             }
         }
+    }
+
+    /// <summary>
+    /// Applies the per-user ±1 vote cap for a dance rating delta.
+    /// Returns <c>false</c> (and sets <paramref name="effective"/> to <c>null</c>) when the
+    /// delta is entirely absorbed by the cap and should not be applied at all.
+    /// Batch and service accounts (<c>batch*</c>, <c>tempo-bot</c>) are exempt from the cap.
+    /// </summary>
+    private static bool TryGetCappedDelta(
+        DanceRatingDelta drd,
+        string user,
+        Dictionary<(string, string), int> contributions,
+        out DanceRatingDelta effective)
+    {
+        var isBatchUser = user == null || user.StartsWith("batch") || user == "tempo-bot";
+        if (isBatchUser)
+        {
+            effective = drd;
+            return true;
+        }
+
+        var key = (user, drd.DanceId);
+        contributions.TryGetValue(key, out var currentNet);
+        var effectiveNet = Math.Clamp(currentNet + drd.Delta, -1, 1);
+        var effectiveDelta = effectiveNet - currentNet;
+        if (effectiveDelta == 0)
+        {
+            effective = null;
+            return false;
+        }
+
+        contributions[key] = effectiveNet;
+        effective = new DanceRatingDelta(drd.DanceId, effectiveDelta);
+        return true;
     }
 
     public static string TagsFromDances(IEnumerable<string> dances)

--- a/m4dModels/Song.cs
+++ b/m4dModels/Song.cs
@@ -1538,6 +1538,10 @@ public class Song : TaggableObject
 
         HashSet<string> isUserModified = [];
 
+        // Track each non-service user's net contribution per dance to enforce a ±1 cap.
+        // Batch and service accounts (batch*, tempo-bot) are exempt and may use any delta.
+        var userDanceContributions = new Dictionary<(string, string), int>();
+
         foreach (var prop in properties)
         {
             var bn = prop.BaseName;
@@ -1554,7 +1558,19 @@ public class Song : TaggableObject
                     break;
                 case DanceRatingField:
                     {
-                        var del = SoftUpdateDanceRating(prop.Value);
+                        var drd = new DanceRatingDelta(prop.Value);
+                        var isBatchUser = user == null || user.StartsWith("batch") || user == "tempo-bot";
+                        if (!isBatchUser)
+                        {
+                            var key = (user, drd.DanceId);
+                            userDanceContributions.TryGetValue(key, out var currentNet);
+                            var effectiveNet = Math.Clamp(currentNet + drd.Delta, -1, 1);
+                            var effectiveDelta = effectiveNet - currentNet;
+                            if (effectiveDelta == 0) break;
+                            userDanceContributions[key] = effectiveNet;
+                            drd = new DanceRatingDelta(drd.DanceId, effectiveDelta);
+                        }
+                        var del = SoftUpdateDanceRating(drd);
                         if (del != null)
                         {
                             drDelete.Add(del);


### PR DESCRIPTION
## Problem

Pseudo users (playlist-import accounts marked with `|P`, e.g. `ArthurMurrays|P`) could
accumulate a net weight greater than +1 on a single dance if the same song appeared in
multiple playlists imported from the same source. The property log would contain two
identical `DanceRating=CHA+1` entries attributed to the same user, resulting in a weight
of 2 instead of the intended maximum of 1. Real users are already blocked from voting
more than once at the API/UI level, but that guard does not apply retroactively when
replaying the stored property log.

## Solution

Cap each user’s net contribution to any dance at ±1 **during property log replay**
(loading), so the fix applies retrospectively to all existing data without modifying the
stored log. Batch and service accounts (`batch*`, `tempo-bot`) are exempt and may use
any delta value.

The cap is implemented in both the server-side and client-side song models, which mirror
each other.

## Changes

### `m4dModels/Song.cs` — `LoadProperties`

- Added a `Dictionary<(string user, string danceId), int>` to track each non-service
  user’s running net contribution per dance.
- In the `DanceRatingField` case, the effective delta is clamped so the user’s net never
  exceeds ±1 before being applied.

### `m4d/ClientApp/src/models/Song.ts` — `loadProperties` / `addDanceRating`

- Added a `Map<string, number>` for the same per-user-per-dance contribution tracking.
- The `danceRatingField` case applies the same ±1 clamp using `currentModified.userName`
  (which already strips the `|P` suffix).
- `addDanceRating` signature changed from `(value: string)` to `(delta: number, danceId: string)`
  to accept pre-computed effective deltas.

### `m4dModels.Tests/DanceRatingCapTests.cs` _(new)_

8 integration tests covering: pseudo user 2×/3× votes capped, real user capped, two
different users each contributing +1, upvote+downvote removes dance, up-down-up nets +1,
batch user not capped, per-dance isolation.

### `m4d/ClientApp/src/models/__tests__/Song.test.ts`

9 new unit tests mirroring the C# test cases above.

### `architecture/song-internal-format.md` _(new)_

Documentation of the internal song property-log format: serialization, property name
syntax, all field types, edit block structure, user identity taxonomy, computed Song
object, ChunkedSong, history model, TypeScript vs C# constant mapping, and annotated
examples.
