### PR TITLE
Database Reconnection Recovery (Phase 7)

### DIFF
--- a/architecture/service-resilience-phase7-completion-report.md
+++ b/architecture/service-resilience-phase7-completion-report.md
@@ -1,0 +1,146 @@
+# Service Resilience Phase 7: Database Reconnection Recovery
+
+**Date**: June 2, 2026
+**Status**: ✅ COMPLETE
+**Branch**: database-resiliency
+
+## Overview
+
+Phase 7 implements automatic database reconnection for the scenario where the app and an on-demand Azure SQL database start simultaneously: the app comes up first, the DB takes 20–45 seconds to wake, migrations fail, and the app has been running in degraded mode ever since. This phase adds a lightweight recovery mechanism that detects when the DB becomes reachable again on the next user request and re-runs deferred initialisation — all without restarting the app.
+
+## Problem Statement
+
+The Azure test instance uses on-demand SQL: both the App Service and the database wake up together when the first request arrives. Because migrations run synchronously during startup, the app marks `Database` as `Unavailable` and continues in degraded mode. Previously, the only way to recover was a manual app restart.
+
+Secondary: mid-request `SqlException` / `Win32Exception` from `UserMetadata.Create` was unhandled, producing the ASP.NET developer exception page rather than a graceful degraded response.
+
+## Implementation
+
+### New: `DatabaseRecoveryService`
+
+**File**: `m4d/Services/DatabaseRecoveryService.cs`
+
+A singleton service that:
+
+1. **`TriggerRecoveryIfNeeded()`** — called on every user request via pipeline middleware. Does nothing if the database is `Healthy` or `Unknown`. Re-reads the current connection string from `IConfiguration` on every call (so `appsettings.json` edits mid-run are picked up). Applies a configurable throttle (default 1 minute) to avoid hammering a still-down server. Fires `AttemptRecoveryAsync` as a background `Task.Run` — the user request is never delayed.
+
+2. **`AttemptRecoveryAsync(string connectionString)`** — guarded by a `SemaphoreSlim(1,1)` to prevent concurrent attempts. Builds a fresh `DbContextOptions` with `ConnectTimeout=60` (no `EnableRetryOnFailure` — single fast probe). Calls `Database.CanConnectAsync()`. On success: marks `Database` healthy immediately, then creates a DI scope and runs `DanceStatsInstance.FixupStats` to complete the deferred startup work. A `FixupStats` failure does not undo the healthy mark — the DB is connectable and individual operations can proceed.
+
+**Throttle interval** is read from `ServiceHealth:DatabaseRetryInterval` (default `00:01:00`).
+
+### Middleware registration (`Program.cs`)
+
+```csharp
+var dbRecoveryService = app.Services.GetRequiredService<DatabaseRecoveryService>();
+app.Use(async (context, next) =>
+{
+    dbRecoveryService.TriggerRecoveryIfNeeded();
+    await next();
+});
+```
+
+The middleware sits early in the pipeline (after `UseRouting`, before authentication) so it fires on every request, including anonymous ones.
+
+`DatabaseRecoveryService` itself is registered as a singleton:
+
+```csharp
+services.AddSingleton<DatabaseRecoveryService>();
+```
+
+### Live connection string reload (`Program.cs`)
+
+`AddDbContext` now uses the `(IServiceProvider, DbContextOptionsBuilder)` factory overload so the connection string is re-read from `IConfiguration` on every context resolution:
+
+```csharp
+services.AddDbContext<DanceMusicContext>((sp, options) =>
+{
+    var cfg = sp.GetRequiredService<IConfiguration>();
+    var liveConnStr = cfg["AZURE_SQL_CONNECTIONSTRING"]
+        ?? cfg.GetConnectionString("DanceMusicContextConnection")
+        ?? connectionString;  // fallback to startup value
+    options.UseSqlServer(liveConnStr, sqlOptions =>
+    {
+        sqlOptions.EnableRetryOnFailure(maxRetryCount: 5, ...);
+        sqlOptions.CommandTimeout(60);
+    });
+});
+```
+
+`IConfiguration` reads from in-memory dictionaries (populated from `appsettings.json` via the file-watcher), so the per-resolution cost is a dictionary key lookup — negligible. This is what allows the recovery service's fresh `DanceMusicContext` scope to use the updated connection string without an app restart.
+
+### `UserMetadata.Create` exception handling (`DMController.cs` + `UserMetadata.cs`)
+
+`UserMetadata.Create` calls `UserManager.FindByNameAsync`, which hits the DB. When the DB is down this throws `SqlException` / `Win32Exception`. Previously this produced an unhandled exception page.
+
+Fix: added a catch in `DanceMusicController.OnActionExecutionAsync`:
+
+```csharp
+UserMetadata userMetadata;
+try
+{
+    userMetadata = await UserMetadata.Create(UserName, UserManager);
+}
+catch (Exception ex) when (ex is SqlException || ex is Win32Exception ||
+                           ex.InnerException is SqlException ||
+                           ex.InnerException is Win32Exception)
+{
+    ServiceHealth?.MarkUnavailable("Database", $"{ex.GetType().Name}: {ex.Message}");
+    userMetadata = UserMetadata.Anonymous;
+}
+ViewData["UserMetadata"] = userMetadata;
+```
+
+`UserMetadata.Anonymous` is a new static factory (added to `UserMetadata.cs`) that returns a null-user instance — the same safe object the code already produces for unauthenticated visitors:
+
+```csharp
+public static UserMetadata Anonymous => new UserMetadata(null, null);
+```
+
+Execution continues through `OnActionExecutionAsync` normally, so the controller action fires, the service-status banner renders, and the user sees a meaningful degraded page rather than an error screen. The catch also calls `MarkUnavailable`, feeding the recovery trigger so the next request will attempt reconnection.
+
+## Configuration
+
+```json
+"ServiceHealth": {
+  "DatabaseRetryInterval": "00:01:00"
+}
+```
+
+For local testing, set to a shorter interval such as `"00:00:15"`.
+
+## Log Messages
+
+| Level  | Message                                                                                   |
+| ------ | ----------------------------------------------------------------------------------------- |
+| `Info` | `DatabaseRecoveryService initialised (retry interval: 00:01:00)`                          |
+| `Info` | `Database recovery: attempting reconnection...`                                           |
+| `Info` | `Database recovery: connection restored in 7656ms – running post-recovery initialisation` |
+| `Info` | `Database recovery: post-recovery FixupStats completed`                                   |
+| `Info` | `Database recovery: probe failed after 5001ms – <error>`                                  |
+| `Warn` | `Database recovery: post-recovery FixupStats failed (database still healthy): <error>`    |
+| `Warn` | `Database recovery: DanceStatsManager.Instance is null – skipping FixupStats`             |
+
+## Files Changed
+
+| File                                      | Change                                                                        |
+| ----------------------------------------- | ----------------------------------------------------------------------------- |
+| `m4d/Services/DatabaseRecoveryService.cs` | **New** — reconnection service                                                |
+| `m4d/Program.cs`                          | Register singleton + middleware; change `AddDbContext` to factory overload    |
+| `m4d/Controllers/DMController.cs`         | Catch DB exceptions in `OnActionExecutionAsync`, use `UserMetadata.Anonymous` |
+| `m4d/ViewModels/UserMetadata.cs`          | Add `Anonymous` static factory                                                |
+| `m4d/appsettings.json`                    | Add `ServiceHealth:DatabaseRetryInterval` config key                          |
+
+## Testing
+
+### Local test procedure
+
+1. Set `DanceMusicContextConnection` to a nonexistent server (e.g. `Server=nonexistent-server.invalid;Connect Timeout=5;...`) and start the app.
+2. Verify: app starts, pages render in degraded mode (service status banner visible), no exception page.
+3. While the app is running, restore the connection string to `(localdb)\\mssqllocaldb;Database=m4d;...`.
+4. Hit any page — within `DatabaseRetryInterval` the recovery fires in the background.
+5. Check logs for "connection restored" and "FixupStats completed".
+6. Subsequent page loads work fully.
+
+### Azure cold-start scenario
+
+On the Azure test instance, the `ConnectTimeout=60` in the probe context gives the SQL database enough time to wake (typically 20–45 s). The user sees a degraded page on the first request; within one retry interval after the DB becomes reachable the app self-heals.

--- a/architecture/service-resilience-plan.md
+++ b/architecture/service-resilience-plan.md
@@ -13,7 +13,6 @@ Based on code analysis, the site depends on the following external services:
 ### Critical Services (Required for Core Functionality)
 
 1. **SQL Server Database** (`DanceMusicContextConnection`)
-
    - Connection string: SQL Server connection
    - Used for: User accounts, song data, playlists, dance information, voting
    - Impact if down: Cannot retrieve or store any data
@@ -22,7 +21,6 @@ Based on code analysis, the site depends on the following external services:
    - Target behavior: Application starts successfully, serves cached/static content
 
 2. **Azure App Configuration**
-
    - Endpoint: `https://music4dance.azconfig.io`
    - Used for: Feature flags, configuration refresh, Key Vault integration
    - Impact if down: Cannot load feature flags or dynamic configuration
@@ -38,14 +36,12 @@ Based on code analysis, the site depends on the following external services:
 ### Authentication Services (Optional but Important)
 
 4. **Google OAuth**
-
    - ClientId/ClientSecret required
    - Used for: User authentication via Google
    - Impact if down: Users cannot log in with Google
    - Current behavior: Login page shows option but fails on click
 
 5. **Facebook OAuth**
-
    - ClientId/ClientSecret required
    - Used for: User authentication via Facebook
    - Impact if down: Users cannot log in with Facebook
@@ -60,14 +56,12 @@ Based on code analysis, the site depends on the following external services:
 ### Supporting Services
 
 7. **Azure Communication Services**
-
    - ConnectionString required
    - Used for: Email sending (confirmation emails, notifications)
    - Impact if down: Users cannot receive confirmation emails
    - Current behavior: Likely throws exception when trying to send email
 
 8. **reCAPTCHA v2**
-
    - SiteKey/SecretKey required
    - Used for: Bot prevention on registration/forms
    - Impact if down: Forms may be vulnerable to spam, or may block legitimate users
@@ -531,7 +525,6 @@ Frontend Work:
 **Final Tasks Before Completion**:
 
 1. ✅ **Email Notifications on First Service Failure** (Section 5.2)
-
    - Send email to configured admin addresses on initial service failure
    - Track notification state to prevent duplicate emails
    - Use existing Azure Communication Services (same as password resets)
@@ -552,6 +545,33 @@ Frontend Work:
 - ✅ Update warning banner automatically refreshes with health polling
 - ✅ Unified status communication system (service health + manual updates)
 
+### Phase 6: Azure Search Credential Error Handling ✅ COMPLETE
+
+See [Phase 6 Completion Report](service-resilience-phase6-completion-report.md) for full details.
+
+### Phase 7: Database Reconnection Recovery ✅ COMPLETE
+
+**Scope**: Automatic self-healing when the database is unavailable at startup (Azure on-demand SQL cold-start scenario).
+
+**Problem Statement**: On the Azure test instance, both the App Service and the SQL database wake on-demand. The app starts first, migration fails, and `Database` is marked `Unavailable`. Previously the only recovery was a manual app restart.
+
+**Implementation**:
+
+- ✅ **`DatabaseRecoveryService`** (`m4d/Services/DatabaseRecoveryService.cs`) — singleton that fires a background reconnection probe on each user request, throttled to at most once per `ServiceHealth:DatabaseRetryInterval` (default 1 minute). On success, marks DB healthy and runs deferred `FixupStats` initialisation.
+- ✅ **Request pipeline middleware** — `TriggerRecoveryIfNeeded()` called early in the pipeline; never blocks the user request (fire-and-forget `Task.Run`).
+- ✅ **Live connection string reload** — `AddDbContext` now uses the `(IServiceProvider, options)` factory overload so the connection string is re-read from `IConfiguration` on every context resolution. Enables mid-run `appsettings.json` updates to be picked up without a restart (cost: one `ConcurrentDictionary` lookup per request scope — negligible).
+- ✅ **`UserMetadata.Create` exception handling** — `DanceMusicController.OnActionExecutionAsync` now catches `SqlException` / `Win32Exception`, marks DB unavailable, and continues with `UserMetadata.Anonymous` rather than producing an error page.
+- ✅ **`UserMetadata.Anonymous`** — new static factory on `UserMetadata` that returns a null-user instance (identical to an unauthenticated visitor) for use when the DB is down.
+
+**Key Deliverables**:
+
+- ✅ App self-heals from startup DB failure within one retry interval after DB becomes reachable
+- ✅ No app restart required
+- ✅ DB exceptions during `OnActionExecutionAsync` produce degraded pages, not error screens
+- ✅ Live connection string changes picked up automatically by all new scoped contexts
+
+**Configuration**: `ServiceHealth:DatabaseRetryInterval` (default `"00:01:00"`). See [Phase 7 Completion Report](service-resilience-phase7-completion-report.md).
+
 ### Phase 5: Static Cache Fallback ✅ COMPLETE
 
 **Scope**: Ensure resilience during fresh deployments by maintaining static JSON cache in source control.
@@ -561,13 +581,11 @@ Frontend Work:
 **Implementation Tasks**:
 
 1. ✅ **Create Static Cache Directory Structure**
-
    - Add `m4d/ClientApp/public/cache/` directory to source control
    - Store fallback versions of critical JSON data files
    - Include in build output for deployment
 
 2. ✅ **Export Current Data to Static Cache Files**
-
    - Generate fallback JSON files from current database
    - Dance database fallback (~29 KB)
    - Tag database fallback (~164 KB)
@@ -575,7 +593,6 @@ Frontend Work:
    - Metrics fallback (~3 KB)
 
 3. ✅ **Update Frontend to Use Static Fallback**
-
    - Created `LoadDanceDatabase.ts` helper with three-tier fallback chain
    - Fallback order: Live API → Runtime cache → Static fallback
    - Console logging when falling back to static cache

--- a/m4d/Controllers/DMController.cs
+++ b/m4d/Controllers/DMController.cs
@@ -42,7 +42,19 @@ public class DanceMusicController(
         ActionExecutingContext context, ActionExecutionDelegate next)
     {
         // Create UserMetadata early (needed for both tracking modes)
-        var userMetadata = await UserMetadata.Create(UserName, UserManager);
+        UserMetadata userMetadata;
+        try
+        {
+            userMetadata = await UserMetadata.Create(UserName, UserManager);
+        }
+        catch (Exception ex) when (ex is Microsoft.Data.SqlClient.SqlException ||
+                                   ex is System.ComponentModel.Win32Exception ||
+                                   (ex.InnerException is Microsoft.Data.SqlClient.SqlException) ||
+                                   (ex.InnerException is System.ComponentModel.Win32Exception))
+        {
+            ServiceHealth?.MarkUnavailable("Database", $"{ex.GetType().Name}: {ex.Message}");
+            userMetadata = UserMetadata.Anonymous;
+        }
         ViewData["UserMetadata"] = userMetadata;
 
         // Check if client-side tracking is enabled early to avoid setting cookies

--- a/m4d/Controllers/DMController.cs
+++ b/m4d/Controllers/DMController.cs
@@ -38,6 +38,16 @@ public class DanceMusicController(
 
     private MusicServiceManager _musicServiceManager;
 
+    // Walk the full exception chain so EF-wrapped SqlException/Win32Exception
+    // at any nesting depth are caught and treated as a DB connectivity failure.
+    private static bool ContainsDatabaseException(Exception ex)
+    {
+        for (var e = ex; e != null; e = e.InnerException)
+            if (e is Microsoft.Data.SqlClient.SqlException || e is System.ComponentModel.Win32Exception)
+                return true;
+        return false;
+    }
+
     public override async Task OnActionExecutionAsync(
         ActionExecutingContext context, ActionExecutionDelegate next)
     {
@@ -47,10 +57,7 @@ public class DanceMusicController(
         {
             userMetadata = await UserMetadata.Create(UserName, UserManager);
         }
-        catch (Exception ex) when (ex is Microsoft.Data.SqlClient.SqlException ||
-                                   ex is System.ComponentModel.Win32Exception ||
-                                   (ex.InnerException is Microsoft.Data.SqlClient.SqlException) ||
-                                   (ex.InnerException is System.ComponentModel.Win32Exception))
+        catch (Exception ex) when (ContainsDatabaseException(ex))
         {
             ServiceHealth?.MarkUnavailable("Database", $"{ex.GetType().Name}: {ex.Message}");
             userMetadata = UserMetadata.Anonymous;

--- a/m4d/Program.cs
+++ b/m4d/Program.cs
@@ -368,8 +368,17 @@ else
 {
     try
     {
-        services.AddDbContext<DanceMusicContext>(options =>
-            options.UseSqlServer(connectionString, sqlOptions =>
+        services.AddDbContext<DanceMusicContext>((sp, options) =>
+        {
+            // Re-read the connection string from IConfiguration on every context
+            // resolution so that mid-run appsettings changes (e.g. the database
+            // recovery scenario where the connection string is updated while the
+            // app is running) are picked up by new scoped contexts automatically.
+            var cfg = sp.GetRequiredService<IConfiguration>();
+            var liveConnStr = cfg["AZURE_SQL_CONNECTIONSTRING"]
+                ?? cfg.GetConnectionString("DanceMusicContextConnection")
+                ?? connectionString;
+            options.UseSqlServer(liveConnStr, sqlOptions =>
             {
                 sqlOptions.EnableRetryOnFailure(
                     maxRetryCount: 5,
@@ -378,7 +387,8 @@ else
                 // Set command timeout to 60 seconds to handle Azure SQL cold starts
                 // Default is 30s which can timeout when database is warming up
                 sqlOptions.CommandTimeout(60);
-            }));
+            });
+        });
         // Note: Database health is marked healthy after migrations run synchronously
         // later in startup (or after the first successful FixupStats DB access).
         // It is intentionally not marked healthy here at registration time.
@@ -563,6 +573,8 @@ services.AddAutoMapper(
 
 services.AddViteServices();
 
+services.AddSingleton<DatabaseRecoveryService>();
+
 services.AddHostedService<DanceStatsHostedService>();
 services.AddHostedService<StartupInitializationService>();
 
@@ -731,6 +743,16 @@ else
 
 app.UseHttpLogging();
 app.UseRouting();
+
+// Database recovery: when the DB was unavailable at startup (e.g., Azure on-demand SQL still
+// waking up), attempt a reconnection on user requests.  The attempt is fire-and-forget and
+// throttled by ServiceHealth:DatabaseRetryInterval so it never delays the caller.
+var dbRecoveryService = app.Services.GetRequiredService<DatabaseRecoveryService>();
+app.Use(async (context, next) =>
+{
+    dbRecoveryService.TriggerRecoveryIfNeeded();
+    await next();
+});
 
 // Configure forwarded headers for Azure Front Door
 // This must come before authentication to ensure RemoteIpAddress is correct

--- a/m4d/Services/DatabaseRecoveryService.cs
+++ b/m4d/Services/DatabaseRecoveryService.cs
@@ -1,0 +1,219 @@
+#nullable enable
+
+using System.Diagnostics;
+using m4d.Services.ServiceHealth;
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+
+namespace m4d.Services;
+
+/// <summary>
+/// Handles reconnection attempts when the database becomes unavailable at startup.
+///
+/// Typical scenario: the Azure test instance (both app and DB are on-demand) receives a
+/// request while the SQL server is still waking up. The startup health check fails and
+/// marks the database unavailable. This service retries the connection on each subsequent
+/// user request, throttled to at most once per <c>ServiceHealth:DatabaseRetryInterval</c>
+/// (default 1 minute).
+///
+/// The reconnection attempt is fire-and-forget so it never delays the user's request.
+/// On success it marks the database healthy and re-runs the deferred FixupStats
+/// initialisation that was skipped during startup.
+/// </summary>
+public class DatabaseRecoveryService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ServiceHealthManager _serviceHealth;
+    private readonly ILogger<DatabaseRecoveryService> _logger;
+    private readonly IConfiguration _configuration;
+    private readonly TimeSpan _retryInterval;
+
+    // Semaphore ensures at most one recovery attempt runs at a time.
+    private readonly SemaphoreSlim _retryLock = new(1, 1);
+
+    // Best-effort throttle: set before the attempt starts so concurrent callers
+    // see the updated time immediately; the semaphore protects actual execution.
+    private volatile int _lastRetryTicks = 0; // Interlocked-safe DateTime.UtcNow.Ticks truncated to int32 range
+
+    // Store full ticks as long for accuracy
+    private long _lastRetryUtcTicks = 0;
+
+    public DatabaseRecoveryService(
+        IServiceProvider serviceProvider,
+        ServiceHealthManager serviceHealth,
+        IConfiguration configuration,
+        ILogger<DatabaseRecoveryService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _serviceHealth = serviceHealth;
+        _logger = logger;
+        _configuration = configuration;
+
+        var intervalStr = configuration["ServiceHealth:DatabaseRetryInterval"] ?? "00:01:00";
+        _retryInterval = TimeSpan.TryParse(intervalStr, out var parsed) ? parsed : TimeSpan.FromMinutes(1);
+
+        _logger.LogInformation("DatabaseRecoveryService initialised (retry interval: {Interval})", _retryInterval);
+    }
+
+    /// <summary>
+    /// Call on every user request (cheap when the database is healthy).
+    /// If the database is unavailable and the retry throttle has elapsed, a
+    /// background reconnection attempt is started without blocking the caller.
+    /// </summary>
+    public void TriggerRecoveryIfNeeded()
+    {
+        // Fast-path: nothing to do when database is healthy or unknown
+        var status = _serviceHealth.GetServiceStatus("Database");
+        if (status.Status != ServiceStatus.Unavailable)
+            return;
+
+        // No connection string configured → recovery is impossible (re-read each time so
+        // appsettings changes mid-run are picked up, useful for local testing)
+        var connectionString = _configuration["AZURE_SQL_CONNECTIONSTRING"]
+            ?? _configuration.GetConnectionString("DanceMusicContextConnection");
+        if (string.IsNullOrEmpty(connectionString))
+            return;
+
+        // Throttle check (non-atomic read is intentional – best-effort only)
+        var elapsed = TimeSpan.FromTicks(DateTime.UtcNow.Ticks - Interlocked.Read(ref _lastRetryUtcTicks));
+        if (elapsed < _retryInterval)
+            return;
+
+        // Fire-and-forget: never blocks the user request
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await AttemptRecoveryAsync(connectionString);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error in database recovery background task");
+            }
+        });
+    }
+
+    // ---------------------------------------------------------------------------
+    // Private helpers
+    // ---------------------------------------------------------------------------
+
+    private async Task AttemptRecoveryAsync(string connectionString)
+    {
+        // Allow only one concurrent attempt; others return immediately
+        if (!await _retryLock.WaitAsync(0))
+        {
+            _logger.LogDebug("Database recovery skipped – another attempt is already in progress");
+            return;
+        }
+
+        try
+        {
+            // Update the throttle timestamp now (inside the lock) so that the
+            // next TriggerRecoveryIfNeeded call sees an up-to-date value whether
+            // or not this attempt succeeds.
+            Interlocked.Exchange(ref _lastRetryUtcTicks, DateTime.UtcNow.Ticks);
+
+            _logger.LogInformation("Database recovery: attempting reconnection...");
+
+            // --- Connectivity test -------------------------------------------------
+            // Build a fresh connection string with an extended Connect Timeout so that
+            // Azure SQL on-demand gets enough time to wake up (typically 20-45 s).
+            string testConnStr;
+            try
+            {
+                var csb = new SqlConnectionStringBuilder(connectionString)
+                {
+                    ConnectTimeout = 60   // seconds; overrides whatever is in the stored string
+                };
+                testConnStr = csb.ConnectionString;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("Database recovery: could not parse connection string – {Error}", ex.Message);
+                return;
+            }
+
+            var testOptions = new DbContextOptionsBuilder<DanceMusicContext>()
+                .UseSqlServer(testConnStr, o =>
+                {
+                    o.CommandTimeout(60);
+                    // No EnableRetryOnFailure here – we want a single fast-fail probe
+                })
+                .Options;
+
+            bool canConnect;
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                using var testContext = new DanceMusicContext(testOptions);
+                canConnect = await testContext.Database.CanConnectAsync();
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                _logger.LogInformation(
+                    "Database recovery: probe failed after {Elapsed}ms – {Error}",
+                    sw.ElapsedMilliseconds, ex.Message);
+                return;
+            }
+
+            sw.Stop();
+
+            if (!canConnect)
+            {
+                _logger.LogInformation(
+                    "Database recovery: probe returned false after {Elapsed}ms", sw.ElapsedMilliseconds);
+                return;
+            }
+
+            _logger.LogInformation(
+                "Database recovery: connection restored in {Elapsed}ms – running post-recovery initialisation",
+                sw.ElapsedMilliseconds);
+
+            // Mark healthy immediately so controllers start serving real content.
+            // FixupStats below will re-confirm (and re-mark unavailable on failure).
+            _serviceHealth.MarkHealthy("Database", sw.Elapsed);
+
+            // --- Post-recovery FixupStats ------------------------------------------
+            // Re-run the DB-dependent portion of DanceStatsInstance.FixupStats that
+            // was skipped during startup when the DB was unavailable.
+            try
+            {
+                using var scope = _serviceProvider.CreateScope();
+                var sp = scope.ServiceProvider;
+
+                var context = sp.GetRequiredService<DanceMusicContext>();
+                var userManager = sp.GetRequiredService<UserManager<ApplicationUser>>();
+                var searchService = sp.GetRequiredService<ISearchServiceManager>();
+                var statsManager = sp.GetRequiredService<IDanceStatsManager>();
+
+                if (statsManager.Instance != null)
+                {
+                    var dms = new DanceMusicService(context, userManager, searchService, statsManager);
+                    await statsManager.Instance.FixupStats(dms, _serviceHealth);
+                    _logger.LogInformation("Database recovery: post-recovery FixupStats completed");
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "Database recovery: DanceStatsManager.Instance is null – skipping FixupStats; " +
+                        "stats will be initialised when the next admin cache refresh runs");
+                }
+            }
+            catch (Exception ex)
+            {
+                // A FixupStats failure does not undo the healthy mark – the DB itself
+                // is connectable; individual operations may still succeed.
+                _logger.LogWarning(ex,
+                    "Database recovery: post-recovery FixupStats failed (database still healthy): {Error}",
+                    ex.Message);
+            }
+        }
+        finally
+        {
+            _retryLock.Release();
+        }
+    }
+}

--- a/m4d/Services/DatabaseRecoveryService.cs
+++ b/m4d/Services/DatabaseRecoveryService.cs
@@ -33,11 +33,8 @@ public class DatabaseRecoveryService
     // Semaphore ensures at most one recovery attempt runs at a time.
     private readonly SemaphoreSlim _retryLock = new(1, 1);
 
-    // Best-effort throttle: set before the attempt starts so concurrent callers
-    // see the updated time immediately; the semaphore protects actual execution.
-    private volatile int _lastRetryTicks = 0; // Interlocked-safe DateTime.UtcNow.Ticks truncated to int32 range
-
-    // Store full ticks as long for accuracy
+    // Throttle: last attempt start time in UTC ticks (updated before Task.Run so
+    // concurrent callers see the updated value immediately and don't queue extra tasks).
     private long _lastRetryUtcTicks = 0;
 
     public DatabaseRecoveryService(
@@ -76,10 +73,14 @@ public class DatabaseRecoveryService
         if (string.IsNullOrEmpty(connectionString))
             return;
 
-        // Throttle check (non-atomic read is intentional – best-effort only)
-        var elapsed = TimeSpan.FromTicks(DateTime.UtcNow.Ticks - Interlocked.Read(ref _lastRetryUtcTicks));
+        // Throttle check – update the timestamp here (before Task.Run) so that
+        // concurrent requests racing through TriggerRecoveryIfNeeded all see the
+        // updated value and don't each queue a separate Task.Run work item.
+        var now = DateTime.UtcNow.Ticks;
+        var elapsed = TimeSpan.FromTicks(now - Interlocked.Read(ref _lastRetryUtcTicks));
         if (elapsed < _retryInterval)
             return;
+        Interlocked.Exchange(ref _lastRetryUtcTicks, now);
 
         // Fire-and-forget: never blocks the user request
         _ = Task.Run(async () =>
@@ -110,9 +111,8 @@ public class DatabaseRecoveryService
 
         try
         {
-            // Update the throttle timestamp now (inside the lock) so that the
-            // next TriggerRecoveryIfNeeded call sees an up-to-date value whether
-            // or not this attempt succeeds.
+            // Refresh the throttle timestamp inside the lock so the interval
+            // is measured from when the attempt actually ran, not when it was queued.
             Interlocked.Exchange(ref _lastRetryUtcTicks, DateTime.UtcNow.Ticks);
 
             _logger.LogInformation("Database recovery: attempting reconnection...");

--- a/m4d/ViewModels/UserMetadata.cs
+++ b/m4d/ViewModels/UserMetadata.cs
@@ -11,6 +11,8 @@ public class UserMetadata
         return new UserMetadata(user, roles);
     }
 
+    public static UserMetadata Anonymous => new UserMetadata(null, null);
+
     private UserMetadata(ApplicationUser user, IList<string> roles)
     {
         User = user;

--- a/m4d/appsettings.json
+++ b/m4d/appsettings.json
@@ -104,5 +104,8 @@
     "GlobalMaxRequestsPerWindow": 100,
     "GlobalWindowMinutes": 1,
     "CaptchaThresholdPercent": 20
+  },
+  "ServiceHealth": {
+    "DatabaseRetryInterval": "00:01:00"
   }
 }


### PR DESCRIPTION
## Summary

Implements automatic self-healing for the Azure on-demand SQL cold-start scenario: when both the App Service and the SQL database wake simultaneously, the app starts first, migrations fail, and the DB is marked unavailable. Previously this required a manual restart. Now the app detects when the DB becomes reachable again and recovers automatically — no restart needed.

## Changes

### New: `DatabaseRecoveryService`

A singleton that fires a background reconnection probe on each user request (throttled to once per `ServiceHealth:DatabaseRetryInterval`, default 1 min). The probe:

- Builds fresh `DbContextOptions` with a 60-second `ConnectTimeout` (gives Azure SQL time to wake)
- Calls `CanConnectAsync()` — single fast-fail probe, no retry
- On success: marks `Database` healthy, then runs deferred `FixupStats` initialisation in a new DI scope

The probe is fire-and-forget (`Task.Run`) — user requests are never delayed. A `SemaphoreSlim(1,1)` prevents concurrent attempts.

### `Program.cs` — two changes

1. **Singleton + middleware registration**: `TriggerRecoveryIfNeeded()` is wired into the request pipeline early (after `UseRouting`, before auth).

2. **Live connection string reload**: `AddDbContext` now uses the `(IServiceProvider, options)` factory overload so the connection string is re-read from `IConfiguration` on every context resolution. This means a mid-run `appsettings.json` edit is picked up by the very next request scope — no restart. Cost is a dictionary key lookup per request (negligible).

### `DMController.cs` — exception handling in `OnActionExecutionAsync`

`UserMetadata.Create` calls `UserManager.FindByNameAsync` which hits the DB. When the DB is down this was throwing an unhandled `SqlException`/`Win32Exception`, producing the developer exception page.

Fix: catch block marks `Database` unavailable and falls through with `UserMetadata.Anonymous`, so execution continues normally and the page renders in degraded mode with the service status banner.

### `UserMetadata.cs` — new `Anonymous` factory

```csharp
public static UserMetadata Anonymous => new UserMetadata(null, null);
```

Returns a null-user instance — identical to an unauthenticated visitor — for use when the DB cannot be reached.

### `appsettings.json`

Added `ServiceHealth:DatabaseRetryInterval` (default `"00:01:00"`).

## Testing

Local test procedure:

1. Set `DanceMusicContextConnection` to a nonexistent server (`Server=nonexistent-server.invalid;Connect Timeout=5;...`) and start the app.
2. Verify: app starts, pages render in degraded mode, no exception page.
3. While running, restore the real connection string.
4. Hit any page — within the retry interval recovery fires in background.
5. Check logs for “connection restored” and “FixupStats completed”; subsequent loads work fully.

## Files Changed

| File                                                          | Change                                                         |
| ------------------------------------------------------------- | -------------------------------------------------------------- |
| `m4d/Services/DatabaseRecoveryService.cs`                     | New                                                            |
| `m4d/Program.cs`                                              | Register service + middleware; `AddDbContext` factory overload |
| `m4d/Controllers/DMController.cs`                             | Catch DB exceptions in `OnActionExecutionAsync`                |
| `m4d/ViewModels/UserMetadata.cs`                              | Add `Anonymous` static factory                                 |
| `m4d/appsettings.json`                                        | Add `ServiceHealth:DatabaseRetryInterval`                      |
| `architecture/service-resilience-phase7-completion-report.md` | New                                                            |
| `architecture/service-resilience-plan.md`                     | Add Phase 7 to implementation phases                           |
