### PR TITLE
Admin Pages Performance: Phases 2–5 + PageFrame

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -131,6 +131,12 @@ The directory itself is tracked (via `local/.gitkeep`) but its contents are giti
   - **NEVER** use `<i class="bi bi-icon-name">` (old Bootstrap Icons pattern)
   - Icons from `@iconify-json/bi` package (Bootstrap Icons)
   - No explicit imports needed - unplugin-icons handles auto-import
+- **PageFrame**: ALL Vue page apps (`src/pages/*/App.vue`) MUST wrap their template content in `<PageFrame id="app" :title="...">` (or `title="..."` for static titles)
+  - Provides: main navigation menu, service status banner, h1 page title, and site footer
+  - Pages that skip PageFrame will lack all site chrome (nav, footer, branding)
+  - Use `const pageTitle = computed(() => ...)` for dynamic titles, then `:title="pageTitle"`
+  - **Note**: PageFrame's footer contains `<a target="_blank">` — avoid `a[target="_blank"]` in tests; use more-specific selectors (e.g. `img[alt="..."]`)
+
 - **Bootstrap Components**: ALWAYS prefer bootstrap-vue-next components over custom implementations or native Bootstrap 5
   - Use `<BAccordion>`, `<BAlert>`, `<BButton>`, `<BCard>`, etc. from bootstrap-vue-next
   - Avoid manual Bootstrap CSS/JS patterns when equivalent component exists

--- a/architecture/admin-pages-performance.md
+++ b/architecture/admin-pages-performance.md
@@ -398,12 +398,18 @@ src/pages/searches/
 
 - Server handles paging — each page click navigates to `/Searches/Index?...&page=N`
 - Sort toggle (Most Popular / Most Recent) navigates via computed URL, resets to page 1
-- Spotify Only switch navigates via computed URL (same parameters + toggled `spotifyOnly`)
+- Spotify Only switch navigates via an `onSpotifyToggle()` handler function that sets
+  `window.location.href` — Vue template expressions do not have `window` in scope, so the
+  navigation must happen inside a `<script setup>` function
 - Toggle Details navigates via computed URL (admin only)
-- Windowed pagination nav: ±2 window around current page, first/last always shown, ellipsis in gaps
+- Pagination: `BPagination` (bootstrap-vue-next) + page-jump input (`Page [n] of N`), matching
+  `SongFooter.vue` style. `total-rows="totalPages" per-page="1"` maps page count directly.
+  `@page-click` intercepts BVN's internal routing and sets `window.location.href` to the
+  server URL for the selected page
 - `BTable` fields are computed based on `showDetails` — detail view adds Query, User, Count,
   Created, Modified columns
 - Per-row delete URL and search URLs are pre-built in the model (not computed in Vue)
+- All pages wrapped in `<PageFrame>` for consistent nav/header/footer chrome
 
 ---
 
@@ -456,19 +462,20 @@ src/pages/activity-log/
     model.ts               -- test fixture data
 ```
 
-Pagination nav follows same windowed pattern as Searches.
+Pagination follows the same `BPagination` + page-jump input pattern as Searches. All pages
+wrapped in `<PageFrame id="app" title="Activity Log">`.
 
 ---
 
 ## Development Phases
 
-| Phase | PR scope                                              | Status                | Outcome                                                             |
-| ----- | ----------------------------------------------------- | --------------------- | ------------------------------------------------------------------- |
-| **1** | ApplicationUsers/Index → Vue (DTO + Vue page + tests) | ✅ Complete (PR #174) | Users page is responsive; all auxiliary pages unchanged             |
-| **2** | PlayList/Index → Vue                                  | ✅ Complete           | Playlists page is responsive                                        |
-| **3** | Searches/Index server paging (DB-level Skip/Take)     | ✅ Complete           | Searches paginated server-side                                      |
-| **4** | ActivityLog/Index server paging                       | ✅ Complete           | Activity log paginated server-side                                  |
-| **5** | Searches/Index + ActivityLog/Index → Vue conversion   | ✅ Complete           | Both pages rendered by Vue with windowed server-side pagination nav |
+| Phase | PR scope                                              | Status                | Outcome                                                                                                      |
+| ----- | ----------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **1** | ApplicationUsers/Index → Vue (DTO + Vue page + tests) | ✅ Complete (PR #174) | Users page is responsive; all auxiliary pages unchanged                                                      |
+| **2** | PlayList/Index → Vue                                  | ✅ Complete           | Playlists page is responsive                                                                                 |
+| **3** | Searches/Index server paging (DB-level Skip/Take)     | ✅ Complete           | Searches paginated server-side                                                                               |
+| **4** | ActivityLog/Index server paging                       | ✅ Complete           | Activity log paginated server-side                                                                           |
+| **5** | Searches/Index + ActivityLog/Index → Vue conversion   | ✅ Complete           | Both pages rendered by Vue with `BPagination` + page-jump input; PageFrame added to all four admin Vue pages |
 
 Each phase is independently deployable. Later phases can be re-prioritised without affecting
 earlier ones.
@@ -500,6 +507,11 @@ earlier ones.
 - **Snapshot tests** for both pages: `searches.test.ts`, `activity-log.test.ts`
 - **Behavior tests**: sort active state, pagination visibility, delete-all visibility,
   admin Toggle Details visibility, table columns in detail mode, Spotify icon, no-user placeholder
+- **Pagination selector**: use `ul.pagination` (the `<ul>` BPagination always renders); do not
+  use `nav[aria-label]` — bootstrap-vue-next does not render it in a form reachable by CSS
+  attribute selector in JSDOM
+- **Spotify icon test**: use `img[alt="Spotify Playlist"]` rather than `a[target="_blank"]` —
+  PageFrame's footer also contains an `<a target="_blank">` link
 - **Manual smoke test**: navigate to each page, verify pagination nav, sort toggles, delete buttons,
   Spotify links, and (for Searches) the admin Toggle Details link.
 
@@ -525,3 +537,19 @@ earlier ones.
 
 5. **Browser history / URL state**: Filter toggles (showUnconfirmed, etc.) do not update the URL.
    This is acceptable for an admin-only page.
+
+6. **Pagination controls (server-paged pages)**: Searches and ActivityLog use `BPagination`
+   (bootstrap-vue-next) plus a direct page-jump input (`Page [n] of N`), matching `SongFooter.vue`.
+   Config: `total-rows="totalPages" per-page="1"` maps page numbers directly; `@page-click`
+   intercepts BVN's client-side routing and instead sets `window.location.href` to the
+   server-rendered URL for the selected page. Client-paged pages (admin-users, playlist) continue
+   to use BPagination with BTable's built-in `current-page` / `per-page` props.
+
+7. **`window.location.href` in Vue templates**: Vue 3's template compiler does not expose
+   `window` as a global. Any navigation that needs `window.location.href` must be wrapped in a
+   `<script setup>` handler function (e.g. `onSpotifyToggle()`). Binding `@change="window.location.href = ..."` directly in the template will fail silently at runtime.
+
+8. **PageFrame**: All `src/pages/*/App.vue` root components wrap their content in `<PageFrame>`
+   to provide the main navigation bar, service status banner, `<h1>` page title, and site footer.
+   `admin-users` and `playlist` (Phases 1–2) were retrofitted with PageFrame alongside the
+   Phase 5 work.

--- a/architecture/admin-pages-performance.md
+++ b/architecture/admin-pages-performance.md
@@ -7,10 +7,10 @@ Chromium-based browsers to become unresponsive. The root cause is not the data v
 is the cost of parsing and laying out thousands of DOM nodes at once. Two categories of pages need
 different treatments:
 
-| Category               | Pages                                      | Strategy                                                      |
-| ---------------------- | ------------------------------------------ | ------------------------------------------------------------- |
-| **Vue conversion**     | `ApplicationUsers/Index`, `PlayList/Index` | Plant all data as JSON, page/filter/sort client-side with BVN |
-| **Server-side paging** | `Searches/Index`, `ActivityLog/Index`      | Add `page` parameter, paginate at the DB/query level          |
+| Category                           | Pages                                      | Strategy                                                                                           |
+| ---------------------------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| **Vue conversion (client paging)** | `ApplicationUsers/Index`, `PlayList/Index` | Plant all data as JSON, page/filter/sort client-side with BVN                                      |
+| **Vue conversion (server paging)** | `Searches/Index`, `ActivityLog/Index`      | Server paginates at DB level; Vue renders the current page and windowed server-side pagination nav |
 
 Auxiliary pages (Details, Edit, Delete confirmation, ChangeRoles, etc.) remain as Razor — no
 conversion is needed or wanted for these.
@@ -288,7 +288,7 @@ changing how `filteredLists` is computed client-side, not eliminating the server
 
 ---
 
-## Part 3 — Server-Side Paging: Searches/Index _(Priority 3)_
+## Part 3 — Vue Conversion + Server-Side Paging: Searches/Index _(Priority 3)_
 
 ### Current behavior
 
@@ -296,8 +296,9 @@ changing how `filteredLists` is computed client-side, not eliminating the server
 
 ### Target behavior
 
-Add a `page` parameter. Page at the database level via `.Skip()`/`.Take()` and display Bootstrap
-pagination controls in the existing Razor view. No Vue conversion.
+Add a `page` parameter. Page at the database level via `.Skip()`/`.Take()`. Render via Vue using
+the `Vue3()` helper — server supplies `SearchesPageModel` JSON; Vue renders the table and builds
+windowed server-side pagination nav links (no SPA routing — each page click navigates to the server).
 
 ### C# changes
 
@@ -335,14 +336,78 @@ public async Task<IActionResult> Index(string user, string sort = null,
 }
 ```
 
-### Razor view changes
+### C# changes
 
-Add a standard Bootstrap pagination block at the bottom of `Index.cshtml`, passing the current
-filter parameters through `asp-route-*` attributes to preserve state across page turns.
+#### New DTOs — `m4d/ViewModels/SearchesPageModel.cs`
+
+```csharp
+public class SearchSummary
+{
+    public long Id { get; set; }
+    public string UserName { get; set; }   // "anonymous" when no user
+    public string Query { get; set; }
+    public string Description { get; set; }  // filter.Description, computed server-side
+    public string SearchUrl { get; set; }    // pre-built; involves SongFilter serialization
+    public string SearchPageUrl { get; set; } // link to most-recently-visited page (optional)
+    public int? MostRecentPage { get; set; }
+    public int Count { get; set; }
+    public DateTime Created { get; set; }
+    public DateTime Modified { get; set; }
+    public string Spotify { get; set; }
+    public string DeleteUrl { get; set; }   // pre-built with all current filter params
+}
+
+public class SearchesPageModel
+{
+    public List<SearchSummary> Searches { get; set; }
+    public int Page { get; set; }
+    public int TotalPages { get; set; }
+    public string Sort { get; set; }          // "recent" or null
+    public bool ShowDetails { get; set; }     // admin detail view
+    public bool SpotifyOnly { get; set; }
+    public string User { get; set; }          // "all" or a username
+    public bool IsAdmin { get; set; }         // show Toggle Details link
+    public bool CanDeleteAll { get; set; }    // false when User == "all"
+    public string BasicSearchUrl { get; set; }
+    public string AdvancedSearchUrl { get; set; }
+    public string DeleteAllUrl { get; set; }
+}
+```
+
+Search URLs and delete URLs are pre-built server-side because they require `SongFilter`
+serialization. Pagination/sort/toggle URLs are built client-side by the Vue component from the
+known parameters (user, sort, showDetails, spotifyOnly).
+
+#### Modified `Index()` action
+
+Builds `SearchesPageModel`, projects each `Search` to `SearchSummary` using `Url.Action()` for
+per-row URLs, then returns `Vue3("My Searches", "Search history", "searches", viewModel)`.
+
+### Vue page: `src/pages/searches/`
+
+```
+src/pages/searches/
+  App.vue               -- renders controls + table + pagination nav
+  SearchesPageModel.ts  -- TypedJSON-decorated model classes
+  __tests__/
+    searches.test.ts    -- snapshot + behavior tests
+    model.ts            -- test fixture data
+```
+
+**Vue design decisions:**
+
+- Server handles paging — each page click navigates to `/Searches/Index?...&page=N`
+- Sort toggle (Most Popular / Most Recent) navigates via computed URL, resets to page 1
+- Spotify Only switch navigates via computed URL (same parameters + toggled `spotifyOnly`)
+- Toggle Details navigates via computed URL (admin only)
+- Windowed pagination nav: ±2 window around current page, first/last always shown, ellipsis in gaps
+- `BTable` fields are computed based on `showDetails` — detail view adds Query, User, Count,
+  Created, Modified columns
+- Per-row delete URL and search URLs are pre-built in the model (not computed in Vue)
 
 ---
 
-## Part 4 — Server-Side Paging: ActivityLog/Index _(Priority 4)_
+## Part 4 — Vue Conversion + Server-Side Paging: ActivityLog/Index _(Priority 4)_
 
 ### Current behavior
 
@@ -350,45 +415,60 @@ filter parameters through `asp-route-*` attributes to preserve state across page
 
 ### Target behavior
 
-Same treatment as Searches/Index: add `page` parameter, paginate at the DB level, add Bootstrap
-pagination to the existing Razor partial.
+Same paging treatment as Searches/Index. Render via Vue — server supplies `ActivityLogPageModel`
+JSON; Vue renders the table and windowed server-side pagination nav.
 
 ### C# changes
 
+#### New DTOs — `m4d/ViewModels/ActivityLogPageModel.cs`
+
 ```csharp
-private const int ActivityLogPageSize = 100;
-
-public IActionResult Index(int page = 1)
+public class ActivityLogEntry
 {
-    var query = Database.Context.ActivityLog
-        .OrderByDescending(l => l.Date)
-        .Include(a => a.User);
+    public int Id { get; set; }
+    public DateTimeOffset Date { get; set; }
+    public string UserName { get; set; }
+    public string Action { get; set; }
+    public string Details { get; set; }
+}
 
-    var totalCount = query.Count();
-    var list = query
-        .Skip((page - 1) * ActivityLogPageSize)
-        .Take(ActivityLogPageSize)
-        .AsEnumerable();
-
-    ViewBag.Page = page;
-    ViewBag.TotalPages = (int)Math.Ceiling((double)totalCount / ActivityLogPageSize);
-    return View(list);
+public class ActivityLogPageModel
+{
+    public List<ActivityLogEntry> Entries { get; set; }
+    public int Page { get; set; }
+    public int TotalPages { get; set; }
 }
 ```
 
-### Razor view changes
+#### Modified `Index()` action
 
-Same as Searches — add pagination controls at the bottom of `Views/ActivityLog/Index.cshtml`.
+Builds `ActivityLogPageModel`, then returns
+`Vue3("Activity Log", "Admin: Activity log", "activity-log", viewModel)`.
+
+### Vue page: `src/pages/activity-log/`
+
+```
+src/pages/activity-log/
+  App.vue                  -- renders table + pagination nav
+  ActivityLogPageModel.ts  -- TypedJSON-decorated model classes
+  __tests__/
+    activity-log.test.ts   -- snapshot + behavior tests
+    model.ts               -- test fixture data
+```
+
+Pagination nav follows same windowed pattern as Searches.
 
 ---
 
 ## Development Phases
 
-| Phase | PR scope                                              | Status                | Outcome                                                 |
-| ----- | ----------------------------------------------------- | --------------------- | ------------------------------------------------------- |
-| **1** | ApplicationUsers/Index → Vue (DTO + Vue page + tests) | ✅ Complete (PR #174) | Users page is responsive; all auxiliary pages unchanged |
-| **2** | PlayList/Index → Vue                                  | ✅ Complete           | Playlists page is responsive                            |
-| **3** | Searches/Index + ActivityLog/Index server paging      | Not started           | Remaining tables paginated without Vue conversion       |
+| Phase | PR scope                                              | Status                | Outcome                                                             |
+| ----- | ----------------------------------------------------- | --------------------- | ------------------------------------------------------------------- |
+| **1** | ApplicationUsers/Index → Vue (DTO + Vue page + tests) | ✅ Complete (PR #174) | Users page is responsive; all auxiliary pages unchanged             |
+| **2** | PlayList/Index → Vue                                  | ✅ Complete           | Playlists page is responsive                                        |
+| **3** | Searches/Index server paging (DB-level Skip/Take)     | ✅ Complete           | Searches paginated server-side                                      |
+| **4** | ActivityLog/Index server paging                       | ✅ Complete           | Activity log paginated server-side                                  |
+| **5** | Searches/Index + ActivityLog/Index → Vue conversion   | ✅ Complete           | Both pages rendered by Vue with windowed server-side pagination nav |
 
 Each phase is independently deployable. Later phases can be re-prioritised without affecting
 earlier ones.
@@ -409,10 +489,19 @@ earlier ones.
   (auxiliary actions are unchanged; `Index()` now returns a `VueModel` but the existing tests
   only verify auxiliary actions like `Edit`, `Delete`, `ChangeRoles`).
 
-### Phase 3 & 4 (Paging)
+### Phase 3 & 4 (Server-Side Paging)
 
-- Add integration test for the `Index(page)` action verifying correct `Skip`/`Take` behaviour.
+- Integration test for `Index(page)` action verifying correct `Skip`/`Take` behaviour
+  (`Index_PaginatesResults_WhenMoreThanPageSizeExists`).
 - Manual verification that page 1 loads the first N records and page 2 loads the next N.
+
+### Phase 5 (Vue Conversion of Searches + ActivityLog)
+
+- **Snapshot tests** for both pages: `searches.test.ts`, `activity-log.test.ts`
+- **Behavior tests**: sort active state, pagination visibility, delete-all visibility,
+  admin Toggle Details visibility, table columns in detail mode, Spotify icon, no-user placeholder
+- **Manual smoke test**: navigate to each page, verify pagination nav, sort toggles, delete buttons,
+  Spotify links, and (for Searches) the admin Toggle Details link.
 
 ---
 

--- a/m4d.Tests/Controllers/SearchesControllerTests.cs
+++ b/m4d.Tests/Controllers/SearchesControllerTests.cs
@@ -2,11 +2,13 @@ using AutoMapper;
 
 using m4d.Controllers;
 using m4d.Tests.TestHelpers;
+using m4d.ViewModels;
 
 using m4dModels;
 using m4dModels.Tests;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
@@ -85,6 +87,11 @@ public class SearchesControllerTests
         {
             HttpContext = new DefaultHttpContext { User = principal }
         };
+
+        // Set up a no-op IUrlHelper so Url.Action() calls in Index() don't throw
+        var mockUrl = new Mock<IUrlHelper>();
+        mockUrl.Setup(m => m.Action(It.IsAny<UrlActionContext>())).Returns("#");
+        controller.Url = mockUrl.Object;
 
         return controller;
     }
@@ -391,5 +398,65 @@ public class SearchesControllerTests
         // Assert — error view returned, nothing in DB
         Assert.IsInstanceOfType<ViewResult>(result);
         Assert.AreEqual(0, await dms.Context.Searches.CountAsync());
+    }
+
+    // -------------------------------------------------------------------------
+    // Index pagination
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task Index_PaginatesResults_WhenMoreThanPageSizeExists()
+    {
+        // Arrange — add 150 anonymous searches
+        // Use "Index" as a safe query string (parses as empty filter with no dance IDs)
+        var dms = await DanceMusicTester.CreateServiceWithUsers("SearchesPaging");
+
+        for (int i = 0; i < 150; i++)
+        {
+            await AddSearch(dms.Context, userId: null, "Index", count: i,
+                created: new DateTime(2024, 1, 1),
+                modified: new DateTime(2025, 1, 1));
+        }
+
+        // Use separate controller instances per call: ViewBag/ViewData is shared instance-level
+        // state on the controller, so calling the same action twice on one instance causes the
+        // second call's values to overwrite the first result's ViewData and Model.
+        ClaimsIdentity MakeAdminIdentity() => new(
+        [
+            new Claim(ClaimTypes.Name, "dwgray"),
+            new Claim(ClaimTypes.Role, "dbAdmin"),
+        ], "TestAuthentication");
+
+        var controller1 = CreateController(dms, "dwgray");
+        controller1.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(MakeAdminIdentity()) }
+        };
+
+        var controller2 = CreateController(dms, "dwgray");
+        controller2.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(MakeAdminIdentity()) }
+        };
+
+        // Act
+        var result1 = await controller1.Index(user: "all", page: 1) as ViewResult;
+        var result2 = await controller2.Index(user: "all", page: 2) as ViewResult;
+
+        // Assert — model is now SearchesPageModel wrapped in VueModel
+        var pageModel1 = ((result1!.Model as VueModel)!.Model as SearchesPageModel)!;
+        var pageModel2 = ((result2!.Model as VueModel)!.Model as SearchesPageModel)!;
+
+        Assert.AreEqual(100, pageModel1.Searches.Count, "Page 1 should return a full page");
+        Assert.AreEqual(50, pageModel2.Searches.Count, "Page 2 should return the remaining rows");
+        Assert.AreEqual(1, pageModel1.Page);
+        Assert.AreEqual(2, pageModel1.TotalPages);
+        Assert.AreEqual(2, pageModel2.Page);
+        Assert.AreEqual(2, pageModel2.TotalPages);
+
+        // Assert — no overlap between pages
+        var ids1 = pageModel1.Searches.Select(s => s.Id).ToHashSet();
+        var ids2 = pageModel2.Searches.Select(s => s.Id).ToHashSet();
+        Assert.AreEqual(0, ids1.Intersect(ids2).Count(), "Pages should not contain duplicate rows");
     }
 }

--- a/m4d/ClientApp/src/pages/activity-log/ActivityLogPageModel.ts
+++ b/m4d/ClientApp/src/pages/activity-log/ActivityLogPageModel.ts
@@ -1,0 +1,17 @@
+import { jsonArrayMember, jsonMember, jsonObject } from "typedjson";
+
+@jsonObject
+export class ActivityLogEntry {
+  @jsonMember(Number) public id!: number;
+  @jsonMember(String) public date!: string;
+  @jsonMember(String) public userName?: string;
+  @jsonMember(String) public action!: string;
+  @jsonMember(String) public details?: string;
+}
+
+@jsonObject
+export class ActivityLogPageModel {
+  @jsonArrayMember(ActivityLogEntry) public entries!: ActivityLogEntry[];
+  @jsonMember(Number) public page!: number;
+  @jsonMember(Number) public totalPages!: number;
+}

--- a/m4d/ClientApp/src/pages/activity-log/App.vue
+++ b/m4d/ClientApp/src/pages/activity-log/App.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { TypedJSON } from "typedjson";
+import type { BvEvent, TableFieldRaw } from "bootstrap-vue-next";
+import { ActivityLogPageModel, ActivityLogEntry } from "./ActivityLogPageModel";
+
+declare const model_: string;
+
+const model: ActivityLogPageModel = TypedJSON.parse(model_, ActivityLogPageModel)!;
+
+// --- URL builders ---
+function pageUrl(p: number): string {
+  return "/ActivityLog/Index?page=" + p;
+}
+
+// --- Table fields ---
+const fields: Exclude<TableFieldRaw<ActivityLogEntry>, string>[] = [
+  { key: "id" as keyof ActivityLogEntry, label: "Id", sortable: false },
+  { key: "date" as keyof ActivityLogEntry, label: "Date", sortable: false },
+  { key: "userName" as keyof ActivityLogEntry, label: "User Name", sortable: false },
+  { key: "action" as keyof ActivityLogEntry, label: "Action", sortable: false },
+  { key: "details" as keyof ActivityLogEntry, label: "Details", sortable: false },
+];
+
+const editPageNumber = ref(model.page);
+
+function onPageClick(event: BvEvent, pageNum: number): void {
+  event.preventDefault();
+  window.location.href = pageUrl(pageNum);
+}
+
+function goToPage(): void {
+  let page = editPageNumber.value;
+  if (typeof page !== "number" || isNaN(page)) {
+    editPageNumber.value = model.page;
+    return;
+  }
+  page = Math.floor(page);
+  if (page < 1) page = 1;
+  if (page > model.totalPages) page = model.totalPages;
+  editPageNumber.value = page;
+  if (page !== model.page) {
+    window.location.href = pageUrl(page);
+  }
+}
+
+function formatDate(dateStr: string | undefined): string {
+  if (!dateStr) return "";
+  return new Date(dateStr).toLocaleString("en-US", {
+    month: "numeric",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+</script>
+
+<template>
+  <PageFrame id="app" title="Activity Log">
+    <!-- Activity log table -->
+    <BTable
+      id="activity-log-table"
+      :fields="fields"
+      :items="model.entries"
+      striped
+      class="table-songs col-sm"
+    >
+      <template #cell(date)="{ item }">{{ formatDate(item.date) }}</template>
+      <template #cell(userName)="{ item }">
+        <span v-if="item.userName">{{ item.userName }}</span>
+        <span v-else class="text-muted">no user</span>
+      </template>
+    </BTable>
+
+    <!-- Pagination -->
+    <BRow v-if="model.totalPages > 1" class="mt-3">
+      <BCol md="8">
+        <BPagination
+          v-model="editPageNumber"
+          :total-rows="model.totalPages"
+          :per-page="1"
+          limit="9"
+          first-number
+          last-number
+          aria-label="Activity log pages"
+          @page-click="onPageClick"
+        />
+      </BCol>
+      <BCol md="4">
+        Page
+        <input
+          v-model.number="editPageNumber"
+          type="number"
+          step="1"
+          :min="1"
+          :max="model.totalPages"
+          class="form-control form-control-sm d-inline-block"
+          style="width: 4em"
+          aria-label="Page number"
+          @keydown.enter="goToPage"
+          @blur="goToPage"
+        />
+        of {{ model.totalPages }}
+      </BCol>
+    </BRow>
+  </PageFrame>
+</template>

--- a/m4d/ClientApp/src/pages/activity-log/App.vue
+++ b/m4d/ClientApp/src/pages/activity-log/App.vue
@@ -52,6 +52,7 @@ function formatDate(dateStr: string | undefined): string {
     year: "numeric",
     hour: "numeric",
     minute: "2-digit",
+    timeZone: "UTC",
   });
 }
 </script>

--- a/m4d/ClientApp/src/pages/activity-log/__tests__/__snapshots__/activity-log.test.ts.snap
+++ b/m4d/ClientApp/src/pages/activity-log/__tests__/__snapshots__/activity-log.test.ts.snap
@@ -27,7 +27,7 @@ exports[`activity-log page > renders the activity log page snapshot 1`] = `
               <!---->5001
             </td>
             <td class="">
-              <!---->11/20/2024, 6:30 AM
+              <!---->11/20/2024, 2:30 PM
             </td>
             <td class="">
               <!----><span>alice</span>
@@ -45,7 +45,7 @@ exports[`activity-log page > renders the activity log page snapshot 1`] = `
               <!---->5002
             </td>
             <td class="">
-              <!---->11/19/2024, 1:15 AM
+              <!---->11/19/2024, 9:15 AM
             </td>
             <td class="">
               <!----><span>bob</span>
@@ -63,7 +63,7 @@ exports[`activity-log page > renders the activity log page snapshot 1`] = `
               <!---->5003
             </td>
             <td class="">
-              <!---->11/18/2024, 3:00 AM
+              <!---->11/18/2024, 11:00 AM
             </td>
             <td class="">
               <!----><span class="text-muted">no user</span>
@@ -133,7 +133,7 @@ exports[`activity-log page > renders the single-page view snapshot 1`] = `
               <!---->5001
             </td>
             <td class="">
-              <!---->11/20/2024, 6:30 AM
+              <!---->11/20/2024, 2:30 PM
             </td>
             <td class="">
               <!----><span>alice</span>

--- a/m4d/ClientApp/src/pages/activity-log/__tests__/__snapshots__/activity-log.test.ts.snap
+++ b/m4d/ClientApp/src/pages/activity-log/__tests__/__snapshots__/activity-log.test.ts.snap
@@ -1,0 +1,164 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`activity-log page > renders the activity log page snapshot 1`] = `
+"<div><span context="[object Object]">MainMenu</span>
+  <!--v-if-->
+  <!--v-if-->
+  <div id="body-content" class="container-fluid body-content">
+    <h1>Activity Log</h1>
+    <div>
+      <!-- Activity log table -->
+      <table id="activity-log-table" class="table b-table table-striped table-songs col-sm" aria-busy="false">
+        <!---->
+        <thead class="">
+          <tr class="">
+            <th scope="col" class="">Id</th>
+            <th scope="col" class="">Date</th>
+            <th scope="col" class="">User Name</th>
+            <th scope="col" class="">Action</th>
+            <th scope="col" class="">Details</th>
+          </tr>
+          <!---->
+        </thead>
+        <tbody class="">
+          <!---->
+          <tr class="">
+            <td class="">
+              <!---->5001
+            </td>
+            <td class="">
+              <!---->11/20/2024, 6:30 AM
+            </td>
+            <td class="">
+              <!----><span>alice</span>
+            </td>
+            <td class="">
+              <!---->Login
+            </td>
+            <td class="">
+              <!---->Logged in via Spotify
+            </td>
+          </tr>
+          <!---->
+          <tr class="">
+            <td class="">
+              <!---->5002
+            </td>
+            <td class="">
+              <!---->11/19/2024, 1:15 AM
+            </td>
+            <td class="">
+              <!----><span>bob</span>
+            </td>
+            <td class="">
+              <!---->EditSong
+            </td>
+            <td class="">
+              <!---->Updated tempo for song abc123
+            </td>
+          </tr>
+          <!---->
+          <tr class="">
+            <td class="">
+              <!---->5003
+            </td>
+            <td class="">
+              <!---->11/18/2024, 3:00 AM
+            </td>
+            <td class="">
+              <!----><span class="text-muted">no user</span>
+            </td>
+            <td class="">
+              <!---->AnonymousSearch
+            </td>
+            <td class="">
+              <!---->Searched for Waltz
+            </td>
+          </tr>
+          <!---->
+          <!---->
+        </tbody>
+        <!---->
+        <!---->
+      </table><!-- Pagination -->
+      <div class="row mt-3">
+        <div class="col-md-8">
+          <ul class="pagination justify-content-start" role="menubar" aria-disabled="false" aria-label="Activity log pages">
+            <li class="page-item disabled" role="presentation" displayindex="0"><span is="span" class="page-link text-center" aria-label="Go to previous page" aria-disabled="true" role="menuitem">‹</span></li>
+            <li class="page-item active" role="presentation" displayindex="1"><button is="button" class="page-link text-center" aria-label="Go to page 1" aria-posinset="1" aria-setsize="5" role="menuitem" type="button" tabindex="0">1</button></li>
+            <li class="page-item" role="presentation" displayindex="2"><button is="button" class="page-link text-center" aria-label="Go to page 2" aria-posinset="2" aria-setsize="5" role="menuitem" type="button" tabindex="-1">2</button></li>
+            <li class="page-item bv-d-sm-down-none" role="presentation" displayindex="3"><button is="button" class="page-link text-center" aria-label="Go to page 3" aria-posinset="3" aria-setsize="5" role="menuitem" type="button" tabindex="-1">3</button></li>
+            <li class="page-item" role="presentation" displayindex="4"><button is="button" class="page-link text-center" aria-label="Go to page 4" aria-posinset="4" aria-setsize="5" role="menuitem" type="button" tabindex="-1">4</button></li>
+            <li class="page-item" role="presentation" displayindex="5"><button is="button" class="page-link text-center" aria-label="Go to page 5" aria-posinset="5" aria-setsize="5" role="menuitem" type="button" tabindex="-1">5</button></li>
+            <li class="page-item" role="presentation" displayindex="6"><button is="button" class="page-link text-center" aria-label="Go to next page" role="menuitem" type="button" tabindex="-1">›</button></li>
+          </ul>
+        </div>
+        <div class="col-md-4"> Page <input type="number" step="1" min="1" max="5" class="form-control form-control-sm d-inline-block" style="width: 4em;" aria-label="Page number"> of 5</div>
+      </div>
+    </div>
+  </div>
+  <div id="footer-content">
+    <hr>
+    <footer>
+      <p> © 2026 - <a href="https://www.music4dance.net">Music4Dance.net</a> - <a href="https://www.music4dance.net/home/sitemap">Site Map</a> - <a href="https://www.music4dance.net/home/termsofservice">Terms of Service</a> - <a href="https://www.music4dance.net/home/privacypolicy">Privacy Policy</a> - <a href="https://www.music4dance.net/home/credits">Credits</a> - <a href="https://github.com/music4dance/music4dance" target="_blank">Code</a> - <a>Help</a></p>
+    </footer>
+  </div>
+</div>"
+`;
+
+exports[`activity-log page > renders the single-page view snapshot 1`] = `
+"<div><span context="[object Object]">MainMenu</span>
+  <!--v-if-->
+  <!--v-if-->
+  <div id="body-content" class="container-fluid body-content">
+    <h1>Activity Log</h1>
+    <div>
+      <!-- Activity log table -->
+      <table id="activity-log-table" class="table b-table table-striped table-songs col-sm" aria-busy="false">
+        <!---->
+        <thead class="">
+          <tr class="">
+            <th scope="col" class="">Id</th>
+            <th scope="col" class="">Date</th>
+            <th scope="col" class="">User Name</th>
+            <th scope="col" class="">Action</th>
+            <th scope="col" class="">Details</th>
+          </tr>
+          <!---->
+        </thead>
+        <tbody class="">
+          <!---->
+          <tr class="">
+            <td class="">
+              <!---->5001
+            </td>
+            <td class="">
+              <!---->11/20/2024, 6:30 AM
+            </td>
+            <td class="">
+              <!----><span>alice</span>
+            </td>
+            <td class="">
+              <!---->Login
+            </td>
+            <td class="">
+              <!---->Logged in via Spotify
+            </td>
+          </tr>
+          <!---->
+          <!---->
+        </tbody>
+        <!---->
+        <!---->
+      </table><!-- Pagination -->
+      <!--v-if-->
+    </div>
+  </div>
+  <div id="footer-content">
+    <hr>
+    <footer>
+      <p> © 2026 - <a href="https://www.music4dance.net">Music4Dance.net</a> - <a href="https://www.music4dance.net/home/sitemap">Site Map</a> - <a href="https://www.music4dance.net/home/termsofservice">Terms of Service</a> - <a href="https://www.music4dance.net/home/privacypolicy">Privacy Policy</a> - <a href="https://www.music4dance.net/home/credits">Credits</a> - <a href="https://github.com/music4dance/music4dance" target="_blank">Code</a> - <a>Help</a></p>
+    </footer>
+  </div>
+</div>"
+`;

--- a/m4d/ClientApp/src/pages/activity-log/__tests__/activity-log.test.ts
+++ b/m4d/ClientApp/src/pages/activity-log/__tests__/activity-log.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import { loadTestPage, testPageSnapshot } from "@/helpers/TestPageSnapshot";
+import App from "../App.vue";
+import { model, singlePageModel } from "./model";
+
+describe("activity-log page", () => {
+  test("renders the activity log page snapshot", () => {
+    testPageSnapshot(App, model);
+  });
+
+  test("renders the single-page view snapshot", () => {
+    testPageSnapshot(App, singlePageModel);
+  });
+
+  describe("table content", () => {
+    let wrapper: ReturnType<typeof loadTestPage>;
+
+    beforeEach(() => {
+      wrapper = loadTestPage(App, model);
+    });
+
+    test("renders the activity log table", () => {
+      const table = wrapper.find("#activity-log-table");
+      expect(table.exists()).toBe(true);
+    });
+
+    test("shows all entries", () => {
+      const rows = wrapper.findAll("tbody tr");
+      expect(rows.length).toBe(model.entries.length);
+    });
+
+    test("shows entry data", () => {
+      expect(wrapper.text()).toContain("alice");
+      expect(wrapper.text()).toContain("Login");
+      expect(wrapper.text()).toContain("bob");
+      expect(wrapper.text()).toContain("EditSong");
+    });
+
+    test("shows no user placeholder for null userName", () => {
+      expect(wrapper.text()).toContain("no user");
+    });
+  });
+
+  describe("pagination", () => {
+    test("shows pagination when totalPages > 1", () => {
+      const wrapper = loadTestPage(App, model);
+      expect(wrapper.find("ul.pagination").exists()).toBe(true);
+    });
+
+    test("shows correct page numbers in nav", () => {
+      const wrapper = loadTestPage(App, model);
+      const pagination = wrapper.find("ul.pagination");
+      expect(pagination.text()).toContain("1");
+      expect(pagination.text()).toContain("5");
+    });
+
+    test("no pagination shown when totalPages is 1", () => {
+      const wrapper = loadTestPage(App, singlePageModel);
+      expect(wrapper.find("ul.pagination").exists()).toBe(false);
+    });
+  });
+});

--- a/m4d/ClientApp/src/pages/activity-log/__tests__/model.ts
+++ b/m4d/ClientApp/src/pages/activity-log/__tests__/model.ts
@@ -1,0 +1,45 @@
+/**
+ * Test fixture for activity-log page.
+ * Represents a realistic but minimal ActivityLogPageModel payload.
+ */
+export const model = {
+  entries: [
+    {
+      id: 5001,
+      date: "2024-11-20T14:30:00+00:00",
+      userName: "alice",
+      action: "Login",
+      details: "Logged in via Spotify",
+    },
+    {
+      id: 5002,
+      date: "2024-11-19T09:15:00+00:00",
+      userName: "bob",
+      action: "EditSong",
+      details: "Updated tempo for song abc123",
+    },
+    {
+      id: 5003,
+      date: "2024-11-18T11:00:00+00:00",
+      userName: null,
+      action: "AnonymousSearch",
+      details: "Searched for Waltz",
+    },
+  ],
+  page: 1,
+  totalPages: 5,
+};
+
+export const singlePageModel = {
+  entries: [
+    {
+      id: 5001,
+      date: "2024-11-20T14:30:00+00:00",
+      userName: "alice",
+      action: "Login",
+      details: "Logged in via Spotify",
+    },
+  ],
+  page: 1,
+  totalPages: 1,
+};

--- a/m4d/ClientApp/src/pages/admin-users/App.vue
+++ b/m4d/ClientApp/src/pages/admin-users/App.vue
@@ -191,10 +191,7 @@ function playlistsUrl(userName: string): string {
 </script>
 
 <template>
-  <div class="container-fluid">
-    <h2>User Administrator</h2>
-    <hr />
-
+  <PageFrame id="app" title="User Administrator">
     <!-- Summary row -->
     <div class="row mb-3">
       <div class="col-md-3">
@@ -408,5 +405,5 @@ function playlistsUrl(userName: string): string {
       :per-page="perPage"
       size="sm"
     />
-  </div>
+  </PageFrame>
 </template>

--- a/m4d/ClientApp/src/pages/admin-users/__tests__/__snapshots__/admin-users.test.ts.snap
+++ b/m4d/ClientApp/src/pages/admin-users/__tests__/__snapshots__/admin-users.test.ts.snap
@@ -1,204 +1,216 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`admin-users page > renders the admin users page 1`] = `
-"<div class="container-fluid">
-  <h2>User Administrator</h2>
-  <hr><!-- Summary row -->
-  <div class="row mb-3">
-    <div class="col-md-3">
-      <p><strong>Total Users:</strong> 4</p>
-      <p><strong>Registered Users:</strong> 3</p>
-      <p><strong>Confirmed Users:</strong> 2</p>
-      <p><strong>Deleted Users:</strong> 1</p>
-    </div>
-    <div class="col-md-3">
-      <p><b>dbAdmin</b>: 0</p>
-      <p><b>premium</b>: 1</p>
-      <p><b>trial</b>: 0</p>
-    </div>
-    <div class="col-md-3">
-      <p><b>Microsoft</b>: 1</p>
-      <p><b>Spotify</b>: 2</p>
-      <p><b>Facebook</b>: 0</p>
-      <p><b>Google</b>: 1</p>
-    </div>
-    <div class="col-md-3">
-      <p><a href="/ApplicationUsers/Create" class="btn btn-primary" role="button">New Pseudo User</a></p>
-      <p><button class="btn btn-md btn-primary" type="button">Show Unconfirmed</button></p>
-      <p><button class="btn btn-md btn-primary" type="button">Show Pseudo</button></p>
-      <p><button class="btn btn-md btn-primary" type="button">Hide Private</button></p>
-      <p><a href="/ApplicationUsers/ClearCache" class="btn btn-secondary" role="button">Clear Cache</a></p>
-      <p><a href="/ApplicationUsers/VotingResults" class="btn btn-primary" role="button">Voting Results</a></p>
-      <p><a href="/ApplicationUsers/PremiumUsers" class="btn btn-primary" role="button">Premium</a></p>
-    </div>
-  </div><!-- Service preference table -->
-  <table class="table table-striped mb-3">
-    <thead>
-      <tr>
-        <th>Service</th>
-        <th>Users</th>
-        <th>%u</th>
-        <th>%p</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Spotify</td>
-        <td>2</td>
-        <td>67%</td>
-        <td>200%</td>
-      </tr>
-      <tr>
-        <td>Google</td>
-        <td>1</td>
-        <td>33%</td>
-        <td>100%</td>
-      </tr>
-      <tr>
-        <td>none</td>
-        <td>2</td>
-        <td>67%</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <hr>
-  <h3>Users (2)</h3><!-- Text search -->
-  <div class="mb-2" style="max-width: 24rem;"><input id="BootstrapVueNext__ID__v-0__input___" class="form-control form-control-sm" type="text" placeholder="Filter by name or email…" clearable="" value=""></div><!-- Pagination controls (top) -->
-  <div class="d-flex align-items-center gap-3 mb-2">
-    <ul class="pagination justify-content-start pagination-sm mb-0" role="menubar" aria-disabled="false" aria-label="Pagination">
-      <li class="page-item disabled" role="presentation" displayindex="0"><span is="span" class="page-link text-center" aria-label="Go to first page" aria-disabled="true" role="menuitem">«</span></li>
-      <li class="page-item disabled" role="presentation" displayindex="1"><span is="span" class="page-link text-center" aria-label="Go to previous page" aria-disabled="true" role="menuitem">‹</span></li>
-      <li class="page-item active" role="presentation" displayindex="2"><button is="button" class="page-link text-center" aria-label="Go to page 1" aria-posinset="1" aria-setsize="1" role="menuitem" type="button" tabindex="0">1</button></li>
-      <li class="page-item disabled" role="presentation" displayindex="3"><span is="span" class="page-link text-center" aria-label="Go to next page" aria-disabled="true" role="menuitem">›</span></li>
-      <li class="page-item disabled" role="presentation" displayindex="4"><span is="span" class="page-link text-center" aria-label="Go to last page" aria-disabled="true" role="menuitem">»</span></li>
-    </ul>
-    <div class="d-flex align-items-center gap-2"><label class="mb-0 small">Per page:</label><select id="BootstrapVueNext__ID__v-1__input___" class="form-select form-select-sm" style="width: auto;">
-        <option value="25">25</option>
-        <option selected="" value="50">50</option>
-        <option value="100">100</option>
-        <option value="250">250</option>
-      </select></div>
-  </div><!-- User table -->
-  <div class="table-responsive">
-    <table id="users-table" class="table b-table table-hover table-striped table-sm" aria-busy="false">
-      <!---->
-      <thead class="">
-        <tr class="">
-          <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">EC</th>
-          <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">UserName / Email</th>
-          <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">Signed Up</th>
-          <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="descending">Signed In</th>
-          <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">PRV</th>
-          <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">CNT</th>
-          <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">SVC</th>
-          <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">CCF</th>
-          <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">$</th>
-          <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">HC</th>
-          <th scope="col" class="">Roles</th>
-          <th scope="col" class="">Logins</th>
-          <th scope="col" class=""></th>
-        </tr>
-        <!---->
-      </thead>
-      <tbody class="">
-        <!---->
-        <tr class="" id="users-table__row_user-1">
-          <td class="">
-            <!----><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" class="text-success">
-              <path fill="currentColor" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417L5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"></path>
-            </svg>
-          </td>
-          <td class="">
-            <!----><a href="/ApplicationUsers/Details/user-1" style="">alice</a><br><small class="text-muted">alice@example.com</small>
-          </td>
-          <td class="">
-            <!---->3/15/2022
-          </td>
-          <td class="">
-            <!---->11/20/2024
-          </td>
-          <td class="">
-            <!---->255
-          </td>
-          <td class="">
-            <!---->5
-          </td>
-          <td class="">
-            <!---->S
-          </td>
-          <td class="">
-            <!---->0
-          </td>
-          <td class="">
-            <!---->19.99
-          </td>
-          <td class="">
-            <!---->42
-          </td>
-          <td class="">
-            <!----><span><!--v-if-->premium</span>
-          </td>
-          <td class="">
-            <!----><span><!--v-if-->Spotify</span>
-          </td>
-          <td class="">
-            <!----><a href="/Song/FilterUser?user=alice">List Songs</a>, <a href="/Searches/Index?user=alice&amp;showDetails=true&amp;sort=recent">List Searches</a><br><a href="/ApplicationUsers/ChangeRoles/user-1">Change Roles</a><br><a href="/ApplicationUsers/Delete/user-1">Delete</a>, <a href="/ApplicationUsers/Edit/user-1">Edit</a>, <a href="/UsageLog/UserLog?user=alice">Usage</a>, <a href="/PlayList/Index?user=alice">Playlists</a>, <a href="/ApplicationUsers/ClearPremium/user-1">ClearPremium</a>
-          </td>
-        </tr>
-        <!---->
-        <tr class="" id="users-table__row_user-4">
-          <td class="">
-            <!----><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" class="text-success">
-              <path fill="currentColor" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417L5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"></path>
-            </svg>
-          </td>
-          <td class="">
-            <!----><a href="/ApplicationUsers/Details/user-4" style="">DEL:dave</a><br><small class="text-muted">dave@example.com</small>
-          </td>
-          <td class="">
-            <!---->6/1/2020
-          </td>
-          <td class="">
-            <!---->1/15/2021
-          </td>
-          <td class="">
-            <!---->255
-          </td>
-          <td class="">
-            <!---->0
-          </td>
-          <td class="">
+"<div><span context="[object Object]">MainMenu</span>
+  <!--v-if-->
+  <!--v-if-->
+  <div id="body-content" class="container-fluid body-content">
+    <h1>User Administrator</h1>
+    <div>
+      <!-- Summary row -->
+      <div class="row mb-3">
+        <div class="col-md-3">
+          <p><strong>Total Users:</strong> 4</p>
+          <p><strong>Registered Users:</strong> 3</p>
+          <p><strong>Confirmed Users:</strong> 2</p>
+          <p><strong>Deleted Users:</strong> 1</p>
+        </div>
+        <div class="col-md-3">
+          <p><b>dbAdmin</b>: 0</p>
+          <p><b>premium</b>: 1</p>
+          <p><b>trial</b>: 0</p>
+        </div>
+        <div class="col-md-3">
+          <p><b>Microsoft</b>: 1</p>
+          <p><b>Spotify</b>: 2</p>
+          <p><b>Facebook</b>: 0</p>
+          <p><b>Google</b>: 1</p>
+        </div>
+        <div class="col-md-3">
+          <p><a href="/ApplicationUsers/Create" class="btn btn-primary" role="button">New Pseudo User</a></p>
+          <p><button class="btn btn-md btn-primary" type="button">Show Unconfirmed</button></p>
+          <p><button class="btn btn-md btn-primary" type="button">Show Pseudo</button></p>
+          <p><button class="btn btn-md btn-primary" type="button">Hide Private</button></p>
+          <p><a href="/ApplicationUsers/ClearCache" class="btn btn-secondary" role="button">Clear Cache</a></p>
+          <p><a href="/ApplicationUsers/VotingResults" class="btn btn-primary" role="button">Voting Results</a></p>
+          <p><a href="/ApplicationUsers/PremiumUsers" class="btn btn-primary" role="button">Premium</a></p>
+        </div>
+      </div><!-- Service preference table -->
+      <table class="table table-striped mb-3">
+        <thead>
+          <tr>
+            <th>Service</th>
+            <th>Users</th>
+            <th>%u</th>
+            <th>%p</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Spotify</td>
+            <td>2</td>
+            <td>67%</td>
+            <td>200%</td>
+          </tr>
+          <tr>
+            <td>Google</td>
+            <td>1</td>
+            <td>33%</td>
+            <td>100%</td>
+          </tr>
+          <tr>
+            <td>none</td>
+            <td>2</td>
+            <td>67%</td>
+            <td></td>
+          </tr>
+        </tbody>
+      </table>
+      <hr>
+      <h3>Users (2)</h3><!-- Text search -->
+      <div class="mb-2" style="max-width: 24rem;"><input id="BootstrapVueNext__ID__v-0__input___" class="form-control form-control-sm" type="text" placeholder="Filter by name or email…" clearable="" value=""></div><!-- Pagination controls (top) -->
+      <div class="d-flex align-items-center gap-3 mb-2">
+        <ul class="pagination justify-content-start pagination-sm mb-0" role="menubar" aria-disabled="false" aria-label="Pagination">
+          <li class="page-item disabled" role="presentation" displayindex="0"><span is="span" class="page-link text-center" aria-label="Go to first page" aria-disabled="true" role="menuitem">«</span></li>
+          <li class="page-item disabled" role="presentation" displayindex="1"><span is="span" class="page-link text-center" aria-label="Go to previous page" aria-disabled="true" role="menuitem">‹</span></li>
+          <li class="page-item active" role="presentation" displayindex="2"><button is="button" class="page-link text-center" aria-label="Go to page 1" aria-posinset="1" aria-setsize="1" role="menuitem" type="button" tabindex="0">1</button></li>
+          <li class="page-item disabled" role="presentation" displayindex="3"><span is="span" class="page-link text-center" aria-label="Go to next page" aria-disabled="true" role="menuitem">›</span></li>
+          <li class="page-item disabled" role="presentation" displayindex="4"><span is="span" class="page-link text-center" aria-label="Go to last page" aria-disabled="true" role="menuitem">»</span></li>
+        </ul>
+        <div class="d-flex align-items-center gap-2"><label class="mb-0 small">Per page:</label><select id="BootstrapVueNext__ID__v-1__input___" class="form-select form-select-sm" style="width: auto;">
+            <option value="25">25</option>
+            <option selected="" value="50">50</option>
+            <option value="100">100</option>
+            <option value="250">250</option>
+          </select></div>
+      </div><!-- User table -->
+      <div class="table-responsive">
+        <table id="users-table" class="table b-table table-hover table-striped table-sm" aria-busy="false">
+          <!---->
+          <thead class="">
+            <tr class="">
+              <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">EC</th>
+              <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">UserName / Email</th>
+              <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">Signed Up</th>
+              <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="descending">Signed In</th>
+              <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">PRV</th>
+              <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">CNT</th>
+              <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">SVC</th>
+              <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">CCF</th>
+              <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">$</th>
+              <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">HC</th>
+              <th scope="col" class="">Roles</th>
+              <th scope="col" class="">Logins</th>
+              <th scope="col" class=""></th>
+            </tr>
             <!---->
-          </td>
-          <td class="">
-            <!---->0
-          </td>
-          <td class="">
-            <!---->0
-          </td>
-          <td class="">
-            <!---->0
-          </td>
-          <td class=""></td>
-          <td class=""></td>
-          <td class="">
-            <!----><a href="/Song/FilterUser?user=DEL%3Adave">List Songs</a>, <a href="/Searches/Index?user=DEL%3Adave&amp;showDetails=true&amp;sort=recent">List Searches</a><br><a href="/ApplicationUsers/ChangeRoles/user-4">Change Roles</a><br><a href="/ApplicationUsers/Delete/user-4">Delete</a>, <a href="/ApplicationUsers/Edit/user-4">Edit</a>, <a href="/UsageLog/UserLog?user=DEL%3Adave">Usage</a>, <a href="/PlayList/Index?user=DEL%3Adave">Playlists</a>, <a href="/ApplicationUsers/ClearPremium/user-4">ClearPremium</a>
-          </td>
-        </tr>
-        <!---->
-        <!---->
-      </tbody>
-      <!---->
-      <!---->
-    </table>
-  </div><!-- Pagination controls (bottom) -->
-  <ul class="pagination justify-content-start pagination-sm" role="menubar" aria-disabled="false" aria-label="Pagination">
-    <li class="page-item disabled" role="presentation" displayindex="0"><span is="span" class="page-link text-center" aria-label="Go to first page" aria-disabled="true" role="menuitem">«</span></li>
-    <li class="page-item disabled" role="presentation" displayindex="1"><span is="span" class="page-link text-center" aria-label="Go to previous page" aria-disabled="true" role="menuitem">‹</span></li>
-    <li class="page-item active" role="presentation" displayindex="2"><button is="button" class="page-link text-center" aria-label="Go to page 1" aria-posinset="1" aria-setsize="1" role="menuitem" type="button" tabindex="0">1</button></li>
-    <li class="page-item disabled" role="presentation" displayindex="3"><span is="span" class="page-link text-center" aria-label="Go to next page" aria-disabled="true" role="menuitem">›</span></li>
-    <li class="page-item disabled" role="presentation" displayindex="4"><span is="span" class="page-link text-center" aria-label="Go to last page" aria-disabled="true" role="menuitem">»</span></li>
-  </ul>
+          </thead>
+          <tbody class="">
+            <!---->
+            <tr class="" id="users-table__row_user-1">
+              <td class="">
+                <!----><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" class="text-success">
+                  <path fill="currentColor" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417L5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"></path>
+                </svg>
+              </td>
+              <td class="">
+                <!----><a href="/ApplicationUsers/Details/user-1" style="">alice</a><br><small class="text-muted">alice@example.com</small>
+              </td>
+              <td class="">
+                <!---->3/15/2022
+              </td>
+              <td class="">
+                <!---->11/20/2024
+              </td>
+              <td class="">
+                <!---->255
+              </td>
+              <td class="">
+                <!---->5
+              </td>
+              <td class="">
+                <!---->S
+              </td>
+              <td class="">
+                <!---->0
+              </td>
+              <td class="">
+                <!---->19.99
+              </td>
+              <td class="">
+                <!---->42
+              </td>
+              <td class="">
+                <!----><span><!--v-if-->premium</span>
+              </td>
+              <td class="">
+                <!----><span><!--v-if-->Spotify</span>
+              </td>
+              <td class="">
+                <!----><a href="/Song/FilterUser?user=alice">List Songs</a>, <a href="/Searches/Index?user=alice&amp;showDetails=true&amp;sort=recent">List Searches</a><br><a href="/ApplicationUsers/ChangeRoles/user-1">Change Roles</a><br><a href="/ApplicationUsers/Delete/user-1">Delete</a>, <a href="/ApplicationUsers/Edit/user-1">Edit</a>, <a href="/UsageLog/UserLog?user=alice">Usage</a>, <a href="/PlayList/Index?user=alice">Playlists</a>, <a href="/ApplicationUsers/ClearPremium/user-1">ClearPremium</a>
+              </td>
+            </tr>
+            <!---->
+            <tr class="" id="users-table__row_user-4">
+              <td class="">
+                <!----><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" class="text-success">
+                  <path fill="currentColor" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417L5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"></path>
+                </svg>
+              </td>
+              <td class="">
+                <!----><a href="/ApplicationUsers/Details/user-4" style="">DEL:dave</a><br><small class="text-muted">dave@example.com</small>
+              </td>
+              <td class="">
+                <!---->6/1/2020
+              </td>
+              <td class="">
+                <!---->1/15/2021
+              </td>
+              <td class="">
+                <!---->255
+              </td>
+              <td class="">
+                <!---->0
+              </td>
+              <td class="">
+                <!---->
+              </td>
+              <td class="">
+                <!---->0
+              </td>
+              <td class="">
+                <!---->0
+              </td>
+              <td class="">
+                <!---->0
+              </td>
+              <td class=""></td>
+              <td class=""></td>
+              <td class="">
+                <!----><a href="/Song/FilterUser?user=DEL%3Adave">List Songs</a>, <a href="/Searches/Index?user=DEL%3Adave&amp;showDetails=true&amp;sort=recent">List Searches</a><br><a href="/ApplicationUsers/ChangeRoles/user-4">Change Roles</a><br><a href="/ApplicationUsers/Delete/user-4">Delete</a>, <a href="/ApplicationUsers/Edit/user-4">Edit</a>, <a href="/UsageLog/UserLog?user=DEL%3Adave">Usage</a>, <a href="/PlayList/Index?user=DEL%3Adave">Playlists</a>, <a href="/ApplicationUsers/ClearPremium/user-4">ClearPremium</a>
+              </td>
+            </tr>
+            <!---->
+            <!---->
+          </tbody>
+          <!---->
+          <!---->
+        </table>
+      </div><!-- Pagination controls (bottom) -->
+      <ul class="pagination justify-content-start pagination-sm" role="menubar" aria-disabled="false" aria-label="Pagination">
+        <li class="page-item disabled" role="presentation" displayindex="0"><span is="span" class="page-link text-center" aria-label="Go to first page" aria-disabled="true" role="menuitem">«</span></li>
+        <li class="page-item disabled" role="presentation" displayindex="1"><span is="span" class="page-link text-center" aria-label="Go to previous page" aria-disabled="true" role="menuitem">‹</span></li>
+        <li class="page-item active" role="presentation" displayindex="2"><button is="button" class="page-link text-center" aria-label="Go to page 1" aria-posinset="1" aria-setsize="1" role="menuitem" type="button" tabindex="0">1</button></li>
+        <li class="page-item disabled" role="presentation" displayindex="3"><span is="span" class="page-link text-center" aria-label="Go to next page" aria-disabled="true" role="menuitem">›</span></li>
+        <li class="page-item disabled" role="presentation" displayindex="4"><span is="span" class="page-link text-center" aria-label="Go to last page" aria-disabled="true" role="menuitem">»</span></li>
+      </ul>
+    </div>
+  </div>
+  <div id="footer-content">
+    <hr>
+    <footer>
+      <p> © 2026 - <a href="https://www.music4dance.net">Music4Dance.net</a> - <a href="https://www.music4dance.net/home/sitemap">Site Map</a> - <a href="https://www.music4dance.net/home/termsofservice">Terms of Service</a> - <a href="https://www.music4dance.net/home/privacypolicy">Privacy Policy</a> - <a href="https://www.music4dance.net/home/credits">Credits</a> - <a href="https://github.com/music4dance/music4dance" target="_blank">Code</a> - <a>Help</a></p>
+    </footer>
+  </div>
 </div>"
 `;

--- a/m4d/ClientApp/src/pages/playlist/App.vue
+++ b/m4d/ClientApp/src/pages/playlist/App.vue
@@ -41,6 +41,8 @@ function playListTypeName(type: number): string {
   return "Unknown";
 }
 
+const pageTitle = computed(() => `${playListTypeName(model.type)} Playlists`);
+
 // --- Computed ---
 const allPlaylists = computed(() => model.playLists ?? []);
 
@@ -128,9 +130,7 @@ function rowClass(item: PlayListSummary): string {
 </script>
 
 <template>
-  <div class="container-fluid">
-    <h2>{{ playListTypeName(model.type) }} Playlists</h2>
-
+  <PageFrame id="app" :title="pageTitle">
     <!-- User filter banner -->
     <div v-if="userFilter" class="alert alert-info d-flex align-items-center gap-2 py-2">
       <span
@@ -304,5 +304,5 @@ function rowClass(item: PlayListSummary): string {
         </template>
       </template>
     </BTable>
-  </div>
+  </PageFrame>
 </template>

--- a/m4d/ClientApp/src/pages/playlist/__tests__/__snapshots__/playlist.test.ts.snap
+++ b/m4d/ClientApp/src/pages/playlist/__tests__/__snapshots__/playlist.test.ts.snap
@@ -1,132 +1,145 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`playlist page > renders the playlist page 1`] = `
-"<div class="container-fluid">
-  <h2>SongsFromSpotify Playlists</h2><!-- User filter banner -->
+"<div><span context="[object Object]">MainMenu</span>
   <!--v-if-->
-  <div class="row mb-3">
-    <!-- Sidebar: actions -->
-    <div class="col-sm-3">
-      <p><a href="/PlayList/Create" class="btn btn-primary btn-sm">Create New</a></p>
-      <p><a href="/PlayList/RestoreAll" class="btn btn-outline-secondary btn-sm">Restore All</a></p>
-      <p><a href="/PlayList/UpdateAll?type=2" class="btn btn-outline-secondary btn-sm">Update All</a></p>
-      <p><button class="btn btn-sm btn-outline-secondary" type="button">Show Deleted</button></p>
+  <!--v-if-->
+  <div id="body-content" class="container-fluid body-content">
+    <h1>SongsFromSpotify Playlists</h1>
+    <div>
+      <!-- User filter banner -->
       <!--v-if-->
-    </div><!-- Type switcher -->
-    <div class="col-sm-3">
-      <p><strong>Type:</strong></p>
-      <p><a class="fw-bold" href="/PlayList/Index?type=2">SongsFromSpotify</a></p>
-      <p><a class="" href="/PlayList/Index?type=3">SpotifyFromSearch</a></p>
-    </div><!-- BulkCreate (SpotifyFromSearch only) + Statistics -->
-    <!--v-if-->
-    <!-- Stats -->
-    <div class="col-sm-3">
-      <p><strong>Active:</strong> 2</p>
-      <p><strong>Deleted:</strong> 1</p>
+      <div class="row mb-3">
+        <!-- Sidebar: actions -->
+        <div class="col-sm-3">
+          <p><a href="/PlayList/Create" class="btn btn-primary btn-sm">Create New</a></p>
+          <p><a href="/PlayList/RestoreAll" class="btn btn-outline-secondary btn-sm">Restore All</a></p>
+          <p><a href="/PlayList/UpdateAll?type=2" class="btn btn-outline-secondary btn-sm">Update All</a></p>
+          <p><button class="btn btn-sm btn-outline-secondary" type="button">Show Deleted</button></p>
+          <!--v-if-->
+        </div><!-- Type switcher -->
+        <div class="col-sm-3">
+          <p><strong>Type:</strong></p>
+          <p><a class="fw-bold" href="/PlayList/Index?type=2">SongsFromSpotify</a></p>
+          <p><a class="" href="/PlayList/Index?type=3">SpotifyFromSearch</a></p>
+        </div><!-- BulkCreate (SpotifyFromSearch only) + Statistics -->
+        <!--v-if-->
+        <!-- Stats -->
+        <div class="col-sm-3">
+          <p><strong>Active:</strong> 2</p>
+          <p><strong>Deleted:</strong> 1</p>
+        </div>
+      </div><!-- Filter + Pagination controls -->
+      <div class="d-flex align-items-center gap-3 mb-2 flex-wrap"><input id="BootstrapVueNext__ID__v-0__input___" class="form-control form-control-sm" type="text" placeholder="Filter by user, name, description, tags or id…" clearable="" style="max-width: 20rem;" value="">
+        <ul class="pagination justify-content-start pagination-sm mb-0" role="menubar" aria-disabled="false" aria-label="Pagination">
+          <li class="page-item disabled" role="presentation" displayindex="0"><span is="span" class="page-link text-center" aria-label="Go to first page" aria-disabled="true" role="menuitem">«</span></li>
+          <li class="page-item disabled" role="presentation" displayindex="1"><span is="span" class="page-link text-center" aria-label="Go to previous page" aria-disabled="true" role="menuitem">‹</span></li>
+          <li class="page-item active" role="presentation" displayindex="2"><button is="button" class="page-link text-center" aria-label="Go to page 1" aria-posinset="1" aria-setsize="1" role="menuitem" type="button" tabindex="0">1</button></li>
+          <li class="page-item disabled" role="presentation" displayindex="3"><span is="span" class="page-link text-center" aria-label="Go to next page" aria-disabled="true" role="menuitem">›</span></li>
+          <li class="page-item disabled" role="presentation" displayindex="4"><span is="span" class="page-link text-center" aria-label="Go to last page" aria-disabled="true" role="menuitem">»</span></li>
+        </ul>
+        <div class="d-flex align-items-center gap-2"><label class="mb-0 small">Per page:</label><select id="BootstrapVueNext__ID__v-1__input___" class="form-select form-select-sm" style="width: auto;">
+            <option value="25">25</option>
+            <option selected="" value="50">50</option>
+            <option value="100">100</option>
+            <option value="250">250</option>
+          </select></div>
+      </div>
+      <p class="text-muted small"> Showing 2 active playlists </p><!-- Playlist table -->
+      <div class="table-responsive">
+        <table id="playlist-table" class="table b-table table-hover table-striped table-sm" aria-busy="false">
+          <!---->
+          <thead class="">
+            <tr class="">
+              <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">Id</th>
+              <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">User</th>
+              <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">Name</th>
+              <th scope="col" class="">Description</th>
+              <th scope="col" class="">Tags</th>
+              <th scope="col" class="">SongIds</th>
+              <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">Created</th>
+              <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="descending">Updated</th>
+              <th scope="col" class=""></th>
+            </tr>
+            <!---->
+          </thead>
+          <tbody class="">
+            <!---->
+            <tr class="" id="playlist-table__row_spotify-abc123">
+              <td class="">
+                <!----><a href="/PlayList/Details/spotify-abc123">spotify-abc123</a>
+              </td>
+              <td class="">
+                <!----><a href="#">alice</a>
+              </td>
+              <td class="">
+                <!---->Waltz Songs
+              </td>
+              <td class="">
+                <!---->A waltz playlist
+              </td>
+              <td class="">
+                <!---->WAL:Dance
+              </td>
+              <td class="">
+                <!---->song1|song2
+              </td>
+              <td class="">
+                <!---->1/15/2024
+              </td>
+              <td class="">
+                <!---->6/1/2024
+              </td>
+              <td class="">
+                <!----><a href="/PlayList/Update/spotify-abc123">Update</a> | <a href="/PlayList/Edit/spotify-abc123">Edit</a> | <a href="/PlayList/Details/spotify-abc123">Details</a> | <a href="/PlayList/Delete/spotify-abc123">Delete</a>
+                <!--v-if-->
+              </td>
+            </tr>
+            <!---->
+            <tr class="" id="playlist-table__row_spotify-def456">
+              <td class="">
+                <!----><a href="/PlayList/Details/spotify-def456">spotify-def456</a>
+              </td>
+              <td class="">
+                <!----><a href="#">bob</a>
+              </td>
+              <td class="">
+                <!---->Tango Songs
+              </td>
+              <td class="">
+                <!---->A tango playlist
+              </td>
+              <td class="">
+                <!---->TAN:Dance
+              </td>
+              <td class="">
+                <!---->
+              </td>
+              <td class="">
+                <!---->2/20/2024
+              </td>
+              <td class="">
+                <!---->
+              </td>
+              <td class="">
+                <!----><a href="/PlayList/Update/spotify-def456">Update</a> | <a href="/PlayList/Edit/spotify-def456">Edit</a> | <a href="/PlayList/Details/spotify-def456">Details</a> | <a href="/PlayList/Delete/spotify-def456">Delete</a>
+                <!--v-if-->
+              </td>
+            </tr>
+            <!---->
+            <!---->
+          </tbody>
+          <!---->
+          <!---->
+        </table>
+      </div>
     </div>
-  </div><!-- Filter + Pagination controls -->
-  <div class="d-flex align-items-center gap-3 mb-2 flex-wrap"><input id="BootstrapVueNext__ID__v-0__input___" class="form-control form-control-sm" type="text" placeholder="Filter by user, name, description, tags or id…" clearable="" style="max-width: 20rem;" value="">
-    <ul class="pagination justify-content-start pagination-sm mb-0" role="menubar" aria-disabled="false" aria-label="Pagination">
-      <li class="page-item disabled" role="presentation" displayindex="0"><span is="span" class="page-link text-center" aria-label="Go to first page" aria-disabled="true" role="menuitem">«</span></li>
-      <li class="page-item disabled" role="presentation" displayindex="1"><span is="span" class="page-link text-center" aria-label="Go to previous page" aria-disabled="true" role="menuitem">‹</span></li>
-      <li class="page-item active" role="presentation" displayindex="2"><button is="button" class="page-link text-center" aria-label="Go to page 1" aria-posinset="1" aria-setsize="1" role="menuitem" type="button" tabindex="0">1</button></li>
-      <li class="page-item disabled" role="presentation" displayindex="3"><span is="span" class="page-link text-center" aria-label="Go to next page" aria-disabled="true" role="menuitem">›</span></li>
-      <li class="page-item disabled" role="presentation" displayindex="4"><span is="span" class="page-link text-center" aria-label="Go to last page" aria-disabled="true" role="menuitem">»</span></li>
-    </ul>
-    <div class="d-flex align-items-center gap-2"><label class="mb-0 small">Per page:</label><select id="BootstrapVueNext__ID__v-1__input___" class="form-select form-select-sm" style="width: auto;">
-        <option value="25">25</option>
-        <option selected="" value="50">50</option>
-        <option value="100">100</option>
-        <option value="250">250</option>
-      </select></div>
   </div>
-  <p class="text-muted small"> Showing 2 active playlists </p><!-- Playlist table -->
-  <div class="table-responsive">
-    <table id="playlist-table" class="table b-table table-hover table-striped table-sm" aria-busy="false">
-      <!---->
-      <thead class="">
-        <tr class="">
-          <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">Id</th>
-          <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">User</th>
-          <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">Name</th>
-          <th scope="col" class="">Description</th>
-          <th scope="col" class="">Tags</th>
-          <th scope="col" class="">SongIds</th>
-          <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="none">Created</th>
-          <th scope="col" class="b-table-sort-icon-left b-table-sortable-column" tabindex="0" aria-sort="descending">Updated</th>
-          <th scope="col" class=""></th>
-        </tr>
-        <!---->
-      </thead>
-      <tbody class="">
-        <!---->
-        <tr class="" id="playlist-table__row_spotify-abc123">
-          <td class="">
-            <!----><a href="/PlayList/Details/spotify-abc123">spotify-abc123</a>
-          </td>
-          <td class="">
-            <!----><a href="#">alice</a>
-          </td>
-          <td class="">
-            <!---->Waltz Songs
-          </td>
-          <td class="">
-            <!---->A waltz playlist
-          </td>
-          <td class="">
-            <!---->WAL:Dance
-          </td>
-          <td class="">
-            <!---->song1|song2
-          </td>
-          <td class="">
-            <!---->1/15/2024
-          </td>
-          <td class="">
-            <!---->6/1/2024
-          </td>
-          <td class="">
-            <!----><a href="/PlayList/Update/spotify-abc123">Update</a> | <a href="/PlayList/Edit/spotify-abc123">Edit</a> | <a href="/PlayList/Details/spotify-abc123">Details</a> | <a href="/PlayList/Delete/spotify-abc123">Delete</a>
-            <!--v-if-->
-          </td>
-        </tr>
-        <!---->
-        <tr class="" id="playlist-table__row_spotify-def456">
-          <td class="">
-            <!----><a href="/PlayList/Details/spotify-def456">spotify-def456</a>
-          </td>
-          <td class="">
-            <!----><a href="#">bob</a>
-          </td>
-          <td class="">
-            <!---->Tango Songs
-          </td>
-          <td class="">
-            <!---->A tango playlist
-          </td>
-          <td class="">
-            <!---->TAN:Dance
-          </td>
-          <td class="">
-            <!---->
-          </td>
-          <td class="">
-            <!---->2/20/2024
-          </td>
-          <td class="">
-            <!---->
-          </td>
-          <td class="">
-            <!----><a href="/PlayList/Update/spotify-def456">Update</a> | <a href="/PlayList/Edit/spotify-def456">Edit</a> | <a href="/PlayList/Details/spotify-def456">Details</a> | <a href="/PlayList/Delete/spotify-def456">Delete</a>
-            <!--v-if-->
-          </td>
-        </tr>
-        <!---->
-        <!---->
-      </tbody>
-      <!---->
-      <!---->
-    </table>
+  <div id="footer-content">
+    <hr>
+    <footer>
+      <p> © 2026 - <a href="https://www.music4dance.net">Music4Dance.net</a> - <a href="https://www.music4dance.net/home/sitemap">Site Map</a> - <a href="https://www.music4dance.net/home/termsofservice">Terms of Service</a> - <a href="https://www.music4dance.net/home/privacypolicy">Privacy Policy</a> - <a href="https://www.music4dance.net/home/credits">Credits</a> - <a href="https://github.com/music4dance/music4dance" target="_blank">Code</a> - <a>Help</a></p>
+    </footer>
   </div>
 </div>"
 `;

--- a/m4d/ClientApp/src/pages/searches/App.vue
+++ b/m4d/ClientApp/src/pages/searches/App.vue
@@ -144,8 +144,9 @@ function onSpotifyToggle(): void {
       </div>
     </div>
 
-    <!-- Spotify Only switch -->
-    <div class="row mb-3">
+    <!-- Spotify Only switch — hidden for all-users admin view since Spotify links are
+         user-scoped and the toggle would have no meaningful effect across all users -->
+    <div v-if="model.user !== 'all'" class="row mb-3">
       <div class="col-sm">
         <div class="form-check form-switch">
           <input

--- a/m4d/ClientApp/src/pages/searches/App.vue
+++ b/m4d/ClientApp/src/pages/searches/App.vue
@@ -1,0 +1,245 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { TypedJSON } from "typedjson";
+import type { BvEvent, TableFieldRaw } from "bootstrap-vue-next";
+import { SearchesPageModel, SearchSummary } from "./SearchesPageModel";
+
+declare const model_: string;
+
+const model: SearchesPageModel = TypedJSON.parse(model_, SearchesPageModel)!;
+const pageTitle = computed(() => (model.user === "all" ? "All Searches" : "My Searches"));
+// --- URL builders ---
+function pageUrl(p: number): string {
+  const params = new URLSearchParams();
+  if (model.user) params.set("user", model.user);
+  if (model.sort) params.set("sort", model.sort);
+  if (model.showDetails) params.set("showDetails", "true");
+  if (model.spotifyOnly) params.set("spotifyOnly", "true");
+  params.set("page", String(p));
+  return "/Searches/Index?" + params.toString();
+}
+
+function sortUrl(newSort: string): string {
+  const params = new URLSearchParams();
+  if (model.user) params.set("user", model.user);
+  if (newSort) params.set("sort", newSort);
+  if (model.showDetails) params.set("showDetails", "true");
+  if (model.spotifyOnly) params.set("spotifyOnly", "true");
+  return "/Searches/Index?" + params.toString();
+}
+
+function spotifyToggleUrl(): string {
+  const params = new URLSearchParams();
+  if (model.user) params.set("user", model.user);
+  if (model.sort) params.set("sort", model.sort);
+  if (model.showDetails) params.set("showDetails", "true");
+  if (!model.spotifyOnly) params.set("spotifyOnly", "true");
+  return "/Searches/Index?" + params.toString();
+}
+
+function toggleDetailsUrl(): string {
+  const params = new URLSearchParams();
+  if (model.user) params.set("user", model.user);
+  if (model.sort) params.set("sort", model.sort);
+  if (!model.showDetails) params.set("showDetails", "true");
+  if (model.spotifyOnly) params.set("spotifyOnly", "true");
+  return "/Searches/Index?" + params.toString();
+}
+
+// --- Table fields ---
+const fields = computed<Exclude<TableFieldRaw<SearchSummary>, string>[]>(() => {
+  const base: Exclude<TableFieldRaw<SearchSummary>, string>[] = [
+    { key: "search" as keyof SearchSummary, label: "Search", sortable: false },
+  ];
+  if (model.showDetails) {
+    return [
+      ...base,
+      { key: "query" as keyof SearchSummary, label: "Query", sortable: false },
+      { key: "userName" as keyof SearchSummary, label: "User", sortable: false },
+      { key: "count" as keyof SearchSummary, label: "Count", sortable: false },
+      { key: "created" as keyof SearchSummary, label: "Created", sortable: false },
+      { key: "modified" as keyof SearchSummary, label: "Modified", sortable: false },
+    ];
+  }
+  return [
+    ...base,
+    {
+      key: (model.sort === "recent" ? "modified" : "count") as keyof SearchSummary,
+      label: model.sort === "recent" ? "Modified" : "Count",
+      sortable: false,
+    },
+  ];
+});
+
+// --- Windowed pagination entries ---
+const editPageNumber = ref(model.page);
+
+function onPageClick(event: BvEvent, pageNum: number): void {
+  event.preventDefault();
+  window.location.href = pageUrl(pageNum);
+}
+
+function goToPage(): void {
+  let page = editPageNumber.value;
+  if (typeof page !== "number" || isNaN(page)) {
+    editPageNumber.value = model.page;
+    return;
+  }
+  page = Math.floor(page);
+  if (page < 1) page = 1;
+  if (page > model.totalPages) page = model.totalPages;
+  editPageNumber.value = page;
+  if (page !== model.page) {
+    window.location.href = pageUrl(page);
+  }
+}
+
+function formatDate(dateStr: string | undefined): string {
+  if (!dateStr) return "";
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "numeric",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function spotifyUrl(id: string): string {
+  return "https://open.spotify.com/playlist/" + id;
+}
+
+function onSpotifyToggle(): void {
+  window.location.href = spotifyToggleUrl();
+}
+</script>
+
+<template>
+  <PageFrame id="app" :title="pageTitle">
+    <!-- Navigation links -->
+    <div class="row mb-2">
+      <p class="col-sm">
+        <a id="saved-search" :href="model.basicSearchUrl">Basic Search</a>
+      </p>
+      <p class="col-sm text-end pe-4">
+        <a id="advanced-search" :href="model.advancedSearchUrl">Advanced Search</a>
+      </p>
+    </div>
+
+    <!-- Sort buttons -->
+    <div class="row mb-3">
+      <div class="btn-group col-sm" role="group" aria-label="Sort order">
+        <a
+          :href="sortUrl('')"
+          role="button"
+          :class="model.sort !== 'recent' ? 'btn btn-primary' : 'btn btn-outline-primary'"
+        >
+          Most Popular
+        </a>
+        <a
+          :href="sortUrl('recent')"
+          role="button"
+          :class="model.sort === 'recent' ? 'btn btn-primary' : 'btn btn-outline-primary'"
+        >
+          Most Recent
+        </a>
+      </div>
+    </div>
+
+    <!-- Spotify Only switch -->
+    <div class="row mb-3">
+      <div class="col-sm">
+        <div class="form-check form-switch">
+          <input
+            id="spotifyOnlySwitch"
+            class="form-check-input"
+            type="checkbox"
+            role="switch"
+            :checked="model.spotifyOnly"
+            @change="onSpotifyToggle()"
+          />
+          <label class="form-check-label" for="spotifyOnlySwitch">Spotify Only</label>
+        </div>
+      </div>
+    </div>
+
+    <!-- Search table -->
+    <BTable
+      id="searches-table"
+      :fields="fields"
+      :items="model.searches"
+      striped
+      class="table-songs col-sm"
+    >
+      <template #cell(search)="{ item }">
+        <a :href="item.searchUrl" role="button" class="btn btn-success btn-sm">Search</a>
+        <a
+          v-if="item.searchPageUrl && item.mostRecentPage"
+          :href="item.searchPageUrl"
+          role="button"
+          class="btn btn-outline-success btn-sm ms-1"
+        >
+          Page {{ item.mostRecentPage }}
+        </a>
+        &nbsp;
+        <a :href="item.deleteUrl" role="button" class="btn btn-danger btn-sm">Delete</a>
+        &nbsp;
+        <a v-if="item.spotify" :href="spotifyUrl(item.spotify)" target="_blank">
+          <img
+            :src="'/images/icons/spotify-logo.png'"
+            alt="Spotify Playlist"
+            width="24"
+            height="24"
+          />
+        </a>
+        {{ item.description }}
+      </template>
+      <template #cell(created)="{ item }">{{ formatDate(item.created) }}</template>
+      <template #cell(modified)="{ item }">{{ formatDate(item.modified) }}</template>
+    </BTable>
+
+    <!-- Admin controls -->
+    <div v-if="model.isAdmin" class="mt-2">
+      <a :href="toggleDetailsUrl()">Toggle Details</a>
+    </div>
+
+    <!-- Delete All -->
+    <div v-if="model.canDeleteAll && model.deleteAllUrl" class="row mt-2">
+      <div class="col-sm">
+        <a :href="model.deleteAllUrl" class="btn btn-outline-danger btn-sm"
+          >Clear My Search History</a
+        >
+      </div>
+    </div>
+
+    <!-- Pagination -->
+    <BRow v-if="model.totalPages > 1" class="mt-3">
+      <BCol md="8">
+        <BPagination
+          v-model="editPageNumber"
+          :total-rows="model.totalPages"
+          :per-page="1"
+          limit="9"
+          first-number
+          last-number
+          aria-label="Search history pages"
+          @page-click="onPageClick"
+        />
+      </BCol>
+      <BCol md="4">
+        Page
+        <input
+          v-model.number="editPageNumber"
+          type="number"
+          step="1"
+          :min="1"
+          :max="model.totalPages"
+          class="form-control form-control-sm d-inline-block"
+          style="width: 4em"
+          aria-label="Page number"
+          @keydown.enter="goToPage"
+          @blur="goToPage"
+        />
+        of {{ model.totalPages }}
+      </BCol>
+    </BRow>
+  </PageFrame>
+</template>

--- a/m4d/ClientApp/src/pages/searches/SearchesPageModel.ts
+++ b/m4d/ClientApp/src/pages/searches/SearchesPageModel.ts
@@ -1,0 +1,33 @@
+import { jsonArrayMember, jsonMember, jsonObject } from "typedjson";
+
+@jsonObject
+export class SearchSummary {
+  @jsonMember(Number) public id!: number;
+  @jsonMember(String) public userName!: string;
+  @jsonMember(String) public query?: string;
+  @jsonMember(String) public description?: string;
+  @jsonMember(String) public searchUrl!: string;
+  @jsonMember(String) public searchPageUrl?: string;
+  @jsonMember(Number) public mostRecentPage?: number;
+  @jsonMember(Number) public count!: number;
+  @jsonMember(String) public created!: string;
+  @jsonMember(String) public modified!: string;
+  @jsonMember(String) public spotify?: string;
+  @jsonMember(String) public deleteUrl!: string;
+}
+
+@jsonObject
+export class SearchesPageModel {
+  @jsonArrayMember(SearchSummary) public searches!: SearchSummary[];
+  @jsonMember(Number) public page!: number;
+  @jsonMember(Number) public totalPages!: number;
+  @jsonMember(String) public sort?: string;
+  @jsonMember(Boolean) public showDetails!: boolean;
+  @jsonMember(Boolean) public spotifyOnly!: boolean;
+  @jsonMember(String) public user?: string;
+  @jsonMember(Boolean) public isAdmin!: boolean;
+  @jsonMember(Boolean) public canDeleteAll!: boolean;
+  @jsonMember(String) public basicSearchUrl!: string;
+  @jsonMember(String) public advancedSearchUrl!: string;
+  @jsonMember(String) public deleteAllUrl?: string;
+}

--- a/m4d/ClientApp/src/pages/searches/__tests__/__snapshots__/searches.test.ts.snap
+++ b/m4d/ClientApp/src/pages/searches/__tests__/__snapshots__/searches.test.ts.snap
@@ -14,7 +14,9 @@ exports[`searches page > renders the admin detail view snapshot 1`] = `
       </div><!-- Sort buttons -->
       <div class="row mb-3">
         <div class="btn-group col-sm" role="group" aria-label="Sort order"><a href="/Searches/Index?user=alice&amp;showDetails=true" role="button" class="btn btn-primary"> Most Popular </a><a href="/Searches/Index?user=alice&amp;sort=recent&amp;showDetails=true" role="button" class="btn btn-outline-primary"> Most Recent </a></div>
-      </div><!-- Spotify Only switch -->
+      </div>
+      <!-- Spotify Only switch — hidden for all-users admin view since Spotify links are
+         user-scoped and the toggle would have no meaningful effect across all users -->
       <div class="row mb-3">
         <div class="col-sm">
           <div class="form-check form-switch"><input id="spotifyOnlySwitch" class="form-check-input" type="checkbox" role="switch"><label class="form-check-label" for="spotifyOnlySwitch">Spotify Only</label></div>
@@ -148,12 +150,11 @@ exports[`searches page > renders the all-users view snapshot 1`] = `
       </div><!-- Sort buttons -->
       <div class="row mb-3">
         <div class="btn-group col-sm" role="group" aria-label="Sort order"><a href="/Searches/Index?user=all" role="button" class="btn btn-primary"> Most Popular </a><a href="/Searches/Index?user=all&amp;sort=recent" role="button" class="btn btn-outline-primary"> Most Recent </a></div>
-      </div><!-- Spotify Only switch -->
-      <div class="row mb-3">
-        <div class="col-sm">
-          <div class="form-check form-switch"><input id="spotifyOnlySwitch" class="form-check-input" type="checkbox" role="switch"><label class="form-check-label" for="spotifyOnlySwitch">Spotify Only</label></div>
-        </div>
-      </div><!-- Search table -->
+      </div>
+      <!-- Spotify Only switch — hidden for all-users admin view since Spotify links are
+         user-scoped and the toggle would have no meaningful effect across all users -->
+      <!--v-if-->
+      <!-- Search table -->
       <table id="searches-table" class="table b-table table-striped table-songs col-sm" aria-busy="false">
         <!---->
         <thead class="">
@@ -242,7 +243,9 @@ exports[`searches page > renders the searches page snapshot 1`] = `
       </div><!-- Sort buttons -->
       <div class="row mb-3">
         <div class="btn-group col-sm" role="group" aria-label="Sort order"><a href="/Searches/Index?user=alice" role="button" class="btn btn-primary"> Most Popular </a><a href="/Searches/Index?user=alice&amp;sort=recent" role="button" class="btn btn-outline-primary"> Most Recent </a></div>
-      </div><!-- Spotify Only switch -->
+      </div>
+      <!-- Spotify Only switch — hidden for all-users admin view since Spotify links are
+         user-scoped and the toggle would have no meaningful effect across all users -->
       <div class="row mb-3">
         <div class="col-sm">
           <div class="form-check form-switch"><input id="spotifyOnlySwitch" class="form-check-input" type="checkbox" role="switch"><label class="form-check-label" for="spotifyOnlySwitch">Spotify Only</label></div>

--- a/m4d/ClientApp/src/pages/searches/__tests__/__snapshots__/searches.test.ts.snap
+++ b/m4d/ClientApp/src/pages/searches/__tests__/__snapshots__/searches.test.ts.snap
@@ -1,0 +1,324 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`searches page > renders the admin detail view snapshot 1`] = `
+"<div><span context="[object Object]">MainMenu</span>
+  <!--v-if-->
+  <!--v-if-->
+  <div id="body-content" class="container-fluid body-content">
+    <h1>My Searches</h1>
+    <div>
+      <!-- Navigation links -->
+      <div class="row mb-2">
+        <p class="col-sm"><a id="saved-search" href="/Song/Index?user=alice">Basic Search</a></p>
+        <p class="col-sm text-end pe-4"><a id="advanced-search" href="/Song/AdvancedSearchForm?filter=index">Advanced Search</a></p>
+      </div><!-- Sort buttons -->
+      <div class="row mb-3">
+        <div class="btn-group col-sm" role="group" aria-label="Sort order"><a href="/Searches/Index?user=alice&amp;showDetails=true" role="button" class="btn btn-primary"> Most Popular </a><a href="/Searches/Index?user=alice&amp;sort=recent&amp;showDetails=true" role="button" class="btn btn-outline-primary"> Most Recent </a></div>
+      </div><!-- Spotify Only switch -->
+      <div class="row mb-3">
+        <div class="col-sm">
+          <div class="form-check form-switch"><input id="spotifyOnlySwitch" class="form-check-input" type="checkbox" role="switch"><label class="form-check-label" for="spotifyOnlySwitch">Spotify Only</label></div>
+        </div>
+      </div><!-- Search table -->
+      <table id="searches-table" class="table b-table table-striped table-songs col-sm" aria-busy="false">
+        <!---->
+        <thead class="">
+          <tr class="">
+            <th scope="col" class="">Search</th>
+            <th scope="col" class="">Query</th>
+            <th scope="col" class="">User</th>
+            <th scope="col" class="">Count</th>
+            <th scope="col" class="">Created</th>
+            <th scope="col" class="">Modified</th>
+          </tr>
+          <!---->
+        </thead>
+        <tbody class="">
+          <!---->
+          <tr class="">
+            <td class="">
+              <!----><a href="/Song/Index?filter=index-CHA--Cha+Cha" role="button" class="btn btn-success btn-sm">Search</a><a href="/Song/Index?filter=index-CHA--Cha+Cha---.-2" role="button" class="btn btn-outline-success btn-sm ms-1"> Page 2</a> &nbsp; <a href="/Searches/Delete/1001?user=alice" role="button" class="btn btn-danger btn-sm">Delete</a> &nbsp;
+              <!--v-if--> Cha Cha
+            </td>
+            <td class="">
+              <!---->index-CHA--Cha+Cha
+            </td>
+            <td class="">
+              <!---->alice
+            </td>
+            <td class="">
+              <!---->42
+            </td>
+            <td class="">
+              <!---->3/15/2023
+            </td>
+            <td class="">
+              <!---->11/20/2024
+            </td>
+          </tr>
+          <!---->
+          <tr class="">
+            <td class="">
+              <!----><a href="/Song/Index?filter=index-WLT" role="button" class="btn btn-success btn-sm">Search</a>
+              <!--v-if--> &nbsp; <a href="/Searches/Delete/1002?user=alice" role="button" class="btn btn-danger btn-sm">Delete</a> &nbsp; <a href="https://open.spotify.com/playlist/3cEYpjA9oz9GiPac4AsH4n" target="_blank"><img src="/images/icons/spotify-logo.png" alt="Spotify Playlist" width="24" height="24"></a> Waltz
+            </td>
+            <td class="">
+              <!---->index-WLT
+            </td>
+            <td class="">
+              <!---->alice
+            </td>
+            <td class="">
+              <!---->15
+            </td>
+            <td class="">
+              <!---->6/1/2023
+            </td>
+            <td class="">
+              <!---->10/5/2024
+            </td>
+          </tr>
+          <!---->
+          <tr class="">
+            <td class="">
+              <!----><a href="/Song/Index?filter=index--.-.-.-bpm120" role="button" class="btn btn-success btn-sm">Search</a>
+              <!--v-if--> &nbsp; <a href="/Searches/Delete/1003?user=alice" role="button" class="btn btn-danger btn-sm">Delete</a> &nbsp;
+              <!--v-if--> 120 bpm
+            </td>
+            <td class="">
+              <!---->index--.-.-.-bpm120
+            </td>
+            <td class="">
+              <!---->alice
+            </td>
+            <td class="">
+              <!---->7
+            </td>
+            <td class="">
+              <!---->1/10/2024
+            </td>
+            <td class="">
+              <!---->1/10/2024
+            </td>
+          </tr>
+          <!---->
+          <!---->
+        </tbody>
+        <!---->
+        <!---->
+      </table><!-- Admin controls -->
+      <div class="mt-2"><a href="/Searches/Index?user=alice">Toggle Details</a></div><!-- Delete All -->
+      <div class="row mt-2">
+        <div class="col-sm"><a href="/Searches/DeleteAll" class="btn btn-outline-danger btn-sm">Clear My Search History</a></div>
+      </div><!-- Pagination -->
+      <div class="row mt-3">
+        <div class="col-md-8">
+          <ul class="pagination justify-content-start" role="menubar" aria-disabled="false" aria-label="Search history pages">
+            <li class="page-item disabled" role="presentation" displayindex="0"><span is="span" class="page-link text-center" aria-label="Go to previous page" aria-disabled="true" role="menuitem">‹</span></li>
+            <li class="page-item active" role="presentation" displayindex="1"><button is="button" class="page-link text-center" aria-label="Go to page 1" aria-posinset="1" aria-setsize="3" role="menuitem" type="button" tabindex="0">1</button></li>
+            <li class="page-item" role="presentation" displayindex="2"><button is="button" class="page-link text-center" aria-label="Go to page 2" aria-posinset="2" aria-setsize="3" role="menuitem" type="button" tabindex="-1">2</button></li>
+            <li class="page-item" role="presentation" displayindex="3"><button is="button" class="page-link text-center" aria-label="Go to page 3" aria-posinset="3" aria-setsize="3" role="menuitem" type="button" tabindex="-1">3</button></li>
+            <li class="page-item" role="presentation" displayindex="4"><button is="button" class="page-link text-center" aria-label="Go to next page" role="menuitem" type="button" tabindex="-1">›</button></li>
+          </ul>
+        </div>
+        <div class="col-md-4"> Page <input type="number" step="1" min="1" max="3" class="form-control form-control-sm d-inline-block" style="width: 4em;" aria-label="Page number"> of 3</div>
+      </div>
+    </div>
+  </div>
+  <div id="footer-content">
+    <hr>
+    <footer>
+      <p> © 2026 - <a href="https://www.music4dance.net">Music4Dance.net</a> - <a href="https://www.music4dance.net/home/sitemap">Site Map</a> - <a href="https://www.music4dance.net/home/termsofservice">Terms of Service</a> - <a href="https://www.music4dance.net/home/privacypolicy">Privacy Policy</a> - <a href="https://www.music4dance.net/home/credits">Credits</a> - <a href="https://github.com/music4dance/music4dance" target="_blank">Code</a> - <a>Help</a></p>
+    </footer>
+  </div>
+</div>"
+`;
+
+exports[`searches page > renders the all-users view snapshot 1`] = `
+"<div><span context="[object Object]">MainMenu</span>
+  <!--v-if-->
+  <!--v-if-->
+  <div id="body-content" class="container-fluid body-content">
+    <h1>All Searches</h1>
+    <div>
+      <!-- Navigation links -->
+      <div class="row mb-2">
+        <p class="col-sm"><a id="saved-search" href="/Song/Index?user=alice">Basic Search</a></p>
+        <p class="col-sm text-end pe-4"><a id="advanced-search" href="/Song/AdvancedSearchForm?filter=index">Advanced Search</a></p>
+      </div><!-- Sort buttons -->
+      <div class="row mb-3">
+        <div class="btn-group col-sm" role="group" aria-label="Sort order"><a href="/Searches/Index?user=all" role="button" class="btn btn-primary"> Most Popular </a><a href="/Searches/Index?user=all&amp;sort=recent" role="button" class="btn btn-outline-primary"> Most Recent </a></div>
+      </div><!-- Spotify Only switch -->
+      <div class="row mb-3">
+        <div class="col-sm">
+          <div class="form-check form-switch"><input id="spotifyOnlySwitch" class="form-check-input" type="checkbox" role="switch"><label class="form-check-label" for="spotifyOnlySwitch">Spotify Only</label></div>
+        </div>
+      </div><!-- Search table -->
+      <table id="searches-table" class="table b-table table-striped table-songs col-sm" aria-busy="false">
+        <!---->
+        <thead class="">
+          <tr class="">
+            <th scope="col" class="">Search</th>
+            <th scope="col" class="">Count</th>
+          </tr>
+          <!---->
+        </thead>
+        <tbody class="">
+          <!---->
+          <tr class="">
+            <td class="">
+              <!----><a href="/Song/Index?filter=index-CHA--Cha+Cha" role="button" class="btn btn-success btn-sm">Search</a><a href="/Song/Index?filter=index-CHA--Cha+Cha---.-2" role="button" class="btn btn-outline-success btn-sm ms-1"> Page 2</a> &nbsp; <a href="/Searches/Delete/1001?user=alice" role="button" class="btn btn-danger btn-sm">Delete</a> &nbsp;
+              <!--v-if--> Cha Cha
+            </td>
+            <td class="">
+              <!---->42
+            </td>
+          </tr>
+          <!---->
+          <tr class="">
+            <td class="">
+              <!----><a href="/Song/Index?filter=index-WLT" role="button" class="btn btn-success btn-sm">Search</a>
+              <!--v-if--> &nbsp; <a href="/Searches/Delete/1002?user=alice" role="button" class="btn btn-danger btn-sm">Delete</a> &nbsp; <a href="https://open.spotify.com/playlist/3cEYpjA9oz9GiPac4AsH4n" target="_blank"><img src="/images/icons/spotify-logo.png" alt="Spotify Playlist" width="24" height="24"></a> Waltz
+            </td>
+            <td class="">
+              <!---->15
+            </td>
+          </tr>
+          <!---->
+          <tr class="">
+            <td class="">
+              <!----><a href="/Song/Index?filter=index--.-.-.-bpm120" role="button" class="btn btn-success btn-sm">Search</a>
+              <!--v-if--> &nbsp; <a href="/Searches/Delete/1003?user=alice" role="button" class="btn btn-danger btn-sm">Delete</a> &nbsp;
+              <!--v-if--> 120 bpm
+            </td>
+            <td class="">
+              <!---->7
+            </td>
+          </tr>
+          <!---->
+          <!---->
+        </tbody>
+        <!---->
+        <!---->
+      </table><!-- Admin controls -->
+      <!--v-if-->
+      <!-- Delete All -->
+      <!--v-if-->
+      <!-- Pagination -->
+      <div class="row mt-3">
+        <div class="col-md-8">
+          <ul class="pagination justify-content-start" role="menubar" aria-disabled="false" aria-label="Search history pages">
+            <li class="page-item disabled" role="presentation" displayindex="0"><span is="span" class="page-link text-center" aria-label="Go to previous page" aria-disabled="true" role="menuitem">‹</span></li>
+            <li class="page-item active" role="presentation" displayindex="1"><button is="button" class="page-link text-center" aria-label="Go to page 1" aria-posinset="1" aria-setsize="3" role="menuitem" type="button" tabindex="0">1</button></li>
+            <li class="page-item" role="presentation" displayindex="2"><button is="button" class="page-link text-center" aria-label="Go to page 2" aria-posinset="2" aria-setsize="3" role="menuitem" type="button" tabindex="-1">2</button></li>
+            <li class="page-item" role="presentation" displayindex="3"><button is="button" class="page-link text-center" aria-label="Go to page 3" aria-posinset="3" aria-setsize="3" role="menuitem" type="button" tabindex="-1">3</button></li>
+            <li class="page-item" role="presentation" displayindex="4"><button is="button" class="page-link text-center" aria-label="Go to next page" role="menuitem" type="button" tabindex="-1">›</button></li>
+          </ul>
+        </div>
+        <div class="col-md-4"> Page <input type="number" step="1" min="1" max="3" class="form-control form-control-sm d-inline-block" style="width: 4em;" aria-label="Page number"> of 3</div>
+      </div>
+    </div>
+  </div>
+  <div id="footer-content">
+    <hr>
+    <footer>
+      <p> © 2026 - <a href="https://www.music4dance.net">Music4Dance.net</a> - <a href="https://www.music4dance.net/home/sitemap">Site Map</a> - <a href="https://www.music4dance.net/home/termsofservice">Terms of Service</a> - <a href="https://www.music4dance.net/home/privacypolicy">Privacy Policy</a> - <a href="https://www.music4dance.net/home/credits">Credits</a> - <a href="https://github.com/music4dance/music4dance" target="_blank">Code</a> - <a>Help</a></p>
+    </footer>
+  </div>
+</div>"
+`;
+
+exports[`searches page > renders the searches page snapshot 1`] = `
+"<div><span context="[object Object]">MainMenu</span>
+  <!--v-if-->
+  <!--v-if-->
+  <div id="body-content" class="container-fluid body-content">
+    <h1>My Searches</h1>
+    <div>
+      <!-- Navigation links -->
+      <div class="row mb-2">
+        <p class="col-sm"><a id="saved-search" href="/Song/Index?user=alice">Basic Search</a></p>
+        <p class="col-sm text-end pe-4"><a id="advanced-search" href="/Song/AdvancedSearchForm?filter=index">Advanced Search</a></p>
+      </div><!-- Sort buttons -->
+      <div class="row mb-3">
+        <div class="btn-group col-sm" role="group" aria-label="Sort order"><a href="/Searches/Index?user=alice" role="button" class="btn btn-primary"> Most Popular </a><a href="/Searches/Index?user=alice&amp;sort=recent" role="button" class="btn btn-outline-primary"> Most Recent </a></div>
+      </div><!-- Spotify Only switch -->
+      <div class="row mb-3">
+        <div class="col-sm">
+          <div class="form-check form-switch"><input id="spotifyOnlySwitch" class="form-check-input" type="checkbox" role="switch"><label class="form-check-label" for="spotifyOnlySwitch">Spotify Only</label></div>
+        </div>
+      </div><!-- Search table -->
+      <table id="searches-table" class="table b-table table-striped table-songs col-sm" aria-busy="false">
+        <!---->
+        <thead class="">
+          <tr class="">
+            <th scope="col" class="">Search</th>
+            <th scope="col" class="">Count</th>
+          </tr>
+          <!---->
+        </thead>
+        <tbody class="">
+          <!---->
+          <tr class="">
+            <td class="">
+              <!----><a href="/Song/Index?filter=index-CHA--Cha+Cha" role="button" class="btn btn-success btn-sm">Search</a><a href="/Song/Index?filter=index-CHA--Cha+Cha---.-2" role="button" class="btn btn-outline-success btn-sm ms-1"> Page 2</a> &nbsp; <a href="/Searches/Delete/1001?user=alice" role="button" class="btn btn-danger btn-sm">Delete</a> &nbsp;
+              <!--v-if--> Cha Cha
+            </td>
+            <td class="">
+              <!---->42
+            </td>
+          </tr>
+          <!---->
+          <tr class="">
+            <td class="">
+              <!----><a href="/Song/Index?filter=index-WLT" role="button" class="btn btn-success btn-sm">Search</a>
+              <!--v-if--> &nbsp; <a href="/Searches/Delete/1002?user=alice" role="button" class="btn btn-danger btn-sm">Delete</a> &nbsp; <a href="https://open.spotify.com/playlist/3cEYpjA9oz9GiPac4AsH4n" target="_blank"><img src="/images/icons/spotify-logo.png" alt="Spotify Playlist" width="24" height="24"></a> Waltz
+            </td>
+            <td class="">
+              <!---->15
+            </td>
+          </tr>
+          <!---->
+          <tr class="">
+            <td class="">
+              <!----><a href="/Song/Index?filter=index--.-.-.-bpm120" role="button" class="btn btn-success btn-sm">Search</a>
+              <!--v-if--> &nbsp; <a href="/Searches/Delete/1003?user=alice" role="button" class="btn btn-danger btn-sm">Delete</a> &nbsp;
+              <!--v-if--> 120 bpm
+            </td>
+            <td class="">
+              <!---->7
+            </td>
+          </tr>
+          <!---->
+          <!---->
+        </tbody>
+        <!---->
+        <!---->
+      </table><!-- Admin controls -->
+      <!--v-if-->
+      <!-- Delete All -->
+      <div class="row mt-2">
+        <div class="col-sm"><a href="/Searches/DeleteAll" class="btn btn-outline-danger btn-sm">Clear My Search History</a></div>
+      </div><!-- Pagination -->
+      <div class="row mt-3">
+        <div class="col-md-8">
+          <ul class="pagination justify-content-start" role="menubar" aria-disabled="false" aria-label="Search history pages">
+            <li class="page-item disabled" role="presentation" displayindex="0"><span is="span" class="page-link text-center" aria-label="Go to previous page" aria-disabled="true" role="menuitem">‹</span></li>
+            <li class="page-item active" role="presentation" displayindex="1"><button is="button" class="page-link text-center" aria-label="Go to page 1" aria-posinset="1" aria-setsize="3" role="menuitem" type="button" tabindex="0">1</button></li>
+            <li class="page-item" role="presentation" displayindex="2"><button is="button" class="page-link text-center" aria-label="Go to page 2" aria-posinset="2" aria-setsize="3" role="menuitem" type="button" tabindex="-1">2</button></li>
+            <li class="page-item" role="presentation" displayindex="3"><button is="button" class="page-link text-center" aria-label="Go to page 3" aria-posinset="3" aria-setsize="3" role="menuitem" type="button" tabindex="-1">3</button></li>
+            <li class="page-item" role="presentation" displayindex="4"><button is="button" class="page-link text-center" aria-label="Go to next page" role="menuitem" type="button" tabindex="-1">›</button></li>
+          </ul>
+        </div>
+        <div class="col-md-4"> Page <input type="number" step="1" min="1" max="3" class="form-control form-control-sm d-inline-block" style="width: 4em;" aria-label="Page number"> of 3</div>
+      </div>
+    </div>
+  </div>
+  <div id="footer-content">
+    <hr>
+    <footer>
+      <p> © 2026 - <a href="https://www.music4dance.net">Music4Dance.net</a> - <a href="https://www.music4dance.net/home/sitemap">Site Map</a> - <a href="https://www.music4dance.net/home/termsofservice">Terms of Service</a> - <a href="https://www.music4dance.net/home/privacypolicy">Privacy Policy</a> - <a href="https://www.music4dance.net/home/credits">Credits</a> - <a href="https://github.com/music4dance/music4dance" target="_blank">Code</a> - <a>Help</a></p>
+    </footer>
+  </div>
+</div>"
+`;

--- a/m4d/ClientApp/src/pages/searches/__tests__/model.ts
+++ b/m4d/ClientApp/src/pages/searches/__tests__/model.ts
@@ -1,0 +1,74 @@
+/**
+ * Test fixture for searches page.
+ * Represents a realistic but minimal SearchesPageModel payload.
+ */
+export const model = {
+  searches: [
+    {
+      id: 1001,
+      userName: "alice",
+      query: "index-CHA--Cha+Cha",
+      description: "Cha Cha",
+      searchUrl: "/Song/Index?filter=index-CHA--Cha+Cha",
+      searchPageUrl: "/Song/Index?filter=index-CHA--Cha+Cha---.-2",
+      mostRecentPage: 2,
+      count: 42,
+      created: "2023-03-15T10:00:00",
+      modified: "2024-11-20T14:30:00",
+      spotify: null,
+      deleteUrl: "/Searches/Delete/1001?user=alice",
+    },
+    {
+      id: 1002,
+      userName: "alice",
+      query: "index-WLT",
+      description: "Waltz",
+      searchUrl: "/Song/Index?filter=index-WLT",
+      searchPageUrl: null,
+      mostRecentPage: null,
+      count: 15,
+      created: "2023-06-01T08:00:00",
+      modified: "2024-10-05T09:15:00",
+      spotify: "3cEYpjA9oz9GiPac4AsH4n",
+      deleteUrl: "/Searches/Delete/1002?user=alice",
+    },
+    {
+      id: 1003,
+      userName: "alice",
+      query: "index--.-.-.-bpm120",
+      description: "120 bpm",
+      searchUrl: "/Song/Index?filter=index--.-.-.-bpm120",
+      searchPageUrl: null,
+      mostRecentPage: null,
+      count: 7,
+      created: "2024-01-10T12:00:00",
+      modified: "2024-01-10T12:00:00",
+      spotify: null,
+      deleteUrl: "/Searches/Delete/1003?user=alice",
+    },
+  ],
+  page: 1,
+  totalPages: 3,
+  sort: null,
+  showDetails: false,
+  spotifyOnly: false,
+  user: "alice",
+  isAdmin: false,
+  canDeleteAll: true,
+  basicSearchUrl: "/Song/Index?user=alice",
+  advancedSearchUrl: "/Song/AdvancedSearchForm?filter=index",
+  deleteAllUrl: "/Searches/DeleteAll",
+};
+
+export const adminModel = {
+  ...model,
+  isAdmin: true,
+  showDetails: true,
+};
+
+export const allUsersModel = {
+  ...model,
+  user: "all",
+  canDeleteAll: false,
+  deleteAllUrl: null,
+};

--- a/m4d/ClientApp/src/pages/searches/__tests__/searches.test.ts
+++ b/m4d/ClientApp/src/pages/searches/__tests__/searches.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import { loadTestPage, testPageSnapshot } from "@/helpers/TestPageSnapshot";
+import App from "../App.vue";
+import { model, adminModel, allUsersModel } from "./model";
+
+describe("searches page", () => {
+  test("renders the searches page snapshot", () => {
+    testPageSnapshot(App, model);
+  });
+
+  test("renders the admin detail view snapshot", () => {
+    testPageSnapshot(App, adminModel);
+  });
+
+  test("renders the all-users view snapshot", () => {
+    testPageSnapshot(App, allUsersModel);
+  });
+
+  describe("basic (non-admin) view", () => {
+    let wrapper: ReturnType<typeof loadTestPage>;
+
+    beforeEach(() => {
+      wrapper = loadTestPage(App, model);
+    });
+
+    test("shows search buttons for each row", () => {
+      const searchLinks = wrapper.findAll("a.btn-success");
+      expect(searchLinks.length).toBe(model.searches.length);
+    });
+
+    test("shows delete buttons for each row", () => {
+      const deleteLinks = wrapper.findAll("a.btn-danger");
+      expect(deleteLinks.length).toBe(model.searches.length);
+    });
+
+    test("shows page link when mostRecentPage is set", () => {
+      const pageLinks = wrapper.findAll("a.btn-outline-success");
+      expect(pageLinks.length).toBe(1);
+      expect(pageLinks[0].text()).toContain("Page 2");
+    });
+
+    test("shows spotify icon for rows with spotify ID", () => {
+      const spotifyIcons = wrapper.findAll('img[alt="Spotify Playlist"]');
+      expect(spotifyIcons.length).toBe(1);
+    });
+
+    test("shows pagination when totalPages > 1", () => {
+      expect(wrapper.find("ul.pagination").exists()).toBe(true);
+    });
+
+    test("shows delete-all button for user-scoped view", () => {
+      expect(wrapper.find("a.btn-outline-danger").exists()).toBe(true);
+      expect(wrapper.find("a.btn-outline-danger").text()).toContain("Clear My Search History");
+    });
+
+    test("does not show Toggle Details link for non-admin", () => {
+      expect(wrapper.text()).not.toContain("Toggle Details");
+    });
+
+    test("shows Basic Search and Advanced Search links", () => {
+      expect(wrapper.find("#saved-search").exists()).toBe(true);
+      expect(wrapper.find("#advanced-search").exists()).toBe(true);
+    });
+
+    test("shows sort buttons", () => {
+      const sortButtons = wrapper.findAll(".btn-group a");
+      expect(sortButtons.length).toBeGreaterThanOrEqual(2);
+      expect(sortButtons[0].text()).toBe("Most Popular");
+      expect(sortButtons[1].text()).toBe("Most Recent");
+    });
+
+    test("Most Popular is active when sort is not recent", () => {
+      const popularBtn = wrapper.findAll(".btn-group a")[0];
+      expect(popularBtn.classes()).toContain("btn-primary");
+      expect(popularBtn.classes()).not.toContain("btn-outline-primary");
+    });
+  });
+
+  describe("admin detail view", () => {
+    let wrapper: ReturnType<typeof loadTestPage>;
+
+    beforeEach(() => {
+      wrapper = loadTestPage(App, adminModel);
+    });
+
+    test("shows Toggle Details link for admin", () => {
+      expect(wrapper.text()).toContain("Toggle Details");
+    });
+
+    test("shows search table with detail columns", () => {
+      const table = wrapper.find("#searches-table");
+      expect(table.exists()).toBe(true);
+      expect(wrapper.text()).toContain("Query");
+      expect(wrapper.text()).toContain("User");
+      expect(wrapper.text()).toContain("Created");
+    });
+  });
+
+  describe("all-users view", () => {
+    let wrapper: ReturnType<typeof loadTestPage>;
+
+    beforeEach(() => {
+      wrapper = loadTestPage(App, allUsersModel);
+    });
+
+    test("does not show delete-all button for all-users view", () => {
+      expect(wrapper.find("a.btn-outline-danger").exists()).toBe(false);
+    });
+  });
+
+  describe("pagination", () => {
+    test("shows correct page count in pagination nav", () => {
+      const wrapper = loadTestPage(App, model);
+      const pagination = wrapper.find("ul.pagination");
+      expect(pagination.exists()).toBe(true);
+      // Should show page 1 (active), ellipsis optional, page 3 at minimum
+      expect(pagination.text()).toContain("1");
+      expect(pagination.text()).toContain("3");
+    });
+
+    test("no pagination shown when totalPages is 1", () => {
+      const singlePageModel = { ...model, totalPages: 1, page: 1 };
+      const wrapper = loadTestPage(App, singlePageModel);
+      expect(wrapper.find("ul.pagination").exists()).toBe(false);
+    });
+  });
+});

--- a/m4d/Controllers/ActivityLogController.cs
+++ b/m4d/Controllers/ActivityLogController.cs
@@ -1,5 +1,6 @@
 ﻿using m4d.Services;
 using m4d.Services.ServiceHealth;
+using m4d.ViewModels;
 
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -23,10 +24,36 @@ public class ActivityLogController : DanceMusicController
         HelpPage = "song-list";
     }
 
+    private const int ActivityLogPageSize = 100;
+
     // GET: ActivityLogs
-    public IActionResult Index()
+    public IActionResult Index(int page = 1)
     {
-        var list = Database.Context.ActivityLog.OrderByDescending(l => l.Date).Take(500).Include(a => a.User);
-        return View(list);
+        var query = Database.Context.ActivityLog
+            .OrderByDescending(l => l.Date)
+            .Include(a => a.User);
+        var totalCount = query.Count();
+        var entries = query
+            .Skip((page - 1) * ActivityLogPageSize)
+            .Take(ActivityLogPageSize)
+            .AsEnumerable()
+            .Select(item => new ActivityLogEntry
+            {
+                Id = item.Id,
+                Date = item.Date,
+                UserName = item.User?.UserName,
+                Action = item.Action,
+                Details = item.Details,
+            })
+            .ToList();
+
+        var viewModel = new ActivityLogPageModel
+        {
+            Entries = entries,
+            Page = page,
+            TotalPages = (int)Math.Ceiling((double)totalCount / ActivityLogPageSize),
+        };
+
+        return Vue3("Activity Log", "Admin: Activity log", "activity-log", viewModel);
     }
 }

--- a/m4d/Controllers/SearchesController.cs
+++ b/m4d/Controllers/SearchesController.cs
@@ -62,21 +62,35 @@ public class SearchesController : ContentController
             ? searches.OrderByDescending(s => s.Modified)
             : searches.OrderByDescending(s => s.Count);
 
-        var totalCount = await ordered.CountAsync();
-        var model = await ordered
-            .Skip((page - 1) * SearchesPageSize)
-            .Take(SearchesPageSize)
-            .ToListAsync();
-
-
-        if (user is not null and not "all")
-        {
-            await SetSpotify(model, user);
-        }
+        List<Search> model;
+        int totalCount;
 
         if (spotifyOnly && user is not null and not "all")
         {
-            model = model.Where(s => !string.IsNullOrWhiteSpace(s.Spotify)).ToList();
+            // Spotify is a runtime property (not persisted), so it cannot be filtered at the DB
+            // level. Load all results for the user, populate Spotify links, filter, then page
+            // in memory so that totalCount and TotalPages reflect only Spotify-linked searches.
+            var all = await ordered.ToListAsync();
+            await SetSpotify(all, user);
+            var filtered = all.Where(s => !string.IsNullOrWhiteSpace(s.Spotify)).ToList();
+            totalCount = filtered.Count;
+            model = filtered
+                .Skip((page - 1) * SearchesPageSize)
+                .Take(SearchesPageSize)
+                .ToList();
+        }
+        else
+        {
+            totalCount = await ordered.CountAsync();
+            model = await ordered
+                .Skip((page - 1) * SearchesPageSize)
+                .Take(SearchesPageSize)
+                .ToListAsync();
+
+            if (user is not null and not "all")
+            {
+                await SetSpotify(model, user);
+            }
         }
 
         var isAdmin = User.IsInRole("showDiagnostics");
@@ -111,7 +125,7 @@ public class SearchesController : ContentController
                 Created = item.Created,
                 Modified = item.Modified,
                 Spotify = item.Spotify,
-                DeleteUrl = Url.Action("Delete", "Searches", new { id = item.Id, user, showDetails, spotifyOnly, sort }),
+                DeleteUrl = Url.Action("Delete", "Searches", new { id = item.Id, user = item.ApplicationUser?.UserName, showDetails, spotifyOnly, sort }),
             };
         }).ToList();
 

--- a/m4d/Controllers/SearchesController.cs
+++ b/m4d/Controllers/SearchesController.cs
@@ -2,6 +2,7 @@
 
 using m4d.Services;
 using m4d.Services.ServiceHealth;
+using m4d.ViewModels;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
@@ -29,9 +30,11 @@ public class SearchesController : ContentController
         HelpPage = "saved-searches";
     }
 
+    private const int SearchesPageSize = 100;
+
     // GET: Searches
     public async Task<IActionResult> Index(string user, string sort = null,
-        bool showDetails = false, bool spotifyOnly = false)
+        bool showDetails = false, bool spotifyOnly = false, int page = 1)
     {
         if (string.IsNullOrWhiteSpace(user) || user.Equals(
             UserQuery.IdentityUser,
@@ -55,10 +58,15 @@ public class SearchesController : ContentController
             searches = searches.Where(s => s.ApplicationUserId == appUser.Id);
         }
 
-        var model =
-            (string.Equals(sort, "recent")
-                ? searches.OrderByDescending(s => s.Modified)
-                : searches.OrderByDescending(s => s.Count)).Take(250).ToList();
+        var ordered = string.Equals(sort, "recent")
+            ? searches.OrderByDescending(s => s.Modified)
+            : searches.OrderByDescending(s => s.Count);
+
+        var totalCount = await ordered.CountAsync();
+        var model = await ordered
+            .Skip((page - 1) * SearchesPageSize)
+            .Take(SearchesPageSize)
+            .ToListAsync();
 
 
         if (user is not null and not "all")
@@ -71,12 +79,61 @@ public class SearchesController : ContentController
             model = model.Where(s => !string.IsNullOrWhiteSpace(s.Spotify)).ToList();
         }
 
-        ViewBag.Sort = sort;
-        ViewBag.ShowDetails = showDetails;
-        ViewBag.SpotifyOnly = spotifyOnly;
-        ViewBag.SongFilter = Filter;
-        ViewBag.User = user;
-        return View(model);
+        var isAdmin = User.IsInRole("showDiagnostics");
+        var searchSummaries = model.Select(item =>
+        {
+            var t = item.Filter;
+            if (!t.IsAzure)
+            {
+                t.Action = "Advanced";
+            }
+            string searchPageUrl = null;
+            if (item.MostRecentPage.HasValue && item.MostRecentPage.Value > 1)
+            {
+                var tPage = item.Filter;
+                tPage.Page = item.MostRecentPage;
+                if (!tPage.IsAzure)
+                {
+                    tPage.Action = "Advanced";
+                }
+                searchPageUrl = Url.Action("Index", "Song", new { filter = tPage.ToString() });
+            }
+            return new SearchSummary
+            {
+                Id = item.Id,
+                UserName = item.ApplicationUser?.UserName ?? "anonymous",
+                Query = item.Query,
+                Description = t.Description,
+                SearchUrl = Url.Action("Index", "Song", new { filter = t.ToString() }),
+                SearchPageUrl = searchPageUrl,
+                MostRecentPage = item.MostRecentPage,
+                Count = item.Count,
+                Created = item.Created,
+                Modified = item.Modified,
+                Spotify = item.Spotify,
+                DeleteUrl = Url.Action("Delete", "Searches", new { id = item.Id, user, showDetails, spotifyOnly, sort }),
+            };
+        }).ToList();
+
+        var viewModel = new SearchesPageModel
+        {
+            Searches = searchSummaries,
+            Page = page,
+            TotalPages = (int)Math.Ceiling((double)totalCount / SearchesPageSize),
+            Sort = sort,
+            ShowDetails = showDetails,
+            SpotifyOnly = spotifyOnly,
+            User = user,
+            IsAdmin = isAdmin,
+            CanDeleteAll = user is not null and not "all",
+            BasicSearchUrl = Url.Action("Index", "Song", new { user }),
+            AdvancedSearchUrl = Url.Action("advancedsearchform", "Song", new { filter = Filter?.ToString() }),
+            DeleteAllUrl = user is not null and not "all"
+                ? Url.Action("DeleteAll", "Searches", new { sort, showDetails, spotifyOnly })
+                : null,
+        };
+
+        return Vue3("My Searches", "Search history", "searches", viewModel);
     }
 
     // GET: Searches/Resume

--- a/m4d/ViewModels/ActivityLogPageModel.cs
+++ b/m4d/ViewModels/ActivityLogPageModel.cs
@@ -1,0 +1,24 @@
+namespace m4d.ViewModels;
+
+/// <summary>
+/// Safe-to-serialize projection of a single ActivityLog entry.
+/// </summary>
+public class ActivityLogEntry
+{
+    public int Id { get; set; }
+    public DateTimeOffset Date { get; set; }
+    public string UserName { get; set; }
+    public string Action { get; set; }
+    public string Details { get; set; }
+}
+
+/// <summary>
+/// Top-level model for the activity log Vue page.
+/// Server handles paging; Vue renders the current page and builds navigation URLs.
+/// </summary>
+public class ActivityLogPageModel
+{
+    public List<ActivityLogEntry> Entries { get; set; }
+    public int Page { get; set; }
+    public int TotalPages { get; set; }
+}

--- a/m4d/ViewModels/SearchesPageModel.cs
+++ b/m4d/ViewModels/SearchesPageModel.cs
@@ -1,0 +1,41 @@
+namespace m4d.ViewModels;
+
+/// <summary>
+/// Safe-to-serialize projection of a single Search entry for the admin searches index page.
+/// URLs are pre-built server-side since they require SongFilter serialization.
+/// </summary>
+public class SearchSummary
+{
+    public long Id { get; set; }
+    public string UserName { get; set; }
+    public string Query { get; set; }
+    public string Description { get; set; }
+    public string SearchUrl { get; set; }
+    public string SearchPageUrl { get; set; }
+    public int? MostRecentPage { get; set; }
+    public int Count { get; set; }
+    public DateTime Created { get; set; }
+    public DateTime Modified { get; set; }
+    public string Spotify { get; set; }
+    public string DeleteUrl { get; set; }
+}
+
+/// <summary>
+/// Top-level model for the searches Vue page.
+/// Server handles paging; Vue renders the current page and builds navigation URLs.
+/// </summary>
+public class SearchesPageModel
+{
+    public List<SearchSummary> Searches { get; set; }
+    public int Page { get; set; }
+    public int TotalPages { get; set; }
+    public string Sort { get; set; }
+    public bool ShowDetails { get; set; }
+    public bool SpotifyOnly { get; set; }
+    public string User { get; set; }
+    public bool IsAdmin { get; set; }
+    public bool CanDeleteAll { get; set; }
+    public string BasicSearchUrl { get; set; }
+    public string AdvancedSearchUrl { get; set; }
+    public string DeleteAllUrl { get; set; }
+}

--- a/m4d/Views/ActivityLog/Index.cshtml
+++ b/m4d/Views/ActivityLog/Index.cshtml
@@ -4,6 +4,8 @@
 
 @{
     ViewBag.Title = "Activity Log";
+    var page = ViewData.ContainsKey("Page") ? (int)ViewBag.Page : 1;
+    var totalPages = ViewData.ContainsKey("TotalPages") ? (int)ViewBag.TotalPages : 1;
 
     ViewData["BreadCrumbs"] = new List<BreadCrumbItem>
     {
@@ -21,3 +23,44 @@
 <div class="row">
 	<partial name="_ActivityLog" model="Model" />
 </div>
+
+@if (totalPages > 1)
+{
+    const int wingSize = 2;
+    var winStart = Math.Max(2, page - wingSize);
+    var winEnd   = Math.Min(totalPages - 1, page + wingSize);
+    Func<int, string> pageUrl = p => Url.Action("Index", "ActivityLog", new { page = p })!;
+
+    <nav aria-label="Activity log pages" class="mt-3">
+        <ul class="pagination pagination-sm flex-wrap">
+            <li class="page-item @(page == 1 ? "disabled" : "")">
+                @if (page > 1) { <a class="page-link" href="@pageUrl(page - 1)">&laquo;</a> }
+                else            { <span class="page-link">&laquo;</span> }
+            </li>
+            <li class="page-item @(page == 1 ? "active" : "")">
+                <a class="page-link" href="@pageUrl(1)">1</a>
+            </li>
+            @if (winStart > 2)
+            {
+                <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+            }
+            @for (var i = winStart; i <= winEnd; i++)
+            {
+                <li class="page-item @(i == page ? "active" : "")">
+                    <a class="page-link" href="@pageUrl(i)">@i</a>
+                </li>
+            }
+            @if (winEnd < totalPages - 1)
+            {
+                <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+            }
+            <li class="page-item @(page == totalPages ? "active" : "")">
+                <a class="page-link" href="@pageUrl(totalPages)">@totalPages</a>
+            </li>
+            <li class="page-item @(page == totalPages ? "disabled" : "")">
+                @if (page < totalPages) { <a class="page-link" href="@pageUrl(page + 1)">&raquo;</a> }
+                else                    { <span class="page-link">&raquo;</span> }
+            </li>
+        </ul>
+    </nav>
+}

--- a/m4d/Views/Searches/Index.cshtml
+++ b/m4d/Views/Searches/Index.cshtml
@@ -13,6 +13,8 @@ var spotifyOnly = ViewData.ContainsKey("SpotifyOnly") ? ViewBag.SpotifyOnly : fa
 var popularClass = !string.Equals(sort, "recent") ? "btn btn-primary" : "btn btn-outline-primary";
 var recentClass = string.Equals(sort, "recent") ? "btn btn-primary" : "btn btn-outline-primary";
 var userName = ViewBag.User;
+var page = ViewData.ContainsKey("Page") ? (int)ViewBag.Page : 1;
+var totalPages = ViewData.ContainsKey("TotalPages") ? (int)ViewBag.TotalPages : 1;
 
 ViewData["BreadCrumbs"] = new List<BreadCrumbItem>
 {
@@ -121,4 +123,46 @@ ViewData["BreadCrumbs"] = new List<BreadCrumbItem>
     })
     </div>
 </div>
+}
+
+@if (totalPages > 1)
+{
+    const int wingSize = 2;
+    var winStart = Math.Max(2, page - wingSize);
+    var winEnd   = Math.Min(totalPages - 1, page + wingSize);
+    Func<int, string> pageUrl = p => Url.Action("Index", "Searches",
+        new { user = userName, sort, showDetails, spotifyOnly, page = p })!;
+
+    <nav aria-label="Search history pages" class="mt-3">
+        <ul class="pagination pagination-sm flex-wrap">
+            <li class="page-item @(page == 1 ? "disabled" : "")">
+                @if (page > 1) { <a class="page-link" href="@pageUrl(page - 1)">&laquo;</a> }
+                else            { <span class="page-link">&laquo;</span> }
+            </li>
+            <li class="page-item @(page == 1 ? "active" : "")">
+                <a class="page-link" href="@pageUrl(1)">1</a>
+            </li>
+            @if (winStart > 2)
+            {
+                <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+            }
+            @for (var i = winStart; i <= winEnd; i++)
+            {
+                <li class="page-item @(i == page ? "active" : "")">
+                    <a class="page-link" href="@pageUrl(i)">@i</a>
+                </li>
+            }
+            @if (winEnd < totalPages - 1)
+            {
+                <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+            }
+            <li class="page-item @(page == totalPages ? "active" : "")">
+                <a class="page-link" href="@pageUrl(totalPages)">@totalPages</a>
+            </li>
+            <li class="page-item @(page == totalPages ? "disabled" : "")">
+                @if (page < totalPages) { <a class="page-link" href="@pageUrl(page + 1)">&raquo;</a> }
+                else                    { <span class="page-link">&raquo;</span> }
+            </li>
+        </ul>
+    </nav>
 }


### PR DESCRIPTION
## Summary

Completes the admin pages performance initiative:

- **Phase 2** — `PlayList/Index` → Vue (client-side filtering/sorting/pagination)
- **Phases 3–4** — `Searches/Index` and `ActivityLog/Index` server-side pagination (DB-level `Skip`/`Take`)
- **Phase 5** — `Searches/Index` and `ActivityLog/Index` → Vue (server-supplied JSON, `BPagination` + page-jump input)
- **PageFrame** — all four admin Vue pages (`admin-users`, `playlist`, `searches`, `activity-log`) now use `<PageFrame>` for consistent nav/header/footer chrome

—

## Changes

### Phase 2 — PlayList/Index Vue conversion

**New files**

- `m4d/ViewModels/PlayListPageModel.cs` — `PlayListSummary` + `PlayListPageModel` C# DTOs
- `m4d/ClientApp/src/pages/playlist/App.vue` — Vue page
- `m4d/ClientApp/src/pages/playlist/PlayListPageModel.ts` — TypedJSON model
- `m4d/ClientApp/src/pages/playlist/__tests__/playlist.test.ts` — 23 Vitest tests

**Modified**

- `m4d/Controllers/PlayListController.cs` — `Index()` maps to DTOs, calls `Vue3()`; `BulkCreate()` redirects to `Index`
- `m4d/Views/PlayList/Index.cshtml` — deleted (replaced by Vue page)
- `m4d/ClientApp/src/pages/admin-users/App.vue` — fixed `playlistsUrl` bug (was passing `type=0`)

### Phases 3–4 — Server-side pagination (Razor)

Intermediate step, now superseded by Phase 5 Vue pages. Kept for rollback safety.

- `m4d/Views/Searches/Index.cshtml` — windowed pagination nav added
- `m4d/Views/ActivityLog/Index.cshtml` — windowed pagination nav added

### Phase 5 — Searches/Index and ActivityLog/Index Vue conversion

**New files**

- `m4d/ViewModels/SearchesPageModel.cs` — `SearchSummary` + `SearchesPageModel` C# DTOs
- `m4d/ViewModels/ActivityLogPageModel.cs` — `ActivityLogEntry` + `ActivityLogPageModel` C# DTOs
- `m4d/ClientApp/src/pages/searches/App.vue` + `SearchesPageModel.ts` + `__tests__/`
- `m4d/ClientApp/src/pages/activity-log/App.vue` + `ActivityLogPageModel.ts` + `__tests__/`

**Modified**

- `m4d/Controllers/SearchesController.cs`
  - `Index()` now accepts `int page = 1`; paginates at DB level (page size 100)
  - Projects `Search` → `SearchSummary` using `Url.Action()` for per-row URLs
  - Returns `Vue3("My Searches", "Search history", "searches", viewModel)`
  - Fixed variable name collision (`var searchSummaries`) and null-safe `Filter?.ToString()`
- `m4d/Controllers/ActivityLogController.cs`
  - `Index()` now accepts `int page = 1`; paginates at DB level (page size 100)
  - Returns `Vue3("Activity Log", "Admin: Activity log", "activity-log", viewModel)`

### PageFrame additions

- `m4d/ClientApp/src/pages/admin-users/App.vue` — replaced `<div class="container-fluid">` + `<h2>` + `<hr>` with `<PageFrame id="app" title="User Administrator">`
- `m4d/ClientApp/src/pages/playlist/App.vue` — replaced `<div>` + `<h2>` with `<PageFrame id="app" :title="pageTitle">` (dynamic title via `computed`)

### Tests

- `m4d.Tests/Controllers/SearchesControllerTests.cs`
  - `CreateController()` now mocks `IUrlHelper` so `Url.Action()` calls don’t throw
  - New test: `Index_PaginatesResults_WhenMoreThanPageSizeExists`
  - Assertions updated for `VueModel` → `SearchesPageModel` unwrapping
- Snapshots regenerated: `searches`, `activity-log`, `admin-users`, `playlist`

### Documentation

- `.github/copilot-instructions.md` — added PageFrame requirement for all Vue page apps
- `architecture/admin-pages-performance.md` — updated for BPagination style, Spotify toggle fix, PageFrame, test selector note

—

## Bug fixes

**Spotify Only toggle** (`searches/App.vue`)

Vue 3 templates do not expose `window`. The inline `@change="window.location.href = ..."` was
silently a no-op. Fixed by extracting `function onSpotifyToggle()` in `<script setup>`.

—

## Pagination style

Server-paged pages (Searches, ActivityLog) use `BPagination` + page-jump input matching `SongFooter.vue`:

```vue
<BRow v-if="model.totalPages > 1" class="mt-3">
  <BCol md="8">
    <BPagination v-model="editPageNumber" :total-rows="model.totalPages" :per-page="1"
      limit="9" first-number last-number @page-click="onPageClick" />
  </BCol>
  <BCol md="4">
    Page <input v-model.number="editPageNumber" type="number" @keydown.enter="goToPage" @blur="goToPage" />
    of {{ model.totalPages }}
  </BCol>
</BRow>
```

`@page-click` intercepts BVN’s internal routing and sets `window.location.href` to the
server-rendered URL for the selected page.

—

## Test results

- **Server**: 562 tests passing (SelfCrawler excluded)
- **Client**: 27 tests passing

—

## Checklist

- [x] All four admin Vue pages use PageFrame
- [x] PlayList/Index fully converted to Vue
- [x] Searches/Index fully converted to Vue
- [x] ActivityLog/Index fully converted to Vue
- [x] Spotify Only toggle works
- [x] Pagination style consistent with SongFooter.vue
- [x] Server-side tests + pagination integration test passing
- [x] Client snapshot tests regenerated + passing
- [x] Architecture doc updated
- [x] copilot-instructions.md updated with PageFrame rule

## Related

- Phase 1: PR #174 — Admin Users Page Vue SPA Rewrite
- Architecture doc: `architecture/admin-pages-performance.md`
