### PR TITLE
 Add PatternName field and line dance upload enhancements

### DIFF
--- a/DanceTests/TestData/test-dances.json
+++ b/DanceTests/TestData/test-dances.json
@@ -7,9 +7,7 @@
       "denominator": 4
     },
     "blogTag": "waltz",
-    "synonyms": [
-      "Waltz"
-    ],
+    "synonyms": ["Waltz"],
     "instances": [
       {
         "style": "American Smooth",
@@ -28,10 +26,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       },
       {
         "style": "International Standard",
@@ -50,10 +45,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       }
     ]
   },
@@ -83,9 +75,7 @@
       "denominator": 4
     },
     "blogTag": "castle-foxtrot",
-    "synonyms": [
-      "Slow Dance"
-    ],
+    "synonyms": ["Slow Dance"],
     "instances": [
       {
         "style": "Social",
@@ -104,9 +94,7 @@
       "denominator": 4
     },
     "blogTag": "slow-foxtrot",
-    "synonyms": [
-      "Foxtrot"
-    ],
+    "synonyms": ["Foxtrot"],
     "instances": [
       {
         "style": "American Smooth",
@@ -125,10 +113,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       },
       {
         "style": "International Standard",
@@ -147,10 +132,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       }
     ]
   },
@@ -171,10 +153,7 @@
         },
         "competitionGroup": "Ballroom",
         "competitionOrder": 2,
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       },
       {
         "style": "International Standard",
@@ -193,10 +172,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       }
     ]
   },
@@ -208,9 +184,7 @@
       "denominator": 4
     },
     "blogTag": "peabody",
-    "synonyms": [
-      "One Step"
-    ],
+    "synonyms": ["One Step"],
     "instances": [
       {
         "style": "American Smooth",
@@ -228,10 +202,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       }
     ]
   },
@@ -243,9 +214,7 @@
       "denominator": 4
     },
     "blogTag": "waltz",
-    "searchonyms": [
-      "viennese"
-    ],
+    "searchonyms": ["viennese"],
     "instances": [
       {
         "style": "American Smooth",
@@ -264,10 +233,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       },
       {
         "style": "International Standard",
@@ -286,10 +252,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       }
     ]
   },
@@ -319,10 +282,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       }
     ]
   },
@@ -352,10 +312,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       }
     ]
   },
@@ -376,10 +333,7 @@
         },
         "competitionGroup": "Ballroom",
         "competitionOrder": 1,
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       },
       {
         "style": "International Latin",
@@ -398,10 +352,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       }
     ]
   },
@@ -422,10 +373,7 @@
         },
         "competitionGroup": "Ballroom",
         "competitionOrder": 5,
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       }
     ]
   },
@@ -455,10 +403,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       }
     ]
   },
@@ -488,10 +433,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       },
       {
         "style": "International Latin",
@@ -510,10 +452,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       }
     ]
   },
@@ -525,14 +464,8 @@
       "denominator": 4
     },
     "blogTag": "east-coast-swing",
-    "synonyms": [
-      "Triple Swing",
-      "East Coast"
-    ],
-    "searchonyms": [
-      "swing",
-      "ec swing"
-    ],
+    "synonyms": ["Triple Swing", "East Coast"],
+    "searchonyms": ["swing", "ec swing"],
     "instances": [
       {
         "style": "American Rhythm",
@@ -551,10 +484,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       }
     ]
   },
@@ -566,12 +496,8 @@
       "denominator": 4
     },
     "blogTag": "west-coast-swing",
-    "synonyms": [
-      "West Coast"
-    ],
-    "searchonyms": [
-      "wc swing"
-    ],
+    "synonyms": ["West Coast"],
+    "searchonyms": ["wc swing"],
     "instances": [
       {
         "style": "American Rhythm",
@@ -579,9 +505,7 @@
           "min": 112.0,
           "max": 112.0
         },
-        "organizations": [
-          "NDCA"
-        ]
+        "organizations": ["NDCA"]
       },
       {
         "style": "Social",
@@ -589,9 +513,7 @@
           "min": 80.0,
           "max": 130.0
         },
-        "organizations": [
-          "NDCA"
-        ]
+        "organizations": ["NDCA"]
       }
     ]
   },
@@ -603,10 +525,7 @@
       "denominator": 4
     },
     "blogTag": "hustle",
-    "synonyms": [
-      "Street Swing",
-      "Disco Fox"
-    ],
+    "synonyms": ["Street Swing", "Disco Fox"],
     "instances": [
       {
         "style": "American Rhythm",
@@ -615,9 +534,7 @@
           "max": 120.0
         },
         "competitionGroup": "Ballroom",
-        "organizations": [
-          "NDCA"
-        ]
+        "organizations": ["NDCA"]
       }
     ]
   },
@@ -645,10 +562,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       }
     ]
   },
@@ -678,10 +592,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       },
       {
         "style": "American Rhythm",
@@ -699,10 +610,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       }
     ]
   },
@@ -732,10 +640,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       },
       {
         "style": "American Rhythm",
@@ -760,10 +665,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       }
     ]
   },
@@ -792,10 +694,7 @@
             }
           }
         ],
-        "organizations": [
-          "DanceSport",
-          "NDCA"
-        ]
+        "organizations": ["DanceSport", "NDCA"]
       }
     ]
   },
@@ -815,9 +714,7 @@
           "max": 200.0
         },
         "competitionGroup": "Ballroom",
-        "organizations": [
-          "NDCA"
-        ]
+        "organizations": ["NDCA"]
       },
       {
         "style": "Social",
@@ -825,9 +722,7 @@
           "min": 160.0,
           "max": 220.0
         },
-        "organizations": [
-          "NDCA"
-        ]
+        "organizations": ["NDCA"]
       }
     ]
   },
@@ -864,9 +759,7 @@
       "numerator": 4,
       "denominator": 4
     },
-    "searchonyms": [
-      "club two step"
-    ],
+    "searchonyms": ["club two step"],
     "instances": [
       {
         "style": "American Rhythm",
@@ -928,10 +821,7 @@
       "denominator": 4
     },
     "blogTag": "lindy-hop",
-    "synonyms": [
-      "Swing",
-      "Jitterbug"
-    ],
+    "synonyms": ["Swing", "Jitterbug"],
     "instances": [
       {
         "style": "Social",
@@ -1004,9 +894,7 @@
       "denominator": 4
     },
     "blogTag": "tango",
-    "synonyms": [
-      "Tango Argentino"
-    ],
+    "synonyms": ["Tango Argentino"],
     "instances": [
       {
         "style": "Social",
@@ -1166,11 +1054,7 @@
       "denominator": 4
     },
     "blogTag": "single-swing",
-    "synonyms": [
-      "Single-time Swing",
-      "East Coast Single Swing",
-      "Jitterbug"
-    ],
+    "synonyms": ["Single-time Swing", "East Coast Single Swing", "Jitterbug"],
     "instances": [
       {
         "style": "Social",
@@ -1332,6 +1216,18 @@
           "min": 1.0,
           "max": 500.0
         }
+      }
+    ]
+  },
+  {
+    "id": "PTN",
+    "name": "Pattern",
+    "meter": { "numerator": 1, "denominator": 1 },
+    "synonyms": ["Line Dance", "Choreographed Partner Dance", "Sequence Dance"],
+    "instances": [
+      {
+        "style": "Social",
+        "tempoRange": { "min": 1.0, "max": 500.0 }
       }
     ]
   }

--- a/architecture/SongUploadFormat.md
+++ b/architecture/SongUploadFormat.md
@@ -16,42 +16,43 @@ This document describes the full set of options and fields supported by the song
 
 The following header fields are recognized (case-insensitive). You may use any of these as column headers:
 
-| Header Name          | Internal Field  | Description                                                                    |
-| -------------------- | --------------- | ------------------------------------------------------------------------------ |
-| DANCE                | DanceRating     | Dance style(s) for the song - uses dance IDs (see below)                       |
-| TITLE                | Title           | Song title                                                                     |
-| ARTIST               | Artist          | Song artist                                                                    |
-| CONTRIBUTING ARTISTS | Artist          | Alternate header for artist                                                    |
-| LABEL                | Publisher       | Publisher/label                                                                |
-| USER                 | User            | User name (for per-user properties)                                            |
-| TEMPO                | Tempo           | Tempo in BPM                                                                   |
-| BPM                  | Tempo           | Alternate header for tempo                                                     |
-| BEATS-PER-MINUTE     | Tempo           | Alternate header for tempo                                                     |
-| LENGTH               | Length          | Song length (seconds or mm:ss)                                                 |
-| TRACK                | Track           | Track number                                                                   |
-| ALBUM                | Album           | Album name                                                                     |
-| #                    | Track           | Alternate header for track number                                              |
-| PUBLISHER            | Publisher       | Alternate header for publisher                                                 |
-| AMAZONTRACK          | Purchase (AS)   | Amazon track ID                                                                |
-| AMAZON               | Purchase (AS)   | Amazon album ID                                                                |
-| ITUNES               | Purchase (IS)   | iTunes ID                                                                      |
-| PATH                 | OwnerHash       | File path hash                                                                 |
-| TIME                 | Length          | Alternate header for length                                                    |
-| COMMENT              | Tag+            | Adds tags (see below)                                                          |
-| COMMENTS             | Tag+            | Alternate header for tags                                                      |
-| RATING               | R               | Used for rating (see below)                                                    |
-| DANCERS              | DancersCell     | Dancer names                                                                   |
-| TITLE+ARTIST         | TitleArtistCell | Combined title and artist (see below)                                          |
-| DANCETAGS            | DanceTags       | Dance-specific tags                                                            |
-| SONGTAGS             | SongTags        | General song tags                                                              |
-| GENRE                | GenreTags       | Genre/style tags                                                               |
-| YEAR                 | SongYear        | Year (adds a tag)                                                              |
-| MPM                  | MPM             | Measures-per-minute (tempo)                                                    |
-| MULTIDANCE           | MultiDance      | Multiple dances with tags (see below)                                          |
-| DANCECOMMENT         | Comment+        | Comment scoped to the current dance (stored as `Comment+:DanceId`)             |
-| CHOREOGRAPHER        | Choreographer+  | Choreographer scoped to the current dance (stored as `Choreographer+:DanceId`) |
-| STEPSHEETURL         | StepSheetUrl+   | Step sheet URL scoped to the current dance (stored as `StepSheetUrl+:DanceId`) |
-| SPOTIFY              | Purchase (SS)   | Spotify track ID                                                               |
+| Header Name          | Internal Field  | Description                                                                              |
+| -------------------- | --------------- | ---------------------------------------------------------------------------------------- |
+| DANCE                | DanceRating     | Dance style(s) for the song - uses dance IDs (see below)                                 |
+| TITLE                | Title           | Song title                                                                               |
+| ARTIST               | Artist          | Song artist                                                                              |
+| CONTRIBUTING ARTISTS | Artist          | Alternate header for artist                                                              |
+| LABEL                | Publisher       | Publisher/label                                                                          |
+| USER                 | User            | User name (for per-user properties)                                                      |
+| TEMPO                | Tempo           | Tempo in BPM                                                                             |
+| BPM                  | Tempo           | Alternate header for tempo                                                               |
+| BEATS-PER-MINUTE     | Tempo           | Alternate header for tempo                                                               |
+| LENGTH               | Length          | Song length (seconds or mm:ss)                                                           |
+| TRACK                | Track           | Track number                                                                             |
+| ALBUM                | Album           | Album name                                                                               |
+| #                    | Track           | Alternate header for track number                                                        |
+| PUBLISHER            | Publisher       | Alternate header for publisher                                                           |
+| AMAZONTRACK          | Purchase (AS)   | Amazon track ID                                                                          |
+| AMAZON               | Purchase (AS)   | Amazon album ID                                                                          |
+| ITUNES               | Purchase (IS)   | iTunes ID                                                                                |
+| PATH                 | OwnerHash       | File path hash                                                                           |
+| TIME                 | Length          | Alternate header for length                                                              |
+| COMMENT              | Tag+            | Adds tags (see below)                                                                    |
+| COMMENTS             | Tag+            | Alternate header for tags                                                                |
+| RATING               | R               | Used for rating (see below)                                                              |
+| DANCERS              | DancersCell     | Dancer names                                                                             |
+| TITLE+ARTIST         | TitleArtistCell | Combined title and artist (see below)                                                    |
+| DANCETAGS            | DanceTags       | Dance-specific tags                                                                      |
+| SONGTAGS             | SongTags        | General song tags                                                                        |
+| GENRE                | GenreTags       | Genre/style tags                                                                         |
+| YEAR                 | SongYear        | Year (adds a tag)                                                                        |
+| MPM                  | MPM             | Measures-per-minute (tempo)                                                              |
+| MULTIDANCE           | MultiDance      | Multiple dances with tags (see below)                                                    |
+| DANCECOMMENT         | Comment+        | Comment scoped to the current dance (stored as `Comment+:DanceId`)                       |
+| CHOREOGRAPHER        | Choreographer+  | Choreographer scoped to the current dance (stored as `Choreographer+:DanceId`)           |
+| STEPSHEETURL         | StepSheetUrl+   | Step sheet URL scoped to the current dance (stored as `StepSheetUrl+:DanceId`)           |
+| PATTERNNAME          | PatternName+    | Pattern/choreography name scoped to the current dance (stored as `PatternName+:DanceId`) |
+| SPOTIFY              | Purchase (SS)   | Spotify track ID                                                                         |
 
 > **Note:** The internal field is for reference; use the header name in your file.
 
@@ -118,23 +119,29 @@ The following header fields are recognized (case-insensitive). You may use any o
 - **SPOTIFY**: Spotify track ID
 - Used to generate purchase/streaming links for the song.
 
-### Dance-Scoped Fields (DANCECOMMENT, CHOREOGRAPHER, STEPSHEETURL)
+### Dance-Scoped Fields (DANCECOMMENT, CHOREOGRAPHER, STEPSHEETURL, PATTERNNAME)
 
 These fields apply a value to the most recently declared dance rating. They require at least one `DANCE` column to appear earlier in the same row.
 
 | Header        | Stored property format   | Example value                      |
 | ------------- | ------------------------ | ---------------------------------- |
-| DANCECOMMENT  | `Comment+:DanceId`       | `Boots on the Ground`              |
+| DANCECOMMENT  | `Comment+:DanceId`       | `"Ring" by Darren Bailey`          |
 | CHOREOGRAPHER | `Choreographer+:DanceId` | `Tre Little (USA) - January 2025`  |
 | STEPSHEETURL  | `StepSheetUrl+:DanceId`  | `https://www.copperknob.co.uk/...` |
+| PATTERNNAME   | `PatternName+:DanceId`   | `Ring`                             |
 
 The stored property name uses the `+` suffix followed by `:DanceId`, matching the `.Create=` serialization format used by the rest of the system. For example, for a PTN song:
 
 ```
-Comment+:PTN=Boots on the Ground
-Choreographer+:PTN=Tre Little (USA) - January 2025
-StepSheetUrl+:PTN=https://www.copperknob.co.uk/stepsheets/4GPM8ZG/boots-on-the-ground-with-clacker-fan
+Comment+:PTN="Ring" by Darren Bailey
+Choreographer+:PTN=Darren Bailey
+StepSheetUrl+:PTN=https://www.copperknob.co.uk/stepsheets/...
+PatternName+:PTN=Ring
 ```
+
+> **Line dance uploads**: the prepare-line-dance-upload.ps1 script generates DANCECOMMENT as
+> `"PatternName" by Choreographer` (plain ASCII double-quotes around the pattern name). If no
+> choreographer is recorded, the value is just `"PatternName"`.
 
 If there is no prior dance rating on the row, these fields are silently discarded.
 

--- a/architecture/song-internal-format.md
+++ b/architecture/song-internal-format.md
@@ -68,12 +68,12 @@ after `=`) or simply `.CommandName` if no `=` was present during load.
 BaseName[:index[:qualifier]][:danceId]
 ```
 
-| Segment      | Meaning                                                                                                                                                      |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `BaseName`   | Field identity (e.g. `Title`, `Tag+`, `DanceRating`)                                                                                                         |
-| `:index`     | Zero-based, 2-digit decimal index for multi-valued fields (albums, purchases). `-1` = single-value                                                           |
-| `:qualifier` | Optional per-field qualifier — currently used for purchase type (e.g. `AS`, `IS`)                                                                            |
-| `:danceId`   | On `Tag+`/`Tag-`, `Comment+`/`Comment-`, `Choreographer+`/`Choreographer-`, and `StepSheetUrl+`/`StepSheetUrl-`: are the properties that dance ID applies to |
+| Segment      | Meaning                                                                                                                                                                      |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BaseName`   | Field identity (e.g. `Title`, `Tag+`, `DanceRating`)                                                                                                                         |
+| `:index`     | Zero-based, 2-digit decimal index for multi-valued fields (albums, purchases). `-1` = single-value                                                                           |
+| `:qualifier` | Optional per-field qualifier — currently used for purchase type (e.g. `AS`, `IS`)                                                                                            |
+| `:danceId`   | On `Tag+`/`Tag-`, `Comment+`/`Comment-`, `Choreographer+`/`Choreographer-`, `StepSheetUrl+`/`StepSheetUrl-`, and `PatternName+`: are the properties that dance ID applies to |
 
 Examples:
 
@@ -89,6 +89,7 @@ Examples:
 | `Comment+:CHA`       | Cha Cha–scoped comment addition          |
 | `Choreographer+:PTN` | Pattern dance choreographer name         |
 | `StepSheetUrl+:PTN`  | Pattern dance step sheet URL             |
+| `PatternName+:PTN`   | Pattern dance name (line/choreography)   |
 | `.Create`            | Action command (no index / qualifier)    |
 
 ---
@@ -128,8 +129,9 @@ Field families that follow this pattern:
 | Comments       | `Comment+`       | `Comment-`       | —                                        |
 | Choreographer  | `Choreographer+` | `Choreographer-` | Dance-scoped only                        |
 | Step sheet URL | `StepSheetUrl+`  | `StepSheetUrl-`  | Dance-scoped only                        |
+| Pattern name   | `PatternName+`   | —                | Dance-scoped only                        |
 
-Comments, Choreographer, and StepSheetUrl are covered in detail in §3.4. Tag-specific
+Comments, Choreographer, StepSheetUrl, and PatternName are covered in detail in §3.4. Tag-specific
 behaviors are described below.
 
 #### Tag Fields
@@ -190,6 +192,7 @@ pipe-delimited or categorized), and there is no `Delete*` hard-delete variant.
 | `Choreographer-` | `RemoveChoreographerField` | Remove the choreographer from a dance                              |
 | `StepSheetUrl+`  | `AddStepSheetUrlField`     | Add a step sheet URL to a dance                                    |
 | `StepSheetUrl-`  | `RemoveStepSheetUrlField`  | Remove the step sheet URL from a dance                             |
+| `PatternName+`   | `AddPatternNameField`      | Add the pattern/choreography name to a dance                       |
 
 **Example** (line dance song with PTN dance rating):
 

--- a/m4d/.config/dotnet-tools.json
+++ b/m4d/.config/dotnet-tools.json
@@ -3,10 +3,11 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "3.1.2",
+      "version": "10.0.8",
       "commands": [
         "dotnet-ef"
-      ]
+      ],
+      "rollForward": false
     }
   }
 }

--- a/m4d/Program.cs
+++ b/m4d/Program.cs
@@ -379,8 +379,9 @@ else
                 // Default is 30s which can timeout when database is warming up
                 sqlOptions.CommandTimeout(60);
             }));
-        // Note: Database health is confirmed by the migration background task after
-        // a real connection is established - not marked healthy here at registration time.
+        // Note: Database health is marked healthy after migrations run synchronously
+        // later in startup (or after the first successful FixupStats DB access).
+        // It is intentionally not marked healthy here at registration time.
         Console.WriteLine("Database context configured successfully (CommandTimeout: 60s, health pending connection)");
     }
     catch (Exception ex)

--- a/m4d/Program.cs
+++ b/m4d/Program.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Extensions.FileProviders;
@@ -378,8 +379,9 @@ else
                 // Default is 30s which can timeout when database is warming up
                 sqlOptions.CommandTimeout(60);
             }));
-        serviceHealth.MarkHealthy("Database");
-        Console.WriteLine("Database context configured successfully (CommandTimeout: 60s)");
+        // Note: Database health is confirmed by the migration background task after
+        // a real connection is established - not marked healthy here at registration time.
+        Console.WriteLine("Database context configured successfully (CommandTimeout: 60s, health pending connection)");
     }
     catch (Exception ex)
     {
@@ -884,42 +886,34 @@ app.MapRazorPages();
 
 GlobalState.UseTestKeys = isDevelopment;
 
-// Run database migrations in background after app starts accepting requests
-_ = Task.Run(async () =>
+// Run database migrations synchronously before starting the app, so the DB is
+// guaranteed to exist before DanceStatsHostedService or any other hosted service runs.
+if (serviceHealth.GetServiceStatus("Database").Status != ServiceStatus.Unavailable
+    && !useProdDb && !useTestDb)
 {
-    // Wait a moment for app to start accepting HTTP requests
-    await Task.Delay(TimeSpan.FromSeconds(2));
-
-    if (!serviceHealth.IsServiceAvailable("Database"))
-    {
-        Console.WriteLine("Skipping database migrations - database service is unavailable");
-        return;
-    }
-
-    if (useProdDb)
-    {
-        Console.WriteLine("Skipping database migrations and seed data - PROD_DB is set");
-        return;
-    }
-
-    if (useTestDb)
-    {
-        Console.WriteLine("Skipping database migrations and seed data - TEST_DB is set");
-        return;
-    }
-
-    Console.WriteLine("Running database migrations in background...");
+    Console.WriteLine("Running database migrations...");
     try
     {
-        using var scope = app.Services.CreateScope();
-        var sp = scope.ServiceProvider;
-        var db = sp.GetRequiredService<DanceMusicContext>().Database;
+        // Use a context without EnableRetryOnFailure so that Migrate() can reach its
+        // CREATE DATABASE path when the local DB has been deleted, rather than retrying
+        // the failed connection attempt and giving up before the DB is created.
+        var migrationOptions = new DbContextOptionsBuilder<DanceMusicContext>()
+            .UseSqlServer(connectionString, sqlOptions => sqlOptions.CommandTimeout(60))
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
 
-        db.Migrate();
+        using var migrationContext = new DanceMusicContext(migrationOptions);
+        Console.WriteLine($"[Migration] Connecting to: {migrationContext.Database.GetConnectionString()}");
+        Console.WriteLine("[Migration] Calling MigrateAsync...");
+        await migrationContext.Database.MigrateAsync();
+        Console.WriteLine("[Migration] MigrateAsync completed successfully");
+        serviceHealth.MarkHealthy("Database");
         Console.WriteLine("Database migrations completed successfully");
 
         if (isDevelopment)
         {
+            using var scope = app.Services.CreateScope();
+            var sp = scope.ServiceProvider;
             var userManager = sp.GetRequiredService<UserManager<ApplicationUser>>();
             var roleManager = sp.GetRequiredService<RoleManager<IdentityRole>>();
             await UserManagerHelpers.SeedData(userManager, roleManager, configuration);
@@ -932,6 +926,10 @@ _ = Task.Run(async () =>
         Console.WriteLine($"ERROR: Database migration failed: {ex.GetType().Name}: {ex.Message}");
         Console.WriteLine("WARNING: Continuing without database - data features will be unavailable");
     }
-});
+}
+else if (useProdDb || useTestDb)
+{
+    Console.WriteLine("Skipping database migrations - PROD_DB or TEST_DB is set");
+}
 
 app.Run();

--- a/m4dModels.Tests/CreateFromRowTests.cs
+++ b/m4dModels.Tests/CreateFromRowTests.cs
@@ -661,6 +661,20 @@ public class CreateFromRowTests
         Assert.AreEqual(url, sheetProp.Value);
     }
 
+    [TestMethod]
+    public async Task PatternName_AppliedToPriorDanceRating()
+    {
+        var song = await Row(
+            [Song.TitleField, Song.DanceRatingField, Song.AddPatternNameField],
+            ["Title", "PTN", "Ring"]);
+
+        Assert.IsNotNull(song);
+        var patternProp = song.SongProperties.FirstOrDefault(p =>
+            p.BaseName == Song.AddPatternNameField && p.DanceQualifier == "PTN");
+        Assert.IsNotNull(patternProp, "PatternName should be stored with dance qualifier");
+        Assert.AreEqual("Ring", patternProp.Value);
+    }
+
     // ─── MPM (measures per minute) ────────────────────────────────────────────
 
     [TestMethod]
@@ -889,6 +903,7 @@ public class CreateFromRowTests
             ("DANCECOMMENT",        Song.AddCommentField),
             ("CHOREOGRAPHER",       Song.AddChoreographerField),
             ("STEPSHEETURL",        Song.AddStepSheetUrlField),
+            ("PATTERNNAME",         Song.AddPatternNameField),
             ("SONGID",              Song.SongIdOverride),
         };
 

--- a/m4dModels.Tests/StringHelpersTests.cs
+++ b/m4dModels.Tests/StringHelpersTests.cs
@@ -1,0 +1,74 @@
+using m4dModels.Utilities;
+
+namespace m4dModels.Tests;
+
+[TestClass]
+public class StringHelpersTests
+{
+    // ─── UnquoteCsvCell ───────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void UnquoteCsvCell_PlainValue_Unchanged()
+    {
+        Assert.AreEqual("hello", "hello".UnquoteCsvCell());
+    }
+
+    [TestMethod]
+    public void UnquoteCsvCell_SimpleWrappedValue_StripsOuterQuotes()
+    {
+        Assert.AreEqual("hello", "\"hello\"".UnquoteCsvCell());
+    }
+
+    [TestMethod]
+    public void UnquoteCsvCell_InternalDoubledQuotes_Unescaped()
+    {
+        // RFC 4180: "" inside a quoted field → single "
+        // Export-Csv encodes  "Ring" by Darren  as  """Ring"" by Darren"
+        Assert.AreEqual("\"Ring\" by Darren", "\"\"\"Ring\"\" by Darren\"".UnquoteCsvCell());
+    }
+
+    [TestMethod]
+    public void UnquoteCsvCell_EmptyQuotedString_ReturnsEmpty()
+    {
+        Assert.AreEqual("", "\"\"".UnquoteCsvCell());
+    }
+
+    [TestMethod]
+    public void UnquoteCsvCell_EmptyString_Unchanged()
+    {
+        Assert.AreEqual("", "".UnquoteCsvCell());
+    }
+
+    [TestMethod]
+    public void UnquoteCsvCell_SingleQuoteChar_Unchanged()
+    {
+        // A lone " is not a valid RFC 4180 quoted field — return as-is
+        Assert.AreEqual("\"", "\"".UnquoteCsvCell());
+    }
+
+    [TestMethod]
+    public void UnquoteCsvCell_StartsWithQuoteNoClosing_Unchanged()
+    {
+        Assert.AreEqual("\"no close", "\"no close".UnquoteCsvCell());
+    }
+
+    [TestMethod]
+    public void UnquoteCsvCell_EndsWithQuoteNoOpening_Unchanged()
+    {
+        Assert.AreEqual("no open\"", "no open\"".UnquoteCsvCell());
+    }
+
+    [TestMethod]
+    public void UnquoteCsvCell_MultipleInternalDoubledQuotes_AllUnescaped()
+    {
+        // "say ""hello"" and ""bye""" → say "hello" and "bye"
+        Assert.AreEqual("say \"hello\" and \"bye\"",
+            "\"say \"\"hello\"\" and \"\"bye\"\"\"".UnquoteCsvCell());
+    }
+
+    [TestMethod]
+    public void UnquoteCsvCell_ValueWithNoInternalQuotes_StripsOnlyOuter()
+    {
+        Assert.AreEqual("Sherry McClure (USA)", "\"Sherry McClure (USA)\"".UnquoteCsvCell());
+    }
+}

--- a/m4dModels.Tests/TestData/test-dances.json
+++ b/m4dModels.Tests/TestData/test-dances.json
@@ -1479,5 +1479,17 @@
         "style": "Performance"
       }
     ]
+  },
+  {
+    "id": "PTN",
+    "name": "Pattern",
+    "meter": { "numerator": 1, "denominator": 1 },
+    "synonyms": ["Line Dance", "Choreographed Partner Dance", "Sequence Dance"],
+    "instances": [
+      {
+        "style": "Social",
+        "tempoRange": { "min": 1.0, "max": 500.0 }
+      }
+    ]
   }
 ]

--- a/m4dModels/DanceRating.cs
+++ b/m4dModels/DanceRating.cs
@@ -72,6 +72,9 @@ public class DanceRating : TaggableObject
     [DataMember]
     public string StepSheetUrl { get; set; }
 
+    [DataMember]
+    public string PatternName { get; set; }
+
     protected override HashSet<string> ValidClasses => s_validClasses;
 
     public static Dictionary<string, string> DanceMap

--- a/m4dModels/DanceStatsInstance.cs
+++ b/m4dModels/DanceStatsInstance.cs
@@ -287,15 +287,21 @@ public class DanceStatsInstance
             {
                 await instance.FixupStats(database, serviceHealthManager);
             }
-            catch (Exception ex)
+            catch (Microsoft.Data.SqlClient.SqlException ex)
             {
-                // FixupStats DB operations failed - the deserialized instance is still usable
-                // from the cache file; log and continue rather than discarding valid data.
-                Console.WriteLine($"FixupStats failed, using cached stats data: {ex.Message}");
+                // Database-specific failure in FixupStats - the deserialized instance is still
+                // usable from the cache file; log and continue rather than discarding valid data.
+                Console.WriteLine($"FixupStats DB failure, using cached stats data: {ex.Message}");
                 if (serviceHealthManager != null)
                 {
                     (serviceHealthManager as dynamic).MarkUnavailable("Database", $"{ex.GetType().Name}: {ex.Message}");
                 }
+            }
+            catch (Exception ex)
+            {
+                // Non-database failure (e.g. search index update) - log and continue without
+                // poisoning database health, since the DB itself may be perfectly healthy.
+                Console.WriteLine($"FixupStats non-DB failure, using cached stats data: {ex.GetType().Name}: {ex.Message}");
             }
         }
 

--- a/m4dModels/DanceStatsInstance.cs
+++ b/m4dModels/DanceStatsInstance.cs
@@ -144,8 +144,7 @@ public class DanceStatsInstance
             group.MaxWeight = group.Children.Max(d => d.MaxWeight);
         }
 
-        // Check if database is available before attempting database operations
-        // If ServiceHealthManager is provided and database is not healthy, return early
+        // Skip DB-dependent operations if database is already known to be unavailable
         if (serviceHealthManager != null)
         {
             var healthManager = serviceHealthManager as dynamic;
@@ -156,57 +155,75 @@ public class DanceStatsInstance
             }
         }
 
-        var playlists =
-            dms.PlayLists.Where(p => p.Type == PlayListType.SpotifyFromSearch)
-                .Where(p => p.Name != null)
-                .Select(p => new PlaylistMetadata { Id = p.Id, Name = p.Name })
-                .ToDictionary(m => m.Name, m => m);
-
-        var newDances = new List<string>();
-
-        foreach (var dance in Dances.Where(d => playlists.ContainsKey(d.DanceName)))
+        try
         {
-            if (playlists.TryGetValue(dance.DanceName, out var metadata))
-            {
-                dance.SpotifyPlaylist = metadata.Id;
-            }
-        }
+            var playlists =
+                dms.PlayLists.Where(p => p.Type == PlayListType.SpotifyFromSearch)
+                    .Where(p => p.Name != null)
+                    .Select(p => new PlaylistMetadata { Id = p.Id, Name = p.Name })
+                    .ToDictionary(m => m.Name, m => m);
 
-        var saveChanges = false;
-        foreach (var ds in
-            Dances.Concat(Groups).Where(s => s.Dance.Description == null))
-        {
-            var dance = await dms.Dances.FindAsync(ds.DanceId);
-            if (dance == null)
+            var newDances = new List<string>();
+
+            foreach (var dance in Dances.Where(d => playlists.ContainsKey(d.DanceName)))
             {
-                _ = dms.Dances.Add(
-                    new Dance
-                    {
-                        Id = ds.DanceId,
-                        Description = DescriptionPlaceholder
-                    });
-            }
-            else
-            {
-                dance.Description = DescriptionPlaceholder;
+                if (playlists.TryGetValue(dance.DanceName, out var metadata))
+                {
+                    dance.SpotifyPlaylist = metadata.Id;
+                }
             }
 
-            saveChanges = true;
+            var saveChanges = false;
+            foreach (var ds in
+                Dances.Concat(Groups).Where(s => s.Dance.Description == null))
+            {
+                var dance = await dms.Dances.FindAsync(ds.DanceId);
+                if (dance == null)
+                {
+                    _ = dms.Dances.Add(
+                        new Dance
+                        {
+                            Id = ds.DanceId,
+                            Description = DescriptionPlaceholder
+                        });
+                }
+                else
+                {
+                    dance.Description = DescriptionPlaceholder;
+                }
 
-            newDances.Add(ds.DanceId);
-            ds.SetTopSongs([]);
-            ds.SongTags = new TagSummary();
-            ds.DanceTags = new TagSummary();
+                saveChanges = true;
+
+                newDances.Add(ds.DanceId);
+                ds.SetTopSongs([]);
+                ds.SongTags = new TagSummary();
+                ds.DanceTags = new TagSummary();
+            }
+
+            if (saveChanges)
+            {
+                _ = await dms.SaveChanges();
+            }
+
+            if (newDances.Count > 0)
+            {
+                _ = await dms.SongIndex.UpdateIndex(newDances);
+            }
+
+            // First successful DB access - mark healthy if it wasn't already known
+            if (serviceHealthManager != null)
+            {
+                (serviceHealthManager as dynamic).MarkHealthy("Database");
+            }
         }
-
-        if (saveChanges)
+        catch (Microsoft.Data.SqlClient.SqlException ex)
         {
-            _ = await dms.SaveChanges();
-        }
-
-        if (newDances.Count > 0)
-        {
-            _ = await dms.SongIndex.UpdateIndex(newDances);
+            Console.WriteLine($"Database unavailable during FixupStats: {ex.Message}");
+            if (serviceHealthManager != null)
+            {
+                (serviceHealthManager as dynamic).MarkUnavailable("Database", $"{ex.GetType().Name}: {ex.Message}");
+            }
+            // Return gracefully - the in-memory stats loaded from cache are still valid
         }
     }
 
@@ -266,7 +283,20 @@ public class DanceStatsInstance
         var instance = JsonConvert.DeserializeObject<DanceStatsInstance>(json, settings) ?? throw new Exception($"Unable to deserialize dance stats instance: {json}");
         if (database != null)
         {
-            await instance.FixupStats(database, serviceHealthManager);
+            try
+            {
+                await instance.FixupStats(database, serviceHealthManager);
+            }
+            catch (Exception ex)
+            {
+                // FixupStats DB operations failed - the deserialized instance is still usable
+                // from the cache file; log and continue rather than discarding valid data.
+                Console.WriteLine($"FixupStats failed, using cached stats data: {ex.Message}");
+                if (serviceHealthManager != null)
+                {
+                    (serviceHealthManager as dynamic).MarkUnavailable("Database", $"{ex.GetType().Name}: {ex.Message}");
+                }
+            }
         }
 
         manager ??= database.DanceStatsManager;

--- a/m4dModels/Song.cs
+++ b/m4dModels/Song.cs
@@ -15,6 +15,8 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
 
+using m4dModels.Utilities;
+
 using static System.Char;
 
 // ReSharper disable ArrangeThisQualifier
@@ -271,10 +273,11 @@ public class Song : TaggableObject
     public const string SongComment = "SongComment";
     public const string SongYear = "SongYear";
     // Dance-scoped metadata add fields (stored as "Field+:DanceId").
-    // Remove variants (Choreographer-, StepSheetUrl-) are not yet supported in the UX.
+    // Remove variants are not yet supported in the UX.
     // AddCommentField / RemoveCommentField are already defined above ("Comment+" / "Comment-")
     public const string AddChoreographerField = "Choreographer+";
     public const string AddStepSheetUrlField = "StepSheetUrl+";
+    public const string AddPatternNameField = "PatternName+";
     public const string SongIdOverride = "SongIdOverride";
 
     // Commands
@@ -763,10 +766,7 @@ public class Song : TaggableObject
             var baseName = SongProperty.ParseBaseName(fields[i]);
             string qual = null;
             cell = cell.Trim();
-            if (cell.Length > 0 && cell[0] == '"' && cell[^1] == '"')
-            {
-                cell = cell.Trim('"');
-            }
+            cell = cell.UnquoteCsvCell();
 
             specifiedAction |= SongProperty.IsActionName(baseName);
             // ReSharper disable once SwitchStatementMissingSomeCases
@@ -1134,6 +1134,7 @@ public class Song : TaggableObject
                     break;
                 case AddChoreographerField:
                 case AddStepSheetUrlField:
+                case AddPatternNameField:
                     if (!string.IsNullOrWhiteSpace(cell) && ratings != null)
                     {
                         foreach (var r in ratings)
@@ -1321,6 +1322,7 @@ public class Song : TaggableObject
             { "SPOTIFY", SongProperty.FormatName(PurchaseField, null, "SS") },
             { "CHOREOGRAPHER", AddChoreographerField },
             { "STEPSHEETURL", AddStepSheetUrlField },
+            { "PATTERNNAME", AddPatternNameField },
             { "SONGID", SongIdOverride },
         };
 
@@ -1667,6 +1669,9 @@ public class Song : TaggableObject
                     break;
                 case AddStepSheetUrlField:
                     AddObjectStepSheetUrl(prop.DanceQualifier, prop.Value);
+                    break;
+                case AddPatternNameField:
+                    AddObjectPatternName(prop.DanceQualifier, prop.Value);
                     break;
                 case DeleteTagLabel:
                     ForceDeleteTag(prop.DanceQualifier, prop.Value, stats);
@@ -3006,6 +3011,18 @@ public class Song : TaggableObject
                         {
                             _ = CreateProperty(prop.Name, prop.Value);
                             rating.StepSheetUrl = prop.Value;
+                            modified = true;
+                        }
+                    }
+                    break;
+                case AddPatternNameField:
+                    if (prop.DanceQualifier != null && !string.IsNullOrWhiteSpace(prop.Value))
+                    {
+                        var rating = FindRating(prop.DanceQualifier);
+                        if (rating != null)
+                        {
+                            _ = CreateProperty(prop.Name, prop.Value);
+                            rating.PatternName = prop.Value;
                             modified = true;
                         }
                     }
@@ -4564,6 +4581,18 @@ public class Song : TaggableObject
             return;
         }
         rating.StepSheetUrl = value;
+    }
+
+    public void AddObjectPatternName(string qualifier, string value)
+    {
+        if (string.IsNullOrWhiteSpace(qualifier)) return;
+        var rating = FindRating(qualifier);
+        if (rating == null)
+        {
+            Trace.WriteLine($"Bad pattern name on {Title} by {Artist}");
+            return;
+        }
+        rating.PatternName = value;
     }
 
     public void RemoveObjectComment(string qualifier, string userName)

--- a/m4dModels/Utilities/StringHelpers.cs
+++ b/m4dModels/Utilities/StringHelpers.cs
@@ -17,4 +17,19 @@ public static partial class StringHelpers
     {
         return new string([.. filename.Except(System.IO.Path.GetInvalidFileNameChars())]);
     }
+
+    /// <summary>
+    /// Unquotes a single CSV/TSV cell using RFC 4180 rules:
+    /// if the value is wrapped in a matching pair of double-quotes, strip the outer
+    /// quotes and unescape any internal doubled double-quotes (<c>""</c> → <c>"</c>).
+    /// Values that are not wrapped in quotes are returned unchanged.
+    /// </summary>
+    public static string UnquoteCsvCell(this string cell)
+    {
+        if (cell.Length >= 2 && cell[0] == '"' && cell[^1] == '"')
+        {
+            return cell[1..^1].Replace("\"\"", "\"");
+        }
+        return cell;
+    }
 }

--- a/scripts/prepare-line-dance-upload.ps1
+++ b/scripts/prepare-line-dance-upload.ps1
@@ -40,6 +40,12 @@
       SONGID      -> SongIdOverride  (direct SongId lookup, bypasses title matching)
       CHOREOGRAPHER -> Choreographer/PTN dance property (dance-level, like DanceComment)
       STEPSHEETURL  -> StepSheetUrl/PTN dance property (dance-level, like DanceComment)
+      PATTERNNAME   -> PatternName/PTN dance property (the line/pattern dance name)
+
+    DANCECOMMENT is formatted as "PatternName" by Choreographer so the comment text
+    surfaces the dance identity inline wherever comments are displayed.
+
+    DANCETAGS always includes Line Dance:Style (plus the difficulty tag when present).
 #>
 
 [CmdletBinding()]
@@ -208,6 +214,21 @@ foreach ($row in $rows) {
         $unknownDifficulties.Add($rawDiff) | Out-Null
     }
 
+    $choreographer = Get-CleanChoreographerName ($row.'Choreographer')
+    $patternName   = $row.'Dance Name'.Trim()
+
+    # Format DANCECOMMENT as "PatternName" by Choreographer.
+    # The TSV parser in Song.cs uses RFC 4180 unquoting, so plain ASCII double quotes
+    # survive Export-Csv round-tripping correctly.
+    $danceComment = if ($choreographer -ne '') {
+        "`"$patternName`" by $choreographer"
+    } else {
+        "`"$patternName`""
+    }
+
+    # DANCETAGS: always include Line Dance:Style; append difficulty when known
+    $danceTags = if ($diffTag -ne '') { "Line Dance:Style|$diffTag" } else { 'Line Dance:Style' }
+
     $uploadRow = [PSCustomObject]@{
         USER           = $Username
         DANCE          = 'PTN'
@@ -216,10 +237,11 @@ foreach ($row in $rows) {
         ARTIST         = $aa.Artist
         ALBUM          = $aa.Album
         SPOTIFY        = $spotifyId
-        DANCECOMMENT   = $row.'Dance Name'.Trim()
-        CHOREOGRAPHER  = Get-CleanChoreographerName ($row.'Choreographer')
+        DANCECOMMENT   = $danceComment
+        PATTERNNAME    = $patternName
+        CHOREOGRAPHER  = $choreographer
         STEPSHEETURL   = $row.'Copperknob Link'.Trim()
-        DANCETAGS      = $diffTag
+        DANCETAGS      = $danceTags
     }
 
     if ($songId -ne '') {


### PR DESCRIPTION
## Summary

This PR adds a new `PatternName` property for Pattern/line dance songs, improves the line dance upload script, and hardens the startup migration path.

—

## Pattern dance improvements

**New `PatternName` property (`DanceRating.PatternName`)**

Adds a dance-scoped `PatternName+` field to `DanceRating` so the choreography/line dance name is stored as a first-class property alongside `Choreographer` and `StepSheetUrl`. It follows the same dance-scoped storage pattern: `PatternName+:PTN=Ring`.

**`PATTERNNAME` TSV upload column (`Song.cs`)**

Adds `PATTERNNAME` as a recognized upload header that maps to `AddPatternNameField`. Supports both bulk TSV uploads and song property log replay.

**`DANCECOMMENT` now formatted as `"PatternName" by Choreographer`**

The `prepare-line-dance-upload.ps1` script now formats `DANCECOMMENT` as `"PatternName" by Choreographer` (e.g. `"Ring" by Darren Bailey`) so the dance identity surfaces inline wherever comments are displayed. If no choreographer is recorded, the value is just `"PatternName"`.

**`DANCETAGS` always includes `Line Dance:Style`**

The upload script now unconditionally emits `Line Dance:Style` in `DANCETAGS`, appending a difficulty tag when present (e.g. `Line Dance:Style|Intermediate:Difficulty`). Previously, `DANCETAGS` only contained the difficulty tag and `Line Dance:Style` was never set.

—

## CSV unquoting fix (`StringHelpers.UnquoteCsvCell`)

Replaced the inline `Trim('"')` strip in `Song.cs` with a proper RFC 4180-compliant `UnquoteCsvCell()` extension method that:
- Strips outer double-quotes only when the value is a matched pair
- Unescapes internal doubled double-quotes (`""` → `"`)
- Returns non-quoted values unchanged

This correctly handles `Export-Csv` output where a value like `"Ring" by Darren Bailey` is encoded as `"""Ring"" by Darren Bailey"`. The old `Trim('"')` would strip both outer and inner quotes incorrectly.

New unit tests cover plain values, wrapped values, internal doubled quotes, edge cases (single `"`, mismatched quotes), and multiple escaped quotes.

—

## Database startup reliability (`Program.cs`, `DanceStatsInstance.cs`)

- Migrations now run **synchronously before the app starts accepting requests**, ensuring the database exists before `DanceStatsHostedService` or other hosted services run. The previous background-task approach allowed hosted services to race the migration.
- Database health is now marked healthy **after** a real connection is established (inside migration or `FixupStats`), not speculatively at registration time.
- `FixupStats` DB operations are wrapped in a `SqlException` catch so a cold-start DB failure degrades gracefully — the in-memory stats loaded from the cache file remain valid.
- `dotnet-ef` tool updated from 3.1.2 → 10.0.8 to match .NET 10.

—

## Docs

- `architecture/SongUploadFormat.md` — Added `PATTERNNAME` column; updated `DANCECOMMENT` example to show the `"Name" by Choreographer` format; noted how `prepare-line-dance-upload.ps1` generates the column.
- `architecture/song-internal-format.md` — Added `PatternName+` to the property name reference table and field families table.
