### PR TITLE
Fix some dance group handling issues

### DIFF
--- a/m4d.Tests/Services/SongSearchVoteSearchTests.cs
+++ b/m4d.Tests/Services/SongSearchVoteSearchTests.cs
@@ -30,7 +30,7 @@ public class SongSearchVoteSearchTests
         await Task.CompletedTask;
     }
 
-    private static async Task<SongSearch> CreateSongSearchAsync(
+    private static Task<SongSearch> CreateSongSearchAsync(
         DanceMusicService dms,
         IEnumerable<Song> songsToReturn,
         SongFilter filter)
@@ -59,7 +59,8 @@ public class SongSearchVoteSearchTests
             .Returns<string, SearchOptions, CruftFilter>((_, _, _) => AsAsyncEnumerable(songList));
 
         var queue = new TestBackgroundTaskQueue();
-        return new SongSearch(filter, "dwgray", true, mockSongIndex.Object, dms.UserManager, queue, null);
+        return Task.FromResult(
+            new SongSearch(filter, "dwgray", true, mockSongIndex.Object, dms.UserManager, queue, null));
     }
 
     private static async Task<Song> CreateSongAsync(DanceMusicCoreService dms, string raw)

--- a/m4d.Tests/Services/SongSearchVoteSearchTests.cs
+++ b/m4d.Tests/Services/SongSearchVoteSearchTests.cs
@@ -1,0 +1,119 @@
+using Azure.Search.Documents;
+
+using m4d.Services;
+using m4d.Tests.TestHelpers;
+using m4dModels;
+using m4dModels.Tests;
+
+using Moq;
+
+using System.Linq;
+
+namespace m4d.Tests.Services;
+
+[TestClass]
+public class SongSearchVoteSearchTests
+{
+    [ClassInitialize]
+    public static async Task ClassInitialize(TestContext _)
+    {
+        await DanceMusicTester.LoadDances();
+    }
+
+    private static async IAsyncEnumerable<Song> AsAsyncEnumerable(IEnumerable<Song> songs)
+    {
+        foreach (var song in songs)
+        {
+            yield return song;
+        }
+
+        await Task.CompletedTask;
+    }
+
+    private static async Task<SongSearch> CreateSongSearchAsync(
+        DanceMusicService dms,
+        IEnumerable<Song> songsToReturn,
+        SongFilter filter)
+    {
+        var mockSearchService = new Mock<ISearchServiceManager>();
+        mockSearchService
+            .Setup(m => m.GetSongFilter(It.IsAny<string>()))
+            .Returns<string>(s => SongFilter.Create(false, s));
+
+        var mockStats = new Mock<IDanceStatsManager>();
+        var serviceForSongIndex = new DanceMusicService(
+            dms.Context,
+            dms.UserManager,
+            mockSearchService.Object,
+            mockStats.Object);
+
+        var mockSongIndex = new Mock<SongIndex>();
+        mockSongIndex.Setup(m => m.DanceMusicService).Returns(serviceForSongIndex);
+
+        var songList = songsToReturn.ToList();
+        mockSongIndex
+            .Setup(m => m.StreamAll(
+                It.IsAny<string>(),
+                It.IsAny<SearchOptions>(),
+                It.IsAny<CruftFilter>()))
+            .Returns<string, SearchOptions, CruftFilter>((_, _, _) => AsAsyncEnumerable(songList));
+
+        var queue = new TestBackgroundTaskQueue();
+        return new SongSearch(filter, "dwgray", true, mockSongIndex.Object, dms.UserManager, queue, null);
+    }
+
+    private static async Task<Song> CreateSongAsync(DanceMusicCoreService dms, string raw)
+    {
+        return await Song.Create(raw, dms);
+    }
+
+    [TestMethod]
+    public async Task VoteSearch_GroupSelection_ExpandsToMemberDanceVotes()
+    {
+        var dms = await DanceMusicTester.CreateServiceWithUsers("SongSearchVoteSearch_GroupUp");
+        var matchedSong = await CreateSongAsync(
+            dms,
+            ".Create=\tUser=dwgray\tTime=00/00/0000 0:00:00 PM\tTitle=Foxtrot Up\tArtist=Test\tTempo=120.0\tTag+=Slow Foxtrot:Dance\tDanceRating=SFT+1");
+        var otherSong = await CreateSongAsync(
+            dms,
+            ".Create=\tUser=dwgray\tTime=00/00/0000 0:00:00 PM\tTitle=Cha Cha Up\tArtist=Test\tTempo=120.0\tTag+=Cha Cha:Dance\tDanceRating=CHA+1");
+
+        var filter = SongFilter.Create(false, "");
+        filter.Action = "Index";
+        filter.Dances = "FXT";
+        filter.User = "+dwgray|d";
+
+        var songSearch = await CreateSongSearchAsync(dms, [matchedSong, otherSong], filter);
+
+        var results = await songSearch.VoteSearch(new SearchOptions { Size = 25, Skip = 0 });
+
+        Assert.AreEqual(1, results.TotalCount, "Only the matching Foxtrot song should be returned");
+        Assert.AreEqual(1, results.Songs.Count(), "Only one song should be in the result page");
+        Assert.AreEqual("Foxtrot Up", results.Songs.First().Title);
+    }
+
+    [TestMethod]
+    public async Task VoteSearch_GroupSelection_ExpandsToMemberDanceVotes_ForDownVotes()
+    {
+        var dms = await DanceMusicTester.CreateServiceWithUsers("SongSearchVoteSearch_GroupDown");
+        var matchedSong = await CreateSongAsync(
+            dms,
+            ".Create=\tUser=dwgray\tTime=00/00/0000 0:00:00 PM\tTitle=Foxtrot Down\tArtist=Test\tTempo=120.0\tTag+=Slow Foxtrot:Dance\tDanceRating=SFT-1");
+        var otherSong = await CreateSongAsync(
+            dms,
+            ".Create=\tUser=dwgray\tTime=00/00/0000 0:00:00 PM\tTitle=Rumba Down\tArtist=Test\tTempo=120.0\tTag+=Rumba:Dance\tDanceRating=RMB-1");
+
+        var filter = SongFilter.Create(false, "");
+        filter.Action = "Index";
+        filter.Dances = "FXT";
+        filter.User = "+dwgray|x";
+
+        var songSearch = await CreateSongSearchAsync(dms, [matchedSong, otherSong], filter);
+
+        var results = await songSearch.VoteSearch(new SearchOptions { Size = 25, Skip = 0 });
+
+        Assert.AreEqual(1, results.TotalCount, "Only the matching Foxtrot song should be returned");
+        Assert.AreEqual(1, results.Songs.Count(), "Only one song should be in the result page");
+        Assert.AreEqual("Foxtrot Down", results.Songs.First().Title);
+    }
+}

--- a/m4d/ClientApp/src/pages/advanced-search/App.vue
+++ b/m4d/ClientApp/src/pages/advanced-search/App.vue
@@ -144,7 +144,16 @@ const sortId = ref<SortOrder | null>(initialSortId);
 const sortDirection = ref(sortInit.direction);
 
 const danceNames = computed(() => {
-  return dances.value.map((d) => danceDB.danceFromId(d)!.name);
+  return dances.value
+    .map((danceId) => danceDB.fromId(danceId)?.name)
+    .filter((name): name is string => !!name);
+});
+
+const singleDanceName = computed(() => {
+  if (dances.value.length !== 1) {
+    return undefined;
+  }
+  return danceDB.danceFromId(dances.value[0])?.name;
 });
 
 const activities = computed(() => {
@@ -416,9 +425,7 @@ function onReset(evt: Event): void {
         <BFormGroup
           id="tempo-range-group"
           :label="
-            dances.length === 1
-              ? `Tempo range for ${danceDB.danceFromId(dances[0])!.name} (BPM):`
-              : 'Tempo range (BPM):'
+            singleDanceName ? `Tempo range for ${singleDanceName} (BPM):` : 'Tempo range (BPM):'
           "
           label-for="tempo-range"
         >

--- a/m4d/ClientApp/src/pages/advanced-search/__tests__/advanced-search.test.ts
+++ b/m4d/ClientApp/src/pages/advanced-search/__tests__/advanced-search.test.ts
@@ -1,6 +1,7 @@
-import { beforeAll, beforeEach, afterEach, describe, test } from "vitest";
-import { testPageSnapshot } from "@/helpers/TestPageSnapshot";
+import { beforeAll, beforeEach, afterEach, describe, test, expect } from "vitest";
+import { testPageSnapshot, loadTestPage } from "@/helpers/TestPageSnapshot";
 import { mockResizObserver } from "@/helpers/TestHelpers";
+import { SongFilter } from "@/models/SongFilter";
 import App from "../App.vue";
 
 describe("AdvancedSearch.vue", () => {
@@ -30,5 +31,22 @@ describe("AdvancedSearch.vue", () => {
 
   test("renders the advanced search page", async () => {
     testPageSnapshot(App);
+  });
+
+  test("renders dance group filters without crashing", () => {
+    const filter = new SongFilter();
+    filter.action = "advanced";
+    filter.dances = "WLZ";
+
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      enumerable: true,
+      value: new URL(
+        `https://localhost:5001/song/advancedsearchform?filter=${filter.encodedQuery}`,
+      ),
+    });
+
+    const wrapper = loadTestPage(App);
+    expect(wrapper.text()).toContain("Tempo range (BPM):");
   });
 });

--- a/m4d/Services/SongSearch.cs
+++ b/m4d/Services/SongSearch.cs
@@ -92,7 +92,11 @@ public class SongSearch(SongFilter filter, string userName, bool isPremium, Song
         var userQuery = Filter.UserQuery;
         var vote = userQuery.IsUpVoted ? 1 : -1;
         var user = userQuery.IsIdentity ? UserName : userQuery.UserName;
-        var voteDances = Dances.Instance.ExpandGroups(Filter.DanceQuery.Dances).ToList();
+        var voteDances = Dances.Instance
+            .ExpandGroups(Filter.DanceQuery.Dances)
+            .GroupBy(d => d.Id)
+            .Select(g => g.First())
+            .ToList();
         return await PostSearch(options,
             s => voteDances.Any(d => s.NormalizedUserDanceRating(user, d.Id) == vote));
     }

--- a/m4d/Services/SongSearch.cs
+++ b/m4d/Services/SongSearch.cs
@@ -1,4 +1,5 @@
 ﻿using Azure.Search.Documents;
+using DanceLibrary;
 
 using m4d.Services.ServiceHealth;
 using m4d.Utilities;
@@ -91,8 +92,9 @@ public class SongSearch(SongFilter filter, string userName, bool isPremium, Song
         var userQuery = Filter.UserQuery;
         var vote = userQuery.IsUpVoted ? 1 : -1;
         var user = userQuery.IsIdentity ? UserName : userQuery.UserName;
+        var voteDances = Dances.Instance.ExpandGroups(Filter.DanceQuery.Dances).ToList();
         return await PostSearch(options,
-            s => Filter.DanceQuery.Dances.Any(d => s.NormalizedUserDanceRating(user, d.Id) == vote));
+            s => voteDances.Any(d => s.NormalizedUserDanceRating(user, d.Id) == vote));
     }
 
     /// <summary>

--- a/music4dance.code-workspace
+++ b/music4dance.code-workspace
@@ -45,7 +45,7 @@
       "titleBar.activeBackground": "#1857a4",
       "titleBar.activeForeground": "#e7e7e7",
       "titleBar.inactiveBackground": "#1857a499",
-      "titleBar.inactiveForeground": "#e7e7e799",
+      "titleBar.inactiveForeground": "#e7e7e799"
     },
     "peacock.color": "#1857a4",
     "chat.tools.terminal.autoApprove": {


### PR DESCRIPTION
- correctly handle groups in advanced search
    - Don’t show the song name on the tempo filter for song groups
    - do show the group name for user vote modifiers
- correctly handle dance groups for filters on the server end
- improve testing