### PR TITLE
User Deletion: Preserve Votes as Anonymous + Security Fixes

### DIFF
--- a/architecture/account-management.md
+++ b/architecture/account-management.md
@@ -152,3 +152,46 @@ If `FilterUser?user=someuser` returns no results:
 
 External login providers (e.g., Google, Microsoft) require the user to choose a username when
 first logging in via `ExternalLogin.cshtml`. The same username validator applies.
+
+---
+
+## User Deletion and Vote Preservation
+
+When an admin deletes a user via `ApplicationUsersController.DeleteConfirmed`, their song
+contributions (votes, tags, edits) are **preserved but permanently anonymized** rather than
+deleted. This is done by calling `Database.ChangeUserName` before removing the account:
+
+```csharp
+await Database.ChangeUserName(applicationUser.DecoratedName, applicationUser.Id);
+```
+
+### How It Works
+
+`ChangeUserName` finds all songs in Azure Search where the user's `DecoratedName` appears in the
+`UserField` or `UserProxy` properties, then rewrites those properties with the new name. By
+passing the user's GUID as the new name, all contributions are attributed to an anonymous identity
+that happens to look like a GUID.
+
+### Why a GUID Means "Anonymous"
+
+GUIDs (36 characters containing `-`) are detected as anonymous identities throughout the stack:
+
+- **`UserQuery.IsAnonymous`** (TypeScript): `userName.length === 36 && userName.includes('-')` →
+  displays as "Anonymous" in song history and filter descriptions
+- **`UserQuery.IsAnonymous`** (C#): same check → display and filter logic treats them as anonymous
+- **`UserMapper.AnonymizeAll`**: explicitly passes GUIDs through unchanged (already anonymized)
+- **`UserMapper.Deanonymize`**: GUID not found in dictionary → returns GUID unchanged (no-op)
+
+### Why the GUID Is Permanently Anonymous
+
+After the user is deleted the GUID is no longer in the user database, so:
+
+- `AnonymizeFilter` and `DeanonymizeFilter` cannot resolve it → passes through as-is
+- Admin operations that deanonymize history find no match → GUID stays as-is
+- There is no way to reverse the anonymization after deletion — this is intentional
+
+### What Is Also Deleted
+
+- The user's saved searches (`Context.Searches`) are hard-deleted
+- The `ApplicationUser` row is hard-deleted
+- `UserMapper.Clear()` is called to invalidate the in-memory user cache

--- a/m4d/Controllers/ApplicationUsersController.cs
+++ b/m4d/Controllers/ApplicationUsersController.cs
@@ -343,7 +343,28 @@ public class ApplicationUsersController(
 
         // Reassign all song contributions (votes, tags, edits) from the deleted user's name
         // to their GUID ID, so they appear as Anonymous rather than being lost.
-        await Database.ChangeUserName(applicationUser.DecoratedName, applicationUser.Id);
+        if (!ServiceHealth.IsServiceAvailable("SearchService"))
+        {
+            Logger.LogError("Cannot delete user {UserId}: Azure Search is unavailable. " +
+                "Delete aborted to avoid losing song contributions.", id);
+            return StatusCode((int)HttpStatusCode.ServiceUnavailable,
+                "Azure Search is currently unavailable. User deletion requires the search index " +
+                "to be reachable so that song contributions can be anonymized before the account " +
+                "is removed. Please try again once the search service has recovered.");
+        }
+
+        try
+        {
+            await Database.ChangeUserName(applicationUser.DecoratedName, applicationUser.Id);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to anonymize song contributions for user {UserId} ({UserName}) " +
+                "before deletion. Delete aborted.", id, applicationUser.UserName);
+            return StatusCode((int)HttpStatusCode.ServiceUnavailable,
+                "Failed to anonymize song contributions. User deletion aborted to avoid data loss. " +
+                "Please check the search service and try again.");
+        }
 
         var searches = Context.Searches.Where(s => s.ApplicationUserId == applicationUser.Id);
         foreach (var search in searches)

--- a/m4d/Controllers/ApplicationUsersController.cs
+++ b/m4d/Controllers/ApplicationUsersController.cs
@@ -336,6 +336,11 @@ public class ApplicationUsersController(
     {
         var applicationUser = await UserManager.FindByIdAsync(id);
 
+        if (applicationUser == null)
+        {
+            return StatusCode((int)HttpStatusCode.NotFound);
+        }
+
         // Reassign all song contributions (votes, tags, edits) from the deleted user's name
         // to their GUID ID, so they appear as Anonymous rather than being lost.
         await Database.ChangeUserName(applicationUser.DecoratedName, applicationUser.Id);

--- a/m4d/Controllers/ApplicationUsersController.cs
+++ b/m4d/Controllers/ApplicationUsersController.cs
@@ -75,6 +75,12 @@ public class ApplicationUsersController(
 
         var user = Database.Context.Users.Where(u => u.Id == id)
             .Include(u => u.ActivityLog).Include(u => u.Searches).FirstOrDefault();
+
+        if (user == null)
+        {
+            return StatusCode((int)HttpStatusCode.NotFound);
+        }
+
         return View(user);
     }
 
@@ -329,6 +335,10 @@ public class ApplicationUsersController(
     public async Task<ActionResult> DeleteConfirmed(string id)
     {
         var applicationUser = await UserManager.FindByIdAsync(id);
+
+        // Reassign all song contributions (votes, tags, edits) from the deleted user's name
+        // to their GUID ID, so they appear as Anonymous rather than being lost.
+        await Database.ChangeUserName(applicationUser.DecoratedName, applicationUser.Id);
 
         var searches = Context.Searches.Where(s => s.ApplicationUserId == applicationUser.Id);
         foreach (var search in searches)

--- a/m4d/Controllers/UsersController.cs
+++ b/m4d/Controllers/UsersController.cs
@@ -39,8 +39,11 @@ public class UsersController(
             // Return the same response as a private user with no activity to prevent
             // username enumeration: a bad actor cannot distinguish "no such user" from
             // "user exists but has chosen maximum privacy".
-            var emptyProfile = new UserProfile { UserName = id };
-            return Vue3($"Info for {id}", $"Favorites and song lists for {id}",
+            // Use a fixed anonymous placeholder rather than echoing `id` back — a real
+            // private user viewed while unauthenticated would show their GUID, not their
+            // username, so echoing the requested name would leak its existence.
+            var emptyProfile = new UserProfile { UserName = "anonymous" };
+            return Vue3("User Profile", "Favorites and song lists",
                 "user-info", emptyProfile, "account-management");
         }
 

--- a/m4d/Controllers/UsersController.cs
+++ b/m4d/Controllers/UsersController.cs
@@ -32,13 +32,19 @@ public class UsersController(
         var user = await UserManager.FindByNameAsync(id)
             ?? await UserManager.FindByIdAsync(id);
 
+        var isAuthenticated = User.Identity?.IsAuthenticated == true;
+
         if (user == null)
         {
-            return StatusCode((int)HttpStatusCode.NotFound);
+            // Return the same response as a private user with no activity to prevent
+            // username enumeration: a bad actor cannot distinguish "no such user" from
+            // "user exists but has chosen maximum privacy".
+            var emptyProfile = new UserProfile { UserName = id };
+            return Vue3($"Info for {id}", $"Favorites and song lists for {id}",
+                "user-info", emptyProfile, "account-management");
         }
 
         var userName = user.UserName;
-        var isAuthenticated = User.Identity?.IsAuthenticated == true;
         // For private users (Privacy == 0): always expose the GUID, not the real username,
         // even if the profile was looked up by username.
         // For public users: only show the real username to authenticated members.

--- a/m4d/Program.cs
+++ b/m4d/Program.cs
@@ -23,15 +23,10 @@ using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.FeatureManagement;
-
 using Microsoft.Data.SqlClient;
 
 using Newtonsoft.Json.Serialization;
-
-using Owl.reCAPTCHA;
-
 using System.Reflection;
-
 using Vite.AspNetCore;
 
 
@@ -375,8 +370,9 @@ else
             // app is running) are picked up by new scoped contexts automatically.
             var cfg = sp.GetRequiredService<IConfiguration>();
             var liveConnStr = cfg["AZURE_SQL_CONNECTIONSTRING"]
-                ?? cfg.GetConnectionString("DanceMusicContextConnection")
-                ?? connectionString;
+                ?? (cfg.GetValue<bool>("PROD_DB") ? cfg["ProdConnectionString"] : null)
+                ?? (cfg.GetValue<bool>("TEST_DB") ? cfg["TestConnectionString"] : null)
+                ?? cfg.GetConnectionString("DanceMusicContextConnection");
             options.UseSqlServer(liveConnStr, sqlOptions =>
             {
                 sqlOptions.EnableRetryOnFailure(

--- a/m4d/Program.cs
+++ b/m4d/Program.cs
@@ -9,7 +9,6 @@ using m4d.Configuration;
 using m4d.Utilities;
 using m4d.ViewModels;
 
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;


### PR DESCRIPTION
## Summary

This PR improves the user deletion flow so that a deleted user’s song contributions (votes, tags,
edits) are preserved but permanently anonymized rather than lost, fixes a bug that prevented the
`m4d-prod-db` launch profile from connecting to the production SQL database, and closes two
user-enumeration / null-reference issues in the user info/admin endpoints.

—

## Changes

### 1. Preserve votes on user deletion (`ApplicationUsersController`)

Previously `DeleteConfirmed` removed the user row and their saved searches, silently discarding
all of their song contributions.

Now, before deletion, the controller calls:

```csharp
await Database.ChangeUserName(applicationUser.DecoratedName, applicationUser.Id);
```

This rewrites every `UserField` / `UserProxy` reference in Azure Search from the user’s decorated
name to their GUID. Because GUIDs (36 chars, contain `-`) are recognised as anonymous identities
throughout the stack (`UserQuery.IsAnonymous` in both C# and TypeScript,
`UserMapper.AnonymizeAll`, `UserMapper.Deanonymize`), the contributions are permanently and
irrevocably attributed to “Anonymous” — the user’s name is no longer exposed, but their data is
not lost.

Null guards were also added to both `Details` and `DeleteConfirmed` so that a missing user
returns a clean 404 instead of propagating `null` into views or subsequent calls.

See `architecture/account-management.md` → *User Deletion and Vote Preservation* for full details.

### 2. Fix `m4d-prod-db` / `m4d-test-db` profiles ignoring user secrets (`Program.cs`)

The `DbContext` factory lambda re-resolves the connection string at runtime, but its fallback
chain was:

```csharp
cfg["AZURE_SQL_CONNECTIONSTRING"]
    ?? cfg.GetConnectionString("DanceMusicContextConnection")  // always non-null in appsettings.json!
    ?? connectionString;  // ProdConnectionString — never reached
```

Because `DanceMusicContextConnection` is always defined in `appsettings.json`, the prod/test
override set during startup was dead code. Fixed to:

```csharp
cfg["AZURE_SQL_CONNECTIONSTRING"]
    ?? (cfg.GetValue<bool>("PROD_DB") ? cfg["ProdConnectionString"] : null)
    ?? (cfg.GetValue<bool>("TEST_DB") ? cfg["TestConnectionString"] : null)
    ?? cfg.GetConnectionString("DanceMusicContextConnection")
```

### 3. Prevent username enumeration via `/users/info/{username}` (`UsersController`)

`Info` previously returned HTTP 404 for a non-existent username, allowing a bad actor to probe
for valid usernames. It now returns the same Vue page that a real user who has chosen maximum
privacy and has no song activity would produce: an empty profile with zero counts and no Spotify
link. Authenticated visitors cannot distinguish “no such user” from “private user with no
activity”.

—

## Testing

- Delete a user with votes in the prod-db profile; verify their song history shows “Anonymous”
  rather than a missing contributor.
- Visit `/users/info/nonexistentuser` while signed in; verify the same empty profile page appears
  as for a private user — no 404, no error.
- Visit `/ApplicationUsers/Details/{deleted-guid}` (admin); verify a clean 404 rather than an
  exception.
- Launch with `m4d-prod-db` profile; verify the startup console shows
  `[Database] PROD_DB mode: Using ProdConnectionString from user secrets`.
