### PR TITLE
Tempo List page: docs, bug fixes, name filter, column chooser

### DIFF
--- a/architecture/tempo-list-page.md
+++ b/architecture/tempo-list-page.md
@@ -64,6 +64,23 @@ placeholder range — `TempoRange.isInfinite` — as every Performance dance). F
 `tempoRange.isInfinite` catches both categories directly instead of relying on group membership as
 a proxy.
 
+### Name filter (`NameFilterInput.vue`)
+
+A fifth filter row, directly below the four `CheckedList` dropdowns: a free-text box (search-icon
+`BInputGroup`) bound to a `nameFilter` ref. `App.vue`'s `dances` computed applies it last, via
+`DanceDatabase.filterByName(danceDatabase.filter(filter).dances, nameFilter.value)` — the
+`DanceFilter` pass narrows by style/type/meter/organization first, then the name filter narrows
+the *result* by substring match against each dance's `hasString()` (id, name, synonyms,
+searchonyms, case-insensitive, letters-only normalized), same as it ANDs with everything else.
+
+`NameFilterInput.vue` (`m4d/ClientApp/src/components/`) is a small shared component — just the
+`BInputGroup`/`BFormInput`/search-icon markup behind a `v-model` — extracted from this same
+pattern in `dance-index`'s `DanceTable.vue`. It does not call `DanceDatabase.filterByName` itself;
+per the project's filter-construction convention, each page still owns the call to the class
+library's static method and decides what to filter. `DanceChooser.vue` has a near-identical inline
+input but was left as-is since it's a modal with its own layout constraints, not currently sharing
+a component tree with either page above.
+
 ### Filter state (`CheckedList.vue`)
 
 Each of the four dropdowns is a `CheckedList` bound with `v-model` to an array of selected values:
@@ -157,22 +174,47 @@ and Country) always showed every group it belongs to regardless of the Type sele
 are also in `this.groups` (when a group filter is set), so Viennese Waltz's Type column shows just
 "Waltz" once the Type filter is narrowed to Waltz.
 
+### Column chooser
+
+Below the `BTable`, `TempoList.vue` renders a second, small `CheckedList` (reusing the same
+dropdown-with-checkboxes component the four page-level filters use, via `type="Column"`,
+`variant="outline-secondary"`, `size="sm"` so it reads as a secondary/advanced control rather than
+another primary filter) bound to a `visibleColumns` ref. Name is not offered as a choice — it's
+`stickyColumn: true` and always rendered — but Meter, BPM, MPM, Type, and Styles all are, driven by
+a `chooseableColumns: { key, label, defaultVisible }[]` array local to the component. The `fields`
+passed to `BTable` is a `computed` that filters the full field-definition list (`allFields`) down
+to `name` plus whatever's in `visibleColumns`. All five are `defaultVisible: true` today, so the
+table's appearance is unchanged for anyone who doesn't open the chooser; a future optional column
+(the motivating case for building this) should be added to `chooseableColumns` and `allFields` with
+`defaultVisible: false` so it doesn't change the table casual users already know. The selection is
+plain component-local `ref` state — it resets on page reload, there's no persistence (localStorage,
+query string, etc.) — and isn't wired to `App.vue` at all, since it only affects how `TempoList`
+renders columns it already receives via `props.dances`.
+
+`CheckedList.vue` gained two optional props to support this second use, both defaulting to the
+original behavior so the four page-level filters render unchanged: `variant` (`ButtonVariant`,
+default `"primary"`) and `size` (`Size`, default unset/normal), both passed straight through to the
+underlying `BDropdown`.
+
 ## Testing
 
 - `m4d/ClientApp/src/pages/tempo-list/__tests__/App.test.ts` — mounts the real page (via
   `loadTestPage`, real `bootstrap-vue-next` components, real dance content JSON as test data — see
   [[testing-patterns]] "Client-Side Testing Patterns") and exercises the filter pipeline both
-  programmatically (assigning to the exposed `styles`/`types`/`meters`/`organizations` refs) and
-  through genuine DOM checkbox interaction (`input.setValue(true/false)` — `trigger("click")`
+  programmatically (assigning to the exposed `styles`/`types`/`meters`/`organizations`/`nameFilter`
+  refs) and through genuine DOM checkbox interaction (`input.setValue(true/false)` — `trigger("click")`
   does not reliably flip a `BFormCheckboxGroup` checkbox in jsdom, which is why the equivalent
   interaction test in `CheckedList.test.ts` was previously left `test.skip`). Includes regression
   tests for all four fixes below: the tempo-based exclusion (Performance dances *and* Pattern),
   the dropped "Performance" Type option, both the "select all organizations" case and a
   deliberate narrow organization selection (to prove the fix didn't broaden the latter), and the
-  Type column narrowing to the selected group(s).
+  Type column narrowing to the selected group(s). Also covers the name filter, including that it
+  ANDs with the other filters (a group match whose name doesn't satisfy the text filter is
+  excluded).
 - `m4d/ClientApp/src/pages/tempo-list/components/__tests__/TempoList.test.ts` — unit tests for the
-  results table: column content/links for a known dance, the empty-selection caption, and default
-  sort order.
+  results table: column content/links for a known dance, the empty-selection caption, default sort
+  order, and the column chooser (every optional column visible by default, Name not offered as a
+  choice, unchecking a column removes its header and cell content from the table).
 - `m4d/ClientApp/src/pages/tempo-list/components/__tests__/CheckedList.test.ts` — pre-existing;
   covers the dropdown label logic. Two interaction tests remain `test.skip` there for the same
   `trigger("click")` reason above; they were not converted to `setValue` as part of this pass since
@@ -225,11 +267,12 @@ BPM/MPM/Styles already shrank to the selected style(s).
 
 | File | Purpose |
 | --- | --- |
-| `m4d/ClientApp/src/pages/tempo-list/App.vue` | Page: builds filter option lists, holds selection state, computes `dances` |
-| `m4d/ClientApp/src/pages/tempo-list/components/CheckedList.vue` | Reusable multi-select dropdown used for all four filters |
-| `m4d/ClientApp/src/pages/tempo-list/components/TempoList.vue` | Results table |
+| `m4d/ClientApp/src/pages/tempo-list/App.vue` | Page: builds filter option lists, holds selection state (including `nameFilter`), computes `dances` |
+| `m4d/ClientApp/src/pages/tempo-list/components/CheckedList.vue` | Reusable multi-select dropdown used for the four page-level filters and (via `variant`/`size`) the column chooser |
+| `m4d/ClientApp/src/pages/tempo-list/components/TempoList.vue` | Results table; owns the column chooser and `visibleColumns` state |
+| `m4d/ClientApp/src/components/NameFilterInput.vue` | Shared name-filter text input (search icon + `BInputGroup`), used here and by `dance-index`'s `DanceTable.vue` |
 | `m4d/ClientApp/src/models/DanceDatabase/DanceFilter.ts` | Filter matching logic shared with other dance-filtering pages |
-| `m4d/ClientApp/src/models/DanceDatabase/DanceDatabase.ts` | Dance/group/style/organization aggregation, `.filter()` |
+| `m4d/ClientApp/src/models/DanceDatabase/DanceDatabase.ts` | Dance/group/style/organization aggregation, `.filter()`, `.filterByName()` (name-filter matching, shared across pages) |
 | `m4d/ClientApp/src/models/CheckboxTypes.ts` | `CheckboxOption`/value conversion helpers (`optionsFromText`, `valuesFromOptions`, `textFromValues`) |
 | `m4d/Controllers/HomeController.cs` | `Tempi` action |
 | `m4d/ViewModels/TempoListModel.cs` | Server-side model matching the client `TempoListModel` interface |

--- a/architecture/tempo-list-page.md
+++ b/architecture/tempo-list-page.md
@@ -30,9 +30,10 @@ the filter client-side against `DanceFilter`.
 ```text
 window.danceDatabaseJson ──▶ safeDanceDatabase() ──▶ fullDB: DanceDatabase
                                                           │
-                                          groups = fullDB.groups minus "Performance"
+                                    timedDances = fullDB.dances without tempoRange.isInfinite
                                                           │
-                                          danceDatabase = fullDB.filter({ groups })
+                          danceDatabase = new DanceDatabase({ dances: timedDances, groups: fullDB.groups })
+                                                .filter(new DanceFilter({}))   // recomputes .groups
                                                           │
                         ┌───────────────┬─────────────────┼───────────────┐
                         ▼               ▼                 ▼               ▼
@@ -42,21 +43,26 @@ window.danceDatabaseJson ──▶ safeDanceDatabase() ──▶ fullDB: DanceDa
                                                           all selected)
                         └───────────────┴─────────────────┴───────────────┘
                                                           │
-                                    dances = computed(() => danceDatabase.filter(
-                                      new DanceFilter({ styles, groups: types, meters, organizations })
-                                    ).dances)
+                        dances = computed(() => danceDatabase.filter(new DanceFilter({
+                          styles, groups: types, meters,
+                          organizations: selectedOrgs.length === organizationOptions.length
+                            ? undefined       // "every org checked" == "no restriction"
+                            : selectedOrgs,
+                        })).dances)
                                                           │
                                                           ▼
                                               <TempoList :dances="dances" />
 ```
 
-`fullDB` unconditionally drops the "Performance" group (Jazz, Contemporary, Ballet, Broadway, Tap,
-Hip-Hop, Bollywood, Disco, Freestyle) before anything else happens — those dances never appear on
-this page regardless of filter selection. **The Type dropdown still lists a "Performance"
-checkbox anyway**: `DanceDatabase.filter()` rebuilds its `.groups` getter by scanning
-`this.dances` — the *original*, unfiltered dance list — instead of the `dances` it just computed
-two lines above (`DanceDatabase.ts:116-125`), so the group list doesn't actually reflect what was
-filtered out. Checking only "Performance" always yields zero rows.
+`fullDB.dances` is filtered down to `timedDances` by `!d.tempoRange.isInfinite` before anything
+else happens, so any dance with no real tempo never appears on this page regardless of filter
+selection. This used to be done by dropping the "Performance" *group* instead — which happened to
+exclude the 9 actual Performance dances (Jazz, Contemporary, Ballet, Broadway, Tap, Hip-Hop,
+Bollywood, Disco, Freestyle) but missed **Pattern** (`PTN`), a "Social"-style dance filed under the
+"Other" group that also has no real tempo (its one instance carries the same `{min: 1, max: 500}`
+placeholder range — `TempoRange.isInfinite` — as every Performance dance). Filtering by
+`tempoRange.isInfinite` catches both categories directly instead of relying on group membership as
+a proxy.
 
 ### Filter state (`CheckedList.vue`)
 
@@ -66,7 +72,7 @@ Each of the four dropdowns is a `CheckedList` bound with `v-model` to an array o
 | --- | --- | --- | --- |
 | Style | `"Style"` | `danceDatabase.styles` (unique instance styles) | kebab-case string (`optionsFromText`/`wordsToKebab`) |
 | Type | `"Type"` | `danceDatabase.groups` names | kebab-case string |
-| Meter | `"Meter"` | hard-coded `[2/4, 3/4, 4/4]` | `Meter` instance (compared via `.equals()`, cast through `unknown` because `CheckboxValue` doesn't include arbitrary objects — see `INT-TODO` at `App.vue:32`) |
+| Meter | `"Meter"` | hard-coded `[2/4, 3/4, 4/4]` | `Meter` instance (compared via `.equals()`, cast through `unknown` because `CheckboxValue` doesn't include arbitrary objects — see `INT-TODO` at `App.vue:39`) |
 | Organization | `"Organization"` | `danceDatabase.organizations` | kebab-case string |
 
 `CheckedList` shows a dropdown button whose label is "All \<Type\>s" / "No \<Type\>s" / the single
@@ -75,7 +81,7 @@ selected item's text / "`N` \<Type\>s", derived from comparing `model.value.leng
 (`indeterminate` when some but not all options are checked).
 
 Style/Type/Organization option lists are seeded from the server-provided `model_` values via
-`buildList()` → `filterValid()` (`App.vue:46-57`), which silently drops any server-provided value
+`buildList()` → `filterValid()` (`App.vue:53-64`), which silently drops any server-provided value
 that isn't a valid kebab option (e.g. stale query-string values from a bookmarked link) rather than
 erroring. **The Meter dropdown does not read `model.meters` at all** — `meters` is always
 initialized to all three hard-coded options regardless of the `meters` query-string parameter, even
@@ -93,7 +99,9 @@ this page hand-rolls filter matching. For each `DanceType`:
 2. `matchGroups` — the dance must belong to at least one selected group ("some", not "every" — a
    dance like Viennese Waltz that's in both the Waltz and Country groups matches if either is
    selected).
-3. `matchOrganizations` — same "some" semantics against the dance's instances' organizations.
+3. `matchOrganizations` — same "some" semantics against the dance's instances' organizations (see
+   below for why this page normalizes "every organization checked" to `undefined` before this
+   step runs, rather than passing the full option list through).
 4. If all three pass, instances are narrowed to those whose `style` is in the selected `styles`
    list (`getMatchingInstances`); if the resulting instance list is empty, the whole dance is
    dropped (`type.reduce(instances)` is only called when `instances.length > 0`).
@@ -103,15 +111,20 @@ deselecting every style, group, meter, or organization checkbox produces an **em
 not "show everything" — `TempoList.vue`'s `emptyTable` computed then renders the caption "Please
 select at least one item from every drop-down" (`TempoList.vue:15-17`).
 
-`matchOrganizations` (`DanceFilter.ts:44-49`) is `type.organizations.some((o) => this.organizations!.includes(o))`
-whenever `this.organizations` is defined — which it always is on this page, since App.vue always
-passes a `organizations` array (initially "every option"). `.some()` on an **empty** array is
-always `false`, so any dance with no organization affiliation on any instance (most "Social"-style
-dances: Cross-step Waltz, Lindy Hop, Argentine Tango, Bossa Nova, Charleston, etc.) is filtered out
-even when every organization checkbox is checked. In the shipped content this drops the page's
-default result set from all 41 non-Performance dances down to 23 — the "Select All" state for
-Organization silently means "all dances that have at least one organization," not "all dances."
-See the `"organization-less dances are hidden..."` test in `App.test.ts` for a pinned example.
+`matchOrganizations` (`DanceFilter.ts:44-47`) is `type.organizations.some((o) => this.organizations!.includes(o))`
+whenever `this.organizations` is defined. `.some()` on an **empty** array is always `false`, so a
+dance with no organization affiliation on any instance (most "Social"-style dances: Cross-step
+Waltz, Lindy Hop, Argentine Tango, Bossa Nova, Charleston, etc.) can never match a *defined*
+`organizations` filter, no matter what it contains — this is intentional/correct behavior for a
+deliberate, narrow selection (e.g. "NDCA only" genuinely shouldn't surface un-sanctioned dances),
+but it breaks if the caller passes the full option list to mean "no restriction," since a fully
+populated array is still a *defined* filter. App.vue's `dances` computed handles this by
+normalizing "every organization checkbox is checked" to `organizations: undefined` before building
+the `DanceFilter`, rather than passing the explicit list through — see the comment there. This fix
+is deliberately scoped to the page, not `DanceFilter` itself: `DanceFilter` is shared with
+`DanceDeltas.vue` and the `DanceDatabaseFiltering.test.ts` fixtures, which rely on a *specific*
+organization selection genuinely excluding unaffiliated dances (e.g. `organizations: ["NDCA"]`
+should not surface a Social-only dance just because it has no organization at all).
 
 ## `TempoList.vue` (results table)
 
@@ -139,7 +152,10 @@ lexicographically.
   programmatically (assigning to the exposed `styles`/`types`/`meters`/`organizations` refs) and
   through genuine DOM checkbox interaction (`input.setValue(true/false)` — `trigger("click")`
   does not reliably flip a `BFormCheckboxGroup` checkbox in jsdom, which is why the equivalent
-  interaction test in `CheckedList.test.ts` was previously left `test.skip`).
+  interaction test in `CheckedList.test.ts` was previously left `test.skip`). Includes regression
+  tests for all three fixes below: the tempo-based exclusion (Performance dances *and* Pattern),
+  the dropped "Performance" Type option, and both the "select all organizations" case and a
+  deliberate narrow organization selection (to prove the fix didn't broaden the latter).
 - `m4d/ClientApp/src/pages/tempo-list/components/__tests__/TempoList.test.ts` — unit tests for the
   results table: column content/links for a known dance, the empty-selection caption, and default
   sort order.
@@ -147,26 +163,40 @@ lexicographically.
   covers the dropdown label logic. Two interaction tests remain `test.skip` there for the same
   `trigger("click")` reason above; they were not converted to `setValue` as part of this pass since
   `CheckedList.vue` itself was out of scope for this round of coverage.
+- `m4d/ClientApp/src/models/DanceDatabase/__tests__/DanceDatabaseFiltering.test.ts` and
+  `DanceDatabase.test.ts` — unaffected by the fixes above (re-verified): the `matchOrganizations`
+  fix lives in `App.vue`, not `DanceFilter`, specifically so these fixtures' narrow,
+  single-organization selections keep excluding organization-less dances as before; the
+  `DanceDatabase.filter()` groups fix only changes which *groups* come back, not which *dances* do.
 
 ## Known Gaps / Follow-ups
 
-- **"Select All" on Organization doesn't mean "all dances."** `DanceFilter.matchOrganizations`'s
-  `.some()` over an empty `organizations` array is always `false`, so every organization-less
-  "Social" dance is hidden by default. This is the single biggest gap in the page's *current*
-  behavior — it silently cuts the default result set from 41 dances to 23 — and would need a fix
-  in the shared `DanceFilter` class (e.g. treat "every option selected" as equivalent to
-  `undefined`, or special-case an empty `type.organizations`), not just in this page.
-- **The Type dropdown offers a "Performance" option that always yields zero rows**, because
-  `DanceDatabase.filter()`'s `.groups` getter is computed from the pre-filter dance list (see
-  above). Also shared logic — a fix belongs in `DanceDatabase.ts`, not `App.vue`.
 - Meter query-string parameter (`?meters=3%2F4`) is silently ignored client-side (see above) — a
   bookmarked/shared link with a meter filter loses that part of the selection on load.
 - `CheckedList.test.ts` has two `test.skip`ped interaction tests with a TODO blaming
   model/event handling; `setValue(true)` (proven out in this page's tests) resolves the same
   symptom and could unblock them.
-- `App.vue:9-10` has a standing `TODO` to clean up the `CheckboxOptions` structures and consider
+- `App.vue:10-11` has a standing `TODO` to clean up the `CheckboxOptions` structures and consider
   disabling checkboxes that can't produce any results given the current selection (e.g. disable an
   organization once no dance in the current style/type/meter selection offers it).
+
+## Fixed (2026-07-14)
+
+Three bugs found while first documenting this page (see git history for this file/commit) were
+fixed together, since the first two were both in `DanceFilter`/`DanceDatabase`, shared with other
+callers:
+
+1. Dances with no real tempo (Performance dances, and Pattern) are now excluded by
+   `tempoRange.isInfinite` rather than by "Performance" group membership — see the data-flow
+   section above.
+2. `DanceDatabase.filter()`'s `.groups` getter now derives from the dances it just filtered,
+   not the pre-filter list, so a filtered-out group (like "Performance," before fix #1 subsumed
+   it) no longer lingers as a dead dropdown option.
+3. `App.vue`'s `dances` computed normalizes "every organization checkbox checked" to
+   `organizations: undefined` before building its `DanceFilter`, so the default view no longer
+   silently hides every organization-less "Social" dance. `DanceFilter.matchOrganizations` itself
+   was deliberately left unchanged (a narrow, specific organization selection should still exclude
+   unaffiliated dances).
 
 ## Related Code
 

--- a/architecture/tempo-list-page.md
+++ b/architecture/tempo-list-page.md
@@ -144,6 +144,19 @@ Sorting on BPM/MPM sorts by `tempoRange.min` (zero-padded to 4 integer digits vi
 `sortByFormatted`), not by the displayed string, so ranges sort numerically rather than
 lexicographically.
 
+**BPM/MPM/Styles react to the current filter selection; Type now does too.** All three of
+BPM/MPM/Styles are derived from `dance.instances` (`tempoRange` and `styles` are getters that
+fold/map over `this.instances`), and `DanceFilter.reduce()` narrows `instances` to just the
+selected styles before returning a dance — so e.g. with only "American Rhythm" selected, Rumba's
+BPM/MPM/Styles columns show just that one instance's range and style, not the union across all its
+instances. `Type`, by contrast, is a plain `dance.groups` field that `DanceType.reduce()` used to
+clone unchanged (via `assign()`), so a dance in multiple groups (e.g. Viennese Waltz, in both Waltz
+and Country) always showed every group it belongs to regardless of the Type selection.
+`DanceFilter.reduce()` (`DanceFilter.ts:18-35`) now narrows `.groups` the same way it narrows
+`.instances`: after building the reduced `DanceType`, it filters `.groups` down to the ones that
+are also in `this.groups` (when a group filter is set), so Viennese Waltz's Type column shows just
+"Waltz" once the Type filter is narrowed to Waltz.
+
 ## Testing
 
 - `m4d/ClientApp/src/pages/tempo-list/__tests__/App.test.ts` — mounts the real page (via
@@ -153,9 +166,10 @@ lexicographically.
   through genuine DOM checkbox interaction (`input.setValue(true/false)` — `trigger("click")`
   does not reliably flip a `BFormCheckboxGroup` checkbox in jsdom, which is why the equivalent
   interaction test in `CheckedList.test.ts` was previously left `test.skip`). Includes regression
-  tests for all three fixes below: the tempo-based exclusion (Performance dances *and* Pattern),
-  the dropped "Performance" Type option, and both the "select all organizations" case and a
-  deliberate narrow organization selection (to prove the fix didn't broaden the latter).
+  tests for all four fixes below: the tempo-based exclusion (Performance dances *and* Pattern),
+  the dropped "Performance" Type option, both the "select all organizations" case and a
+  deliberate narrow organization selection (to prove the fix didn't broaden the latter), and the
+  Type column narrowing to the selected group(s).
 - `m4d/ClientApp/src/pages/tempo-list/components/__tests__/TempoList.test.ts` — unit tests for the
   results table: column content/links for a known dance, the empty-selection caption, and default
   sort order.
@@ -167,7 +181,12 @@ lexicographically.
   `DanceDatabase.test.ts` — unaffected by the fixes above (re-verified): the `matchOrganizations`
   fix lives in `App.vue`, not `DanceFilter`, specifically so these fixtures' narrow,
   single-organization selections keep excluding organization-less dances as before; the
-  `DanceDatabase.filter()` groups fix only changes which *groups* come back, not which *dances* do.
+  `DanceDatabase.filter()` groups fix only changes which *groups* come back, not which *dances* do;
+  and none of those fixtures pass a `groups` criterion, so the `.groups`-narrowing fix doesn't
+  touch them either.
+- `m4d/ClientApp/src/models/DanceDatabase/__tests__/DanceFilter.test.ts` — unit-level coverage for
+  the `.groups`-narrowing fix directly: narrows to the selected group(s), doesn't mutate the
+  original dance's `.groups` array, and leaves `.groups` untouched when no group filter is set.
 
 ## Known Gaps / Follow-ups
 
@@ -197,6 +216,10 @@ callers:
    silently hides every organization-less "Social" dance. `DanceFilter.matchOrganizations` itself
    was deliberately left unchanged (a narrow, specific organization selection should still exclude
    unaffiliated dances).
+
+A fourth bug, found separately afterward: `DanceFilter.reduce()`'s `.groups` narrowing (see
+"TempoList.vue" above) — the Type column didn't shrink to the selected group(s) the way
+BPM/MPM/Styles already shrank to the selected style(s).
 
 ## Related Code
 

--- a/architecture/tempo-list-page.md
+++ b/architecture/tempo-list-page.md
@@ -1,0 +1,183 @@
+# Tempo List Page (`tempo-list/App.vue`)
+
+## Overview
+
+The Tempo List page (`m4d/ClientApp/src/pages/tempo-list/App.vue`) is a reference page at
+`/Home/Tempi` ("Dance Tempi" in the site map) that lets a visitor cross-reference dance tempos:
+pick a subset of styles, dance types, meters, and organizations, and see a sortable table of every
+matching dance with its BPM/MPM tempo range. It has no server-side filtering — the full dance
+database ships to the client as `window.danceDatabaseJson`, and every checkbox interaction re-runs
+the filter client-side against `DanceFilter`.
+
+## Server-Side Wiring
+
+- `HomeController.Tempi(styles, types, organizations, meters)`
+  (`m4d/Controllers/HomeController.cs:111-127`) reads four `List<string>` query-string parameters
+  and renders the generic Vue3 host view (`m4d/Views/Shared/Vue3.cshtml`) with:
+  - component name `"tempo-list"` (resolves to this `App.vue`)
+  - a `TempoListModel` (`m4d/ViewModels/TempoListModel.cs`) built from the query params via
+    `ConvertParameter`, which turns an empty list into `null` (`HomeController.cs:129-132`)
+  - `danceEnvironment: true`, which makes `Vue3.cshtml` include
+    `_environmentWriter.cshtml` and emit `window.danceDatabaseJson`
+- Because `TempoListModel` is passed as the page's `Model.Model`, `Vue3.cshtml` serializes it with
+  `_jsonCamelCase` and assigns the *object itself* (not a JSON string) to the global `model_` — this
+  page reads `model_` directly rather than calling `TypedJSON.parse(model_, ...)` the way most other
+  Vue3 pages do.
+- No `[Route]` attribute; the URL is the default MVC route, `/Home/Tempi?styles=...&types=...&meters=...&organizations=...`.
+
+## Client-Side Data Flow
+
+```text
+window.danceDatabaseJson ──▶ safeDanceDatabase() ──▶ fullDB: DanceDatabase
+                                                          │
+                                          groups = fullDB.groups minus "Performance"
+                                                          │
+                                          danceDatabase = fullDB.filter({ groups })
+                                                          │
+                        ┌───────────────┬─────────────────┼───────────────┐
+                        ▼               ▼                 ▼               ▼
+                styleOptions/styles typeOptions/types  meterOptions/meters organizationOptions/organizations
+                (from model.styles) (from model.types)  (hard-coded 2/4,   (from model.organizations)
+                                                          3/4, 4/4 — always
+                                                          all selected)
+                        └───────────────┴─────────────────┴───────────────┘
+                                                          │
+                                    dances = computed(() => danceDatabase.filter(
+                                      new DanceFilter({ styles, groups: types, meters, organizations })
+                                    ).dances)
+                                                          │
+                                                          ▼
+                                              <TempoList :dances="dances" />
+```
+
+`fullDB` unconditionally drops the "Performance" group (Jazz, Contemporary, Ballet, Broadway, Tap,
+Hip-Hop, Bollywood, Disco, Freestyle) before anything else happens — those dances never appear on
+this page regardless of filter selection. **The Type dropdown still lists a "Performance"
+checkbox anyway**: `DanceDatabase.filter()` rebuilds its `.groups` getter by scanning
+`this.dances` — the *original*, unfiltered dance list — instead of the `dances` it just computed
+two lines above (`DanceDatabase.ts:116-125`), so the group list doesn't actually reflect what was
+filtered out. Checking only "Performance" always yields zero rows.
+
+### Filter state (`CheckedList.vue`)
+
+Each of the four dropdowns is a `CheckedList` bound with `v-model` to an array of selected values:
+
+| Dropdown | Prop `type` | Options source | Value shape |
+| --- | --- | --- | --- |
+| Style | `"Style"` | `danceDatabase.styles` (unique instance styles) | kebab-case string (`optionsFromText`/`wordsToKebab`) |
+| Type | `"Type"` | `danceDatabase.groups` names | kebab-case string |
+| Meter | `"Meter"` | hard-coded `[2/4, 3/4, 4/4]` | `Meter` instance (compared via `.equals()`, cast through `unknown` because `CheckboxValue` doesn't include arbitrary objects — see `INT-TODO` at `App.vue:32`) |
+| Organization | `"Organization"` | `danceDatabase.organizations` | kebab-case string |
+
+`CheckedList` shows a dropdown button whose label is "All \<Type\>s" / "No \<Type\>s" / the single
+selected item's text / "`N` \<Type\>s", derived from comparing `model.value.length` against
+`options.length` (`CheckedList.vue:13-30`). The "Select All" checkbox is tri-state
+(`indeterminate` when some but not all options are checked).
+
+Style/Type/Organization option lists are seeded from the server-provided `model_` values via
+`buildList()` → `filterValid()` (`App.vue:46-57`), which silently drops any server-provided value
+that isn't a valid kebab option (e.g. stale query-string values from a bookmarked link) rather than
+erroring. **The Meter dropdown does not read `model.meters` at all** — `meters` is always
+initialized to all three hard-coded options regardless of the `meters` query-string parameter, even
+though the server-side `TempoListModel.Meters` is populated and available on `model_`. This is a
+gap relative to the other three filters, not an intentional design choice.
+
+### Filtering logic (`DanceFilter.reduce`, `DanceDatabase.ts`)
+
+`DanceFilter` (`m4d/ClientApp/src/models/DanceDatabase/DanceFilter.ts`) is the single source of
+truth for turning a filter selection into a dance list — per the project convention, nothing in
+this page hand-rolls filter matching. For each `DanceType`:
+
+1. `matchMeter` — the dance's `meter` must equal one of the selected `Meter`s (skipped if
+   `meters` is `undefined`, but this page always passes a defined array).
+2. `matchGroups` — the dance must belong to at least one selected group ("some", not "every" — a
+   dance like Viennese Waltz that's in both the Waltz and Country groups matches if either is
+   selected).
+3. `matchOrganizations` — same "some" semantics against the dance's instances' organizations.
+4. If all three pass, instances are narrowed to those whose `style` is in the selected `styles`
+   list (`getMatchingInstances`); if the resulting instance list is empty, the whole dance is
+   dropped (`type.reduce(instances)` is only called when `instances.length > 0`).
+
+Because step 4 uses `types.value !== undefined` (an empty array still counts as "defined"),
+deselecting every style, group, meter, or organization checkbox produces an **empty result set**,
+not "show everything" — `TempoList.vue`'s `emptyTable` computed then renders the caption "Please
+select at least one item from every drop-down" (`TempoList.vue:15-17`).
+
+`matchOrganizations` (`DanceFilter.ts:44-49`) is `type.organizations.some((o) => this.organizations!.includes(o))`
+whenever `this.organizations` is defined — which it always is on this page, since App.vue always
+passes a `organizations` array (initially "every option"). `.some()` on an **empty** array is
+always `false`, so any dance with no organization affiliation on any instance (most "Social"-style
+dances: Cross-step Waltz, Lindy Hop, Argentine Tango, Bossa Nova, Charleston, etc.) is filtered out
+even when every organization checkbox is checked. In the shipped content this drops the page's
+default result set from all 41 non-Performance dances down to 23 — the "Select All" state for
+Organization silently means "all dances that have at least one organization," not "all dances."
+See the `"organization-less dances are hidden..."` test in `App.test.ts` for a pinned example.
+
+## `TempoList.vue` (results table)
+
+A `BTable` over `props.dances: DanceType[]`, sorted by name ascending by default
+(`sortBy = [{ key: "name", order: "asc" }]`). Columns:
+
+| Column | Content |
+| --- | --- |
+| Name | `<DanceName>` (links to `/dances/{seoName}`, shows synonyms) |
+| Meter | `dance.meter.toString()`, e.g. `"3/4"` |
+| BPM | `dance.tempoRange.toString()`, linked to `/song/advancedsearch?dances={id}&tempomin=...&tempomax=...&sortorder=Dances` (`defaultTempoLink`) |
+| MPM | `dance.tempoRange.mpm(dance.meter.numerator)`, same tempo-search link |
+| Type | Comma-joined group names, each linked to `/dances/{groupName}` — only the *first* group is used to build the link even when a dance belongs to multiple groups (`groupLink` reads `dance.groups?.[0]`) |
+| Styles | Comma-joined style names; a style is only linked to `/dances/{kebab-style}` if its name contains a space (`style.indexOf(" ") !== -1`) — a quirk that means single-word styles like "Social" or "Country" render as plain text while "American Rhythm" links |
+
+Sorting on BPM/MPM sorts by `tempoRange.min` (zero-padded to 4 integer digits via
+`sortByFormatted`), not by the displayed string, so ranges sort numerically rather than
+lexicographically.
+
+## Testing
+
+- `m4d/ClientApp/src/pages/tempo-list/__tests__/App.test.ts` — mounts the real page (via
+  `loadTestPage`, real `bootstrap-vue-next` components, real dance content JSON as test data — see
+  [[testing-patterns]] "Client-Side Testing Patterns") and exercises the filter pipeline both
+  programmatically (assigning to the exposed `styles`/`types`/`meters`/`organizations` refs) and
+  through genuine DOM checkbox interaction (`input.setValue(true/false)` — `trigger("click")`
+  does not reliably flip a `BFormCheckboxGroup` checkbox in jsdom, which is why the equivalent
+  interaction test in `CheckedList.test.ts` was previously left `test.skip`).
+- `m4d/ClientApp/src/pages/tempo-list/components/__tests__/TempoList.test.ts` — unit tests for the
+  results table: column content/links for a known dance, the empty-selection caption, and default
+  sort order.
+- `m4d/ClientApp/src/pages/tempo-list/components/__tests__/CheckedList.test.ts` — pre-existing;
+  covers the dropdown label logic. Two interaction tests remain `test.skip` there for the same
+  `trigger("click")` reason above; they were not converted to `setValue` as part of this pass since
+  `CheckedList.vue` itself was out of scope for this round of coverage.
+
+## Known Gaps / Follow-ups
+
+- **"Select All" on Organization doesn't mean "all dances."** `DanceFilter.matchOrganizations`'s
+  `.some()` over an empty `organizations` array is always `false`, so every organization-less
+  "Social" dance is hidden by default. This is the single biggest gap in the page's *current*
+  behavior — it silently cuts the default result set from 41 dances to 23 — and would need a fix
+  in the shared `DanceFilter` class (e.g. treat "every option selected" as equivalent to
+  `undefined`, or special-case an empty `type.organizations`), not just in this page.
+- **The Type dropdown offers a "Performance" option that always yields zero rows**, because
+  `DanceDatabase.filter()`'s `.groups` getter is computed from the pre-filter dance list (see
+  above). Also shared logic — a fix belongs in `DanceDatabase.ts`, not `App.vue`.
+- Meter query-string parameter (`?meters=3%2F4`) is silently ignored client-side (see above) — a
+  bookmarked/shared link with a meter filter loses that part of the selection on load.
+- `CheckedList.test.ts` has two `test.skip`ped interaction tests with a TODO blaming
+  model/event handling; `setValue(true)` (proven out in this page's tests) resolves the same
+  symptom and could unblock them.
+- `App.vue:9-10` has a standing `TODO` to clean up the `CheckboxOptions` structures and consider
+  disabling checkboxes that can't produce any results given the current selection (e.g. disable an
+  organization once no dance in the current style/type/meter selection offers it).
+
+## Related Code
+
+| File | Purpose |
+| --- | --- |
+| `m4d/ClientApp/src/pages/tempo-list/App.vue` | Page: builds filter option lists, holds selection state, computes `dances` |
+| `m4d/ClientApp/src/pages/tempo-list/components/CheckedList.vue` | Reusable multi-select dropdown used for all four filters |
+| `m4d/ClientApp/src/pages/tempo-list/components/TempoList.vue` | Results table |
+| `m4d/ClientApp/src/models/DanceDatabase/DanceFilter.ts` | Filter matching logic shared with other dance-filtering pages |
+| `m4d/ClientApp/src/models/DanceDatabase/DanceDatabase.ts` | Dance/group/style/organization aggregation, `.filter()` |
+| `m4d/ClientApp/src/models/CheckboxTypes.ts` | `CheckboxOption`/value conversion helpers (`optionsFromText`, `valuesFromOptions`, `textFromValues`) |
+| `m4d/Controllers/HomeController.cs` | `Tempi` action |
+| `m4d/ViewModels/TempoListModel.cs` | Server-side model matching the client `TempoListModel` interface |
+| `m4d/Views/Shared/Vue3.cshtml`, `_environmentWriter.cshtml` | Generic Vue3 page host; emits `model_` and `window.danceDatabaseJson` |

--- a/m4d/ClientApp/.gitignore
+++ b/m4d/ClientApp/.gitignore
@@ -27,7 +27,7 @@ coverage
 *.sln
 *.sw?
 
-.vite-inspect/*
+.vite-inspect/
 
 # yarn
 .pnp.*

--- a/m4d/ClientApp/src/components/DanceChooser.vue
+++ b/m4d/ClientApp/src/components/DanceChooser.vue
@@ -157,7 +157,7 @@ const isGroup = (dance: NamedObject) => {
     </BButton>
     <BInputGroup class="mb-2">
       <BFormInput v-model="nameFilter" type="text" placeholder="Filter Dances" autofocus />
-      <span><IBiSearch /></span>
+      <BInputGroupText><IBiSearch /></BInputGroupText>
     </BInputGroup>
     <div v-if="allStyleFamilies.length > 0" class="mb-2">
       <div class="small text-muted mb-1">Filter by:</div>

--- a/m4d/ClientApp/src/components/NameFilterInput.vue
+++ b/m4d/ClientApp/src/components/NameFilterInput.vue
@@ -13,6 +13,6 @@ const modelValue = defineModel<string>({ required: true });
 <template>
   <BInputGroup class="mb-2">
     <BFormInput :id="id" v-model="modelValue" type="text" :placeholder="placeholder" autofocus />
-    <span><IBiSearch /></span>
+    <BInputGroupText><IBiSearch /></BInputGroupText>
   </BInputGroup>
 </template>

--- a/m4d/ClientApp/src/components/NameFilterInput.vue
+++ b/m4d/ClientApp/src/components/NameFilterInput.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    id?: string;
+    placeholder?: string;
+  }>(),
+  { id: "name-filter", placeholder: "Filter Dances" },
+);
+
+const modelValue = defineModel<string>({ required: true });
+</script>
+
+<template>
+  <BInputGroup class="mb-2">
+    <BFormInput :id="id" v-model="modelValue" type="text" :placeholder="placeholder" autofocus />
+    <span><IBiSearch /></span>
+  </BInputGroup>
+</template>

--- a/m4d/ClientApp/src/components/SpotifyRequirementsModal.vue
+++ b/m4d/ClientApp/src/components/SpotifyRequirementsModal.vue
@@ -127,11 +127,9 @@ const nextStep = computed(() => {
           <div class="requirement-content">
             <strong>Have associated a Spotify account with your music4dance account</strong>
             <div v-if="!hasSpotifyOAuth && isAuthenticated" class="mt-1">
-              <a
-                :href="spotifyConnectHref"
-                class="btn btn-sm btn-primary"
-                >{{ reauthRequired ? "Reconnect Spotify Account" : "Connect Spotify Account" }}</a
-              >
+              <a :href="spotifyConnectHref" class="btn btn-sm btn-primary">{{
+                reauthRequired ? "Reconnect Spotify Account" : "Connect Spotify Account"
+              }}</a>
               <span class="ms-2 text-muted">
                 &mdash;
                 <a

--- a/m4d/ClientApp/src/models/DanceDatabase/DanceDatabase.ts
+++ b/m4d/ClientApp/src/models/DanceDatabase/DanceDatabase.ts
@@ -116,7 +116,7 @@ export class DanceDatabase {
   public filter(filter: DanceFilter): DanceDatabase {
     const dances = filter.filter(this.dances);
     const groups = [
-      ...this.dances.reduce((acc, x) => {
+      ...dances.reduce((acc, x) => {
         x.groups.forEach((g) => acc.add(g.name));
         return acc;
       }, new Set<string>()),

--- a/m4d/ClientApp/src/models/DanceDatabase/DanceFilter.ts
+++ b/m4d/ClientApp/src/models/DanceDatabase/DanceFilter.ts
@@ -24,7 +24,18 @@ export class DanceFilter {
     const instances = this.getMatchingInstances(type).map((inst) =>
       inst.reduceExceptions(coversOrgs ? undefined : this.organizations),
     );
-    return instances.length > 0 ? type.reduce(instances) : null;
+    if (instances.length === 0) {
+      return null;
+    }
+
+    const reduced = type.reduce(instances);
+    // type.reduce() clones .groups as-is (every group the dance belongs to), unlike .instances,
+    // which it narrows to the matched set - narrow .groups the same way so a dance's reported
+    // Type reflects only the selected group(s), not every group it happens to belong to.
+    if (this.groups !== undefined) {
+      reduced.groups = reduced.groups.filter((g) => this.groups!.includes(g.name));
+    }
+    return reduced;
   }
 
   public filter(types: DanceType[]): DanceType[] {

--- a/m4d/ClientApp/src/models/DanceDatabase/__tests__/DanceFilter.test.ts
+++ b/m4d/ClientApp/src/models/DanceDatabase/__tests__/DanceFilter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import { DanceFilter } from "../DanceFilter";
 import { TypedJSON } from "typedjson";
 import { DanceType } from "../DanceType";
+import { DanceGroup } from "../DanceGroup";
 
 describe("DanceFilter.ts", () => {
   test("Reduce returns flattened type when orgainzations are covered", () => {
@@ -25,6 +26,32 @@ describe("DanceFilter.ts", () => {
       expect(res!.tempoRange).toEqual(org!.tempoRange);
       expect(res!.exceptions.length).toEqual(0);
     }
+  });
+
+  test("Reduce narrows .groups to just the selected group(s), like it already narrows instances by style", () => {
+    const dance = createSamba();
+    dance.groups = [
+      new DanceGroup({ internalId: "LAT", internalName: "Latin", danceIds: [] }),
+      new DanceGroup({ internalId: "CTY", internalName: "Country", danceIds: [] }),
+    ];
+
+    const result = new DanceFilter({ groups: ["Latin"] }).reduce(dance)!;
+
+    expect(result.groups.map((g) => g.name)).toEqual(["Latin"]);
+    // the original dance's groups must not be mutated by reduce()
+    expect(dance.groups.map((g) => g.name)).toEqual(["Latin", "Country"]);
+  });
+
+  test("Reduce leaves .groups untouched when the filter has no group criterion", () => {
+    const dance = createSamba();
+    dance.groups = [
+      new DanceGroup({ internalId: "LAT", internalName: "Latin", danceIds: [] }),
+      new DanceGroup({ internalId: "CTY", internalName: "Country", danceIds: [] }),
+    ];
+
+    const result = new DanceFilter({}).reduce(dance)!;
+
+    expect(result.groups.map((g) => g.name)).toEqual(["Latin", "Country"]);
   });
 });
 

--- a/m4d/ClientApp/src/pages/dance-index/__tests__/__snapshots__/dance-index.test.ts.snap
+++ b/m4d/ClientApp/src/pages/dance-index/__tests__/__snapshots__/dance-index.test.ts.snap
@@ -16,7 +16,10 @@ exports[`DanceIndex > Renders dance-index Page 1`] = `
     <div>
       <div>
         <div class="input-group mb-2" role="group">
-          <!----><input id="bvt-dance-filter" class="form-control" type="text" placeholder="Filter Dances" value=""><span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em"><path fill="currentColor" d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0a5.5 5.5 0 0 1 11 0"></path></svg></span>
+          <!----><input id="bvt-dance-filter" class="form-control" type="text" placeholder="Filter Dances" value="">
+          <div class="input-group-text"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+              <path fill="currentColor" d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0a5.5 5.5 0 0 1 11 0"></path>
+            </svg></div>
           <!---->
         </div>
         <div class="list-group">

--- a/m4d/ClientApp/src/pages/dance-index/components/DanceTable.vue
+++ b/m4d/ClientApp/src/pages/dance-index/components/DanceTable.vue
@@ -19,16 +19,7 @@ const filteredDances = computed(() => {
 
 <template>
   <div>
-    <BInputGroup class="mb-2">
-      <BFormInput
-        id="bvt-dance-filter"
-        v-model="nameFilter"
-        type="text"
-        placeholder="Filter Dances"
-        autofocus
-      />
-      <span><IBiSearch /></span>
-    </BInputGroup>
+    <NameFilterInput id="bvt-dance-filter" v-model="nameFilter" placeholder="Filter Dances" />
     <DanceList
       :dances="filteredDances"
       :flush="false"

--- a/m4d/ClientApp/src/pages/tempo-list/App.vue
+++ b/m4d/ClientApp/src/pages/tempo-list/App.vue
@@ -6,6 +6,7 @@ import { computed, ref } from "vue";
 import { DanceDatabase } from "@/models/DanceDatabase/DanceDatabase";
 import { DanceFilter } from "@/models/DanceDatabase/DanceFilter";
 import { Meter } from "@/models/DanceDatabase/Meter";
+import type { DanceType } from "@/models/DanceDatabase/DanceType";
 
 // TODO: Clean up the CheckboxOptions structures
 // Consider disabling checkboxes that don't make sense for the current selection
@@ -50,6 +51,8 @@ const { options: organizationOptions, values: organizations } = buildList(
   model.organizations,
 );
 
+const nameFilter = ref("");
+
 function buildList(values: string[], current?: string[]) {
   const options = optionsFromText(values);
   const all = valuesFromOptions(options);
@@ -79,7 +82,10 @@ const dances = computed(() => {
         ? undefined
         : selectedOrganizations,
   });
-  return danceDatabase.filter(filter).dances;
+  return DanceDatabase.filterByName(
+    danceDatabase.filter(filter).dances,
+    nameFilter.value,
+  ) as DanceType[];
 });
 
 // Exposed for testing
@@ -91,6 +97,7 @@ defineExpose({
   meters,
   organizations,
   organizationOptions,
+  nameFilter,
   dances,
 });
 </script>
@@ -111,6 +118,14 @@ defineExpose({
         class="col-md"
         type="Organization"
         :options="organizationOptions"
+      />
+    </div>
+    <div class="row">
+      <NameFilterInput
+        id="tempo-name-filter"
+        v-model="nameFilter"
+        class="col-md"
+        placeholder="Filter Dances"
       />
     </div>
     <div class="row">

--- a/m4d/ClientApp/src/pages/tempo-list/App.vue
+++ b/m4d/ClientApp/src/pages/tempo-list/App.vue
@@ -3,6 +3,7 @@ import { safeDanceDatabase } from "@/helpers/DanceEnvironmentManager";
 import { type CheckboxOption, type CheckboxValue } from "bootstrap-vue-next";
 import { optionsFromText, valuesFromOptions, textFromValues } from "@/models/CheckboxTypes";
 import { computed, ref } from "vue";
+import { DanceDatabase } from "@/models/DanceDatabase/DanceDatabase";
 import { DanceFilter } from "@/models/DanceDatabase/DanceFilter";
 import { Meter } from "@/models/DanceDatabase/Meter";
 
@@ -19,8 +20,14 @@ declare const model_: TempoListModel;
 const model = model_ || {};
 
 const fullDB = safeDanceDatabase();
-const groups = fullDB.groups.map((g) => g.name).filter((n) => n !== "Performance");
-const danceDatabase = fullDB.filter(new DanceFilter({ groups: groups }));
+// Performance dances (and the occasional non-Performance-group dance like Pattern) have no real
+// tempo - their instances carry a placeholder range rather than an actual BPM/MPM band - so they
+// can never usefully appear on this page. Filtering by tempoRange.isInfinite (rather than by
+// group name) catches all of them, not just the ones grouped under "Performance".
+const timedDances = fullDB.dances.filter((d) => !d.tempoRange.isInfinite);
+const danceDatabase = new DanceDatabase({ dances: timedDances, groups: fullDB.groups }).filter(
+  new DanceFilter({}),
+);
 
 const { options: styleOptions, values: styles } = buildList(danceDatabase.styles, model.styles);
 
@@ -57,11 +64,20 @@ function filterValid(all: string[], selected?: string[]): string[] {
 }
 
 const dances = computed(() => {
+  const selectedOrganizations = textFromValues(organizations.value, organizationOptions.value);
   const filter = new DanceFilter({
     styles: textFromValues(styles.value, styleOptions.value),
     groups: textFromValues(types.value, typeOptions.value),
     meters: meters.value,
-    organizations: textFromValues(organizations.value, organizationOptions.value),
+    // "Every organization selected" must mean "no organization restriction" (like DanceFilter's
+    // undefined), not "match only dances affiliated with one of these organizations" - the
+    // latter incorrectly excludes dances with no organization affiliation at all (e.g. Social
+    // dances like Lindy Hop), since DanceFilter.matchOrganizations can never match an empty list
+    // against anything.
+    organizations:
+      selectedOrganizations.length === organizationOptions.value.length
+        ? undefined
+        : selectedOrganizations,
   });
   return danceDatabase.filter(filter).dances;
 });

--- a/m4d/ClientApp/src/pages/tempo-list/App.vue
+++ b/m4d/ClientApp/src/pages/tempo-list/App.vue
@@ -65,6 +65,18 @@ const dances = computed(() => {
   });
   return danceDatabase.filter(filter).dances;
 });
+
+// Exposed for testing
+defineExpose({
+  styles,
+  styleOptions,
+  types,
+  typeOptions,
+  meters,
+  organizations,
+  organizationOptions,
+  dances,
+});
 </script>
 
 <template>

--- a/m4d/ClientApp/src/pages/tempo-list/__tests__/App.test.ts
+++ b/m4d/ClientApp/src/pages/tempo-list/__tests__/App.test.ts
@@ -199,6 +199,26 @@ describe("tempo-list App.vue", () => {
     ]);
   });
 
+  test("filters by dance name", () => {
+    const wrapper = mountTempoList();
+    wrapper.vm.nameFilter = "waltz";
+
+    expect(danceNames(wrapper)).toEqual(["Cross-step Waltz", "Slow Waltz", "Viennese Waltz"]);
+  });
+
+  test("name filter combines with the other filters (AND across dimensions)", () => {
+    const wrapper = mountTempoList();
+    wrapper.vm.types = ["waltz"];
+    // The Waltz group alone also includes "Tango Vals" (see "filters by type" above), but its
+    // name doesn't contain "waltz", so the name filter narrows it out.
+    wrapper.vm.nameFilter = "waltz";
+
+    expect(danceNames(wrapper)).toEqual(["Cross-step Waltz", "Slow Waltz", "Viennese Waltz"]);
+
+    wrapper.vm.nameFilter = "cross";
+    expect(danceNames(wrapper)).toEqual(["Cross-step Waltz"]);
+  });
+
   test("deselecting every style empties the results, not 'show everything'", () => {
     const wrapper = mountTempoList();
     wrapper.vm.styles = [];

--- a/m4d/ClientApp/src/pages/tempo-list/__tests__/App.test.ts
+++ b/m4d/ClientApp/src/pages/tempo-list/__tests__/App.test.ts
@@ -4,6 +4,8 @@ import type { VueWrapper } from "@vue/test-utils";
 import App from "../App.vue";
 import { loadTestPage } from "@/helpers/TestPageSnapshot";
 import { mockResizObserver } from "@/helpers/TestHelpers";
+import { loadTestDances } from "@/helpers/LoadTestDances";
+import { DanceDatabase } from "@/models/DanceDatabase/DanceDatabase";
 import { Meter } from "@/models/DanceDatabase/Meter";
 import { MenuContext } from "@/models/MenuContext";
 
@@ -19,8 +21,9 @@ vi.mock("@/helpers/GetMenuContext", () => ({
 
 // Dances shown with every filter checkbox selected: every dance except the 9 "Performance" group
 // dances and Pattern, none of which have a real tempo (see the "tempo-based exclusion" test).
-const TIMED_DANCE_COUNT = 40;
-
+const TIMED_DANCE_COUNT = DanceDatabase.load(loadTestDances()).dances.filter(
+  (d) => !d.tempoRange.isInfinite,
+).length;
 function mountTempoList(
   model: Record<string, string[]> = {},
 ): VueWrapper<InstanceType<typeof App>> {

--- a/m4d/ClientApp/src/pages/tempo-list/__tests__/App.test.ts
+++ b/m4d/ClientApp/src/pages/tempo-list/__tests__/App.test.ts
@@ -1,0 +1,223 @@
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import { nextTick } from "vue";
+import type { VueWrapper } from "@vue/test-utils";
+import App from "../App.vue";
+import { loadTestPage } from "@/helpers/TestPageSnapshot";
+import { mockResizObserver } from "@/helpers/TestHelpers";
+import { Meter } from "@/models/DanceDatabase/Meter";
+import { MenuContext } from "@/models/MenuContext";
+
+const mockContext = new MenuContext({
+  userName: "dwgray",
+  roles: [],
+  xsrfToken: "TEST_XSRF",
+});
+
+vi.mock("@/helpers/GetMenuContext", () => ({
+  getMenuContext: () => mockContext,
+}));
+
+// Dances shown with every filter checkbox selected. This is NOT all 41 non-Performance dances:
+// DanceFilter.matchOrganizations uses `type.organizations.some(...)`, which is false for any
+// dance whose instances list no organizations at all (e.g. "Social"-only dances like Cross-step
+// Waltz or Lindy Hop) regardless of which organizations are selected. So "select all" silently
+// hides every organization-less dance — see the dedicated test below and the architecture doc's
+// "Known Gaps" section.
+const DEFAULT_FILTERED_COUNT = 23;
+
+function mountTempoList(
+  model: Record<string, string[]> = {},
+): VueWrapper<InstanceType<typeof App>> {
+  return loadTestPage(App, model) as unknown as VueWrapper<InstanceType<typeof App>>;
+}
+
+function danceNames(wrapper: ReturnType<typeof mountTempoList>): string[] {
+  return wrapper.vm.dances.map((d: { name: string }) => d.name).sort();
+}
+
+function checkboxGroup(wrapper: ReturnType<typeof mountTempoList>, groupId: string) {
+  return wrapper.find(`#${groupId}`).findAll(".form-check");
+}
+
+function findCheckbox(wrapper: ReturnType<typeof mountTempoList>, groupId: string, label: string) {
+  const match = checkboxGroup(wrapper, groupId).find((fc) => fc.text() === label);
+  if (!match) {
+    throw new Error(`No checkbox labeled "${label}" found in #${groupId}`);
+  }
+  return match.find("input");
+}
+
+describe("tempo-list App.vue", () => {
+  beforeEach(() => {
+    mockResizObserver();
+  });
+
+  test("defaults to every filter selected and shows every non-Performance dance", () => {
+    const wrapper = mountTempoList();
+
+    expect(wrapper.vm.styles.length).toBe(wrapper.vm.styleOptions.length);
+    expect(wrapper.vm.types.length).toBe(wrapper.vm.typeOptions.length);
+    expect(wrapper.vm.organizations.length).toBe(wrapper.vm.organizationOptions.length);
+    expect(wrapper.vm.meters.length).toBe(3);
+
+    expect(wrapper.vm.dances.length).toBe(DEFAULT_FILTERED_COUNT);
+    expect(danceNames(wrapper)).toContain("Cha Cha");
+    expect(danceNames(wrapper)).not.toContain("Jazz");
+  });
+
+  test("the Type dropdown still lists 'Performance' even though no Performance dance can ever show", () => {
+    // DanceDatabase.filter() rebuilds its `groups` list by scanning `this.dances` — the
+    // *original*, pre-filter dance list — instead of the `dances` it just filtered
+    // (DanceDatabase.ts:119). So even though App.vue filters "Performance" out of
+    // danceDatabase.dances up front, danceDatabase.groups (and therefore the Type dropdown)
+    // still contains a "Performance" checkbox. Selecting only it yields zero results, because
+    // there are no Performance dances left to match.
+    const wrapper = mountTempoList();
+
+    expect(wrapper.vm.typeOptions.map((o: { text: string }) => o.text)).toContain("Performance");
+
+    wrapper.vm.types = ["performance"];
+    expect(wrapper.vm.dances).toEqual([]);
+  });
+
+  test("organization-less dances are hidden even with every organization selected", () => {
+    // Cross-step Waltz and Lindy Hop are "Social"-style dances with no organization affiliation
+    // in the content data. Because DanceFilter.matchOrganizations checks
+    // `type.organizations.some(...)`, an empty organizations array can never match, even though
+    // every organization checkbox is checked. This is the reason DEFAULT_FILTERED_COUNT (23) is
+    // well under the 41 non-Performance dances that exist.
+    const wrapper = mountTempoList();
+
+    expect(wrapper.vm.organizations.length).toBe(wrapper.vm.organizationOptions.length);
+    expect(danceNames(wrapper)).not.toContain("Cross-step Waltz");
+    expect(danceNames(wrapper)).not.toContain("Lindy Hop");
+  });
+
+  test("filters by style", () => {
+    const wrapper = mountTempoList();
+    wrapper.vm.styles = ["international-standard"];
+
+    expect(danceNames(wrapper)).toEqual([
+      "Quickstep",
+      "Slow Foxtrot",
+      "Slow Waltz",
+      "Tango (Ballroom)",
+      "Viennese Waltz",
+    ]);
+  });
+
+  test("filters by type (dance group)", () => {
+    const wrapper = mountTempoList();
+    wrapper.vm.types = ["waltz"];
+
+    // Cross-step Waltz and Tango Vals are also in the Waltz group but have no organization
+    // affiliation, so the (default, "all selected") organizations filter excludes them — see
+    // "organization-less dances are hidden" above.
+    expect(danceNames(wrapper)).toEqual(["Slow Waltz", "Viennese Waltz"]);
+  });
+
+  test("filters by meter", () => {
+    const wrapper = mountTempoList();
+    wrapper.vm.meters = [new Meter(3, 4)];
+
+    expect(danceNames(wrapper)).toEqual(["Slow Waltz", "Viennese Waltz"]);
+  });
+
+  test("filters by organization", () => {
+    const wrapper = mountTempoList();
+    wrapper.vm.organizations = ["ucwdc"];
+
+    expect(danceNames(wrapper)).toEqual([
+      "Cha Cha",
+      "Country Two Step",
+      "East Coast Swing",
+      "Night Club Two Step",
+      "Polka",
+      "Slow Waltz",
+      "Triple Two",
+      "West Coast Swing",
+    ]);
+  });
+
+  test("combines style, type, and meter filters (AND across dimensions)", () => {
+    const wrapper = mountTempoList();
+    wrapper.vm.styles = ["american-rhythm"];
+    wrapper.vm.types = ["latin"];
+    wrapper.vm.meters = [new Meter(4, 4)];
+
+    // Paso Doble and Samba are Latin/American Rhythm but 2/4 meter, so the meter
+    // filter excludes them even though the style and type filters would include them.
+    expect(danceNames(wrapper)).toEqual([
+      "Bachata",
+      "Bolero",
+      "Cha Cha",
+      "Mambo",
+      "Merengue",
+      "Rumba",
+      "Salsa",
+    ]);
+  });
+
+  test("deselecting every style empties the results, not 'show everything'", () => {
+    const wrapper = mountTempoList();
+    wrapper.vm.styles = [];
+
+    expect(wrapper.vm.dances).toEqual([]);
+  });
+
+  test("the meter filter ignores the server-provided model (known gap)", () => {
+    // TempoListModel.Meters is populated server-side from the ?meters= query param, but
+    // App.vue's meters ref is seeded from a hard-coded option list and never reads model.meters.
+    const wrapper = mountTempoList({ meters: ["3/4"] });
+
+    expect(wrapper.vm.meters.length).toBe(3);
+    expect(wrapper.vm.dances.length).toBe(DEFAULT_FILTERED_COUNT);
+  });
+
+  test("seeds style selection from the server-provided model", () => {
+    const wrapper = mountTempoList({ styles: ["international-standard"] });
+
+    expect(wrapper.vm.styles).toEqual(["international-standard"]);
+    expect(danceNames(wrapper)).toEqual([
+      "Quickstep",
+      "Slow Foxtrot",
+      "Slow Waltz",
+      "Tango (Ballroom)",
+      "Viennese Waltz",
+    ]);
+  });
+
+  test("an invalid server-provided style is dropped rather than applied", () => {
+    const wrapper = mountTempoList({ styles: ["not-a-real-style"] });
+
+    // filterValid() drops values that don't match a known option, leaving nothing selected.
+    expect(wrapper.vm.styles).toEqual([]);
+    expect(wrapper.vm.dances).toEqual([]);
+  });
+
+  test("real checkbox interaction: unchecking 'select all' then checking 'Waltz' filters the table", async () => {
+    const wrapper = mountTempoList();
+
+    await wrapper.find("#type-all").setValue(false);
+    await findCheckbox(wrapper, "type-group", "Waltz").setValue(true);
+    await nextTick();
+
+    const rows = wrapper.findAll("tbody tr");
+    const rowText = rows.map((r) => r.text()).join(" | ");
+
+    expect(rows.length).toBe(2);
+    expect(rowText).toContain("Slow Waltz");
+    expect(rowText).toContain("Viennese Waltz");
+    expect(rowText).not.toContain("Cha Cha");
+  });
+
+  test("empty selection renders the TempoList empty-state caption", async () => {
+    const wrapper = mountTempoList();
+    const selectAll = wrapper.find("#style-all");
+    await selectAll.setValue(false);
+    await nextTick();
+
+    expect(wrapper.text()).toContain("Please select at least one item from every drop-down");
+    expect(wrapper.findAll("tbody tr").length).toBe(0);
+  });
+});

--- a/m4d/ClientApp/src/pages/tempo-list/__tests__/App.test.ts
+++ b/m4d/ClientApp/src/pages/tempo-list/__tests__/App.test.ts
@@ -138,6 +138,20 @@ describe("tempo-list App.vue", () => {
     ]);
   });
 
+  test("a dance's reported Type narrows to the selected group(s), like Styles/BPM/MPM already do", () => {
+    // Viennese Waltz belongs to both the Waltz and Country groups. Before the fix, its Type
+    // column always showed every group it belongs to ("Waltz, Country") regardless of which
+    // Type checkboxes were selected - unlike Styles/BPM/MPM, which already narrow correctly
+    // because they're derived from the (filter-narrowed) instances list.
+    const wrapper = mountTempoList();
+    wrapper.vm.types = ["waltz"];
+
+    const viennese = wrapper.vm.dances.find(
+      (d: { name: string }) => d.name === "Viennese Waltz",
+    ) as { groups: { name: string }[] };
+    expect(viennese.groups.map((g) => g.name)).toEqual(["Waltz"]);
+  });
+
   test("filters by meter", () => {
     const wrapper = mountTempoList();
     wrapper.vm.meters = [new Meter(3, 4)];
@@ -238,6 +252,11 @@ describe("tempo-list App.vue", () => {
     expect(rowText).toContain("Tango Vals");
     expect(rowText).toContain("Viennese Waltz");
     expect(rowText).not.toContain("Cha Cha");
+
+    // TempoList's fields are [name, meter, bpm, mpm, groupName (Type), styles] in that order.
+    const viennesRow = rows.find((r) => r.text().includes("Viennese Waltz"))!;
+    const typeCell = viennesRow.findAll("td")[4]!;
+    expect(typeCell.text()).toBe("Waltz");
   });
 
   test("empty selection renders the TempoList empty-state caption", async () => {

--- a/m4d/ClientApp/src/pages/tempo-list/__tests__/App.test.ts
+++ b/m4d/ClientApp/src/pages/tempo-list/__tests__/App.test.ts
@@ -17,13 +17,9 @@ vi.mock("@/helpers/GetMenuContext", () => ({
   getMenuContext: () => mockContext,
 }));
 
-// Dances shown with every filter checkbox selected. This is NOT all 41 non-Performance dances:
-// DanceFilter.matchOrganizations uses `type.organizations.some(...)`, which is false for any
-// dance whose instances list no organizations at all (e.g. "Social"-only dances like Cross-step
-// Waltz or Lindy Hop) regardless of which organizations are selected. So "select all" silently
-// hides every organization-less dance — see the dedicated test below and the architecture doc's
-// "Known Gaps" section.
-const DEFAULT_FILTERED_COUNT = 23;
+// Dances shown with every filter checkbox selected: every dance except the 9 "Performance" group
+// dances and Pattern, none of which have a real tempo (see the "tempo-based exclusion" test).
+const TIMED_DANCE_COUNT = 40;
 
 function mountTempoList(
   model: Record<string, string[]> = {},
@@ -52,7 +48,7 @@ describe("tempo-list App.vue", () => {
     mockResizObserver();
   });
 
-  test("defaults to every filter selected and shows every non-Performance dance", () => {
+  test("defaults to every filter selected and shows every timed, non-Performance dance", () => {
     const wrapper = mountTempoList();
 
     expect(wrapper.vm.styles.length).toBe(wrapper.vm.styleOptions.length);
@@ -60,35 +56,59 @@ describe("tempo-list App.vue", () => {
     expect(wrapper.vm.organizations.length).toBe(wrapper.vm.organizationOptions.length);
     expect(wrapper.vm.meters.length).toBe(3);
 
-    expect(wrapper.vm.dances.length).toBe(DEFAULT_FILTERED_COUNT);
+    expect(wrapper.vm.dances.length).toBe(TIMED_DANCE_COUNT);
     expect(danceNames(wrapper)).toContain("Cha Cha");
-    expect(danceNames(wrapper)).not.toContain("Jazz");
+    // Organization-less "Social" dances are included once every organization is selected.
+    expect(danceNames(wrapper)).toContain("Cross-step Waltz");
+    expect(danceNames(wrapper)).toContain("Lindy Hop");
   });
 
-  test("the Type dropdown still lists 'Performance' even though no Performance dance can ever show", () => {
-    // DanceDatabase.filter() rebuilds its `groups` list by scanning `this.dances` — the
-    // *original*, pre-filter dance list — instead of the `dances` it just filtered
-    // (DanceDatabase.ts:119). So even though App.vue filters "Performance" out of
-    // danceDatabase.dances up front, danceDatabase.groups (and therefore the Type dropdown)
-    // still contains a "Performance" checkbox. Selecting only it yields zero results, because
-    // there are no Performance dances left to match.
+  test("Performance dances, and any other dance with no real tempo, are excluded", () => {
+    // App.vue used to exclude dances by group name ("Performance"), which missed Pattern - a
+    // "Social"-style, "Other"-group dance that (like every Performance dance) has no actual
+    // tempo: its only instance carries the same {min:1, max:500} placeholder range used to mark
+    // "no meaningful tempo" (TempoRange.isInfinite). Filtering by tempoRange.isInfinite instead
+    // catches both.
     const wrapper = mountTempoList();
 
-    expect(wrapper.vm.typeOptions.map((o: { text: string }) => o.text)).toContain("Performance");
-
-    wrapper.vm.types = ["performance"];
-    expect(wrapper.vm.dances).toEqual([]);
+    const names = danceNames(wrapper);
+    expect(names).not.toContain("Jazz");
+    expect(names).not.toContain("Contemporary");
+    expect(names).not.toContain("Pattern");
   });
 
-  test("organization-less dances are hidden even with every organization selected", () => {
-    // Cross-step Waltz and Lindy Hop are "Social"-style dances with no organization affiliation
-    // in the content data. Because DanceFilter.matchOrganizations checks
-    // `type.organizations.some(...)`, an empty organizations array can never match, even though
-    // every organization checkbox is checked. This is the reason DEFAULT_FILTERED_COUNT (23) is
-    // well under the 41 non-Performance dances that exist.
+  test("the Type dropdown no longer offers a dead 'Performance' option", () => {
+    // DanceDatabase.filter() used to rebuild its `groups` list by scanning the *original*,
+    // pre-filter dance list instead of the dances it had just filtered, so "Performance" lingered
+    // as a Type checkbox even though no Performance dance could ever be selected. Now that
+    // App.vue excludes those dances by tempo up front and DanceDatabase.filter() derives groups
+    // from the surviving dances, the option is gone entirely.
+    const wrapper = mountTempoList();
+
+    expect(wrapper.vm.typeOptions.map((o: { text: string }) => o.text)).not.toContain(
+      "Performance",
+    );
+  });
+
+  test("organization-less dances are shown when every organization is selected", () => {
+    // Cross-step Waltz has no organization affiliation in the content data.
+    // DanceFilter.matchOrganizations can never match an empty organizations list against
+    // anything, so App.vue now normalizes "every organization checked" to `undefined` (no
+    // restriction) rather than passing the full explicit list through - see the "combo" comment
+    // in App.vue's `dances` computed.
     const wrapper = mountTempoList();
 
     expect(wrapper.vm.organizations.length).toBe(wrapper.vm.organizationOptions.length);
+    expect(danceNames(wrapper)).toContain("Cross-step Waltz");
+  });
+
+  test("a deliberate, narrow organization selection still excludes organization-less dances", () => {
+    // The "select all -> undefined" normalization only applies when every option is checked.
+    // Selecting one specific organization must still mean "only dances affiliated with it" -
+    // an organization-less dance shouldn't appear just because the filter isn't empty.
+    const wrapper = mountTempoList();
+    wrapper.vm.organizations = ["ucwdc"];
+
     expect(danceNames(wrapper)).not.toContain("Cross-step Waltz");
     expect(danceNames(wrapper)).not.toContain("Lindy Hop");
   });
@@ -110,17 +130,24 @@ describe("tempo-list App.vue", () => {
     const wrapper = mountTempoList();
     wrapper.vm.types = ["waltz"];
 
-    // Cross-step Waltz and Tango Vals are also in the Waltz group but have no organization
-    // affiliation, so the (default, "all selected") organizations filter excludes them — see
-    // "organization-less dances are hidden" above.
-    expect(danceNames(wrapper)).toEqual(["Slow Waltz", "Viennese Waltz"]);
+    expect(danceNames(wrapper)).toEqual([
+      "Cross-step Waltz",
+      "Slow Waltz",
+      "Tango Vals",
+      "Viennese Waltz",
+    ]);
   });
 
   test("filters by meter", () => {
     const wrapper = mountTempoList();
     wrapper.vm.meters = [new Meter(3, 4)];
 
-    expect(danceNames(wrapper)).toEqual(["Slow Waltz", "Viennese Waltz"]);
+    expect(danceNames(wrapper)).toEqual([
+      "Cross-step Waltz",
+      "Slow Waltz",
+      "Tango Vals",
+      "Viennese Waltz",
+    ]);
   });
 
   test("filters by organization", () => {
@@ -171,7 +198,7 @@ describe("tempo-list App.vue", () => {
     const wrapper = mountTempoList({ meters: ["3/4"] });
 
     expect(wrapper.vm.meters.length).toBe(3);
-    expect(wrapper.vm.dances.length).toBe(DEFAULT_FILTERED_COUNT);
+    expect(wrapper.vm.dances.length).toBe(TIMED_DANCE_COUNT);
   });
 
   test("seeds style selection from the server-provided model", () => {
@@ -205,8 +232,10 @@ describe("tempo-list App.vue", () => {
     const rows = wrapper.findAll("tbody tr");
     const rowText = rows.map((r) => r.text()).join(" | ");
 
-    expect(rows.length).toBe(2);
+    expect(rows.length).toBe(4);
+    expect(rowText).toContain("Cross-step Waltz");
     expect(rowText).toContain("Slow Waltz");
+    expect(rowText).toContain("Tango Vals");
     expect(rowText).toContain("Viennese Waltz");
     expect(rowText).not.toContain("Cha Cha");
   });

--- a/m4d/ClientApp/src/pages/tempo-list/components/CheckedList.vue
+++ b/m4d/ClientApp/src/pages/tempo-list/components/CheckedList.vue
@@ -87,7 +87,7 @@ function toggleAll(checked: CheckboxValue | readonly CheckboxValue[] | undefined
 
 <template>
   <BDropdown
-    id="dropdown-form"
+    :id="computedId + '-dropdown'"
     ref="dropdown"
     :text="title"
     :variant="props.variant"

--- a/m4d/ClientApp/src/pages/tempo-list/components/CheckedList.vue
+++ b/m4d/ClientApp/src/pages/tempo-list/components/CheckedList.vue
@@ -1,14 +1,24 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { type CheckboxValue, type CheckboxOption } from "bootstrap-vue-next";
+import {
+  type CheckboxValue,
+  type CheckboxOption,
+  type ButtonVariant,
+  type Size,
+} from "bootstrap-vue-next";
 import { valuesFromOptions, isComparable } from "@/models/CheckboxTypes";
 import { wordsToKebab } from "@/helpers/StringHelpers";
 
 const model = defineModel<CheckboxValue[]>({ required: true });
-const props = defineProps<{
-  type: string;
-  options: CheckboxOption[];
-}>();
+const props = withDefaults(
+  defineProps<{
+    type: string;
+    options: CheckboxOption[];
+    variant?: ButtonVariant;
+    size?: Size;
+  }>(),
+  { variant: "primary", size: undefined },
+);
 
 const title = computed(() => {
   if (allSelected.value) {
@@ -80,7 +90,8 @@ function toggleAll(checked: CheckboxValue | readonly CheckboxValue[] | undefined
     id="dropdown-form"
     ref="dropdown"
     :text="title"
-    variant="primary"
+    :variant="props.variant"
+    :size="props.size"
     style="margin-bottom: 8px"
     auto-close="outside"
   >

--- a/m4d/ClientApp/src/pages/tempo-list/components/TempoList.vue
+++ b/m4d/ClientApp/src/pages/tempo-list/components/TempoList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { defaultTempoLink } from "@/helpers/LinkHelpers";
 import { wordsToKebab } from "@/helpers/StringHelpers";
-import type { TableFieldRaw, BTableSortBy } from "bootstrap-vue-next";
+import type { TableFieldRaw, BTableSortBy, CheckboxOption } from "bootstrap-vue-next";
 import { computed, ref } from "vue";
 import type { DanceType } from "@/models/DanceDatabase/DanceType";
 
@@ -16,7 +16,33 @@ const emptyTable = computed(() => {
   return props.dances.length === 0 ? "Please select at least one item from every drop-down" : "";
 });
 
-const fields: Exclude<TableFieldRaw<DanceType>, string>[] = [
+// Columns an advanced user can hide - "name" is always shown and isn't offered here. New optional
+// columns should be added to this list with `defaultVisible: false` so casual users don't see
+// their table layout change out from under them.
+interface ChooseableColumn {
+  key: string;
+  label: string;
+  defaultVisible: boolean;
+}
+
+const chooseableColumns: ChooseableColumn[] = [
+  { key: "meter", label: "Meter", defaultVisible: true },
+  { key: "bpm", label: "BPM", defaultVisible: true },
+  { key: "mpm", label: "MPM", defaultVisible: true },
+  { key: "groupName", label: "Type", defaultVisible: true },
+  { key: "styles", label: "Styles", defaultVisible: true },
+];
+
+const columnOptions: CheckboxOption[] = chooseableColumns.map((c) => ({
+  text: c.label,
+  value: c.key,
+}));
+
+const visibleColumns = ref<string[]>(
+  chooseableColumns.filter((c) => c.defaultVisible).map((c) => c.key),
+);
+
+const allFields: Exclude<TableFieldRaw<DanceType>, string>[] = [
   {
     key: "name",
     sortable: true,
@@ -80,6 +106,10 @@ const fields: Exclude<TableFieldRaw<DanceType>, string>[] = [
   },
 ];
 
+const fields = computed(() =>
+  allFields.filter((f) => f.key === "name" || visibleColumns.value.includes(f.key as string)),
+);
+
 function groupLink(dance: DanceType): string {
   return m4dLink(dance.groups?.[0]?.name || "");
 }
@@ -142,5 +172,15 @@ function formatType(dance: DanceType): string {
         </span>
       </template>
     </BTable>
+    <div class="d-flex align-items-center gap-2">
+      <span class="text-muted small">Columns:</span>
+      <CheckedList
+        v-model="visibleColumns"
+        type="Column"
+        :options="columnOptions"
+        variant="outline-secondary"
+        size="sm"
+      />
+    </div>
   </div>
 </template>

--- a/m4d/ClientApp/src/pages/tempo-list/components/__tests__/TempoList.test.ts
+++ b/m4d/ClientApp/src/pages/tempo-list/components/__tests__/TempoList.test.ts
@@ -1,0 +1,121 @@
+import { describe, test, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import TempoList from "../TempoList.vue";
+import { DanceType } from "@/models/DanceDatabase/DanceType";
+import { DanceInstance } from "@/models/DanceDatabase/DanceInstance";
+import { DanceGroup } from "@/models/DanceDatabase/DanceGroup";
+import { TempoRange } from "@/models/DanceDatabase/TempoRange";
+import { Meter } from "@/models/DanceDatabase/Meter";
+
+const waltzGroup = new DanceGroup({ internalId: "WAL", internalName: "Waltz", danceIds: [] });
+const countryGroup = new DanceGroup({ internalId: "CTY", internalName: "Country", danceIds: [] });
+
+function buildDance(): DanceType {
+  const dance = new DanceType({
+    internalId: "SWZ",
+    internalName: "Slow Waltz",
+    meter: new Meter(3, 4),
+    instances: [
+      new DanceInstance({
+        style: "International Standard",
+        tempoRange: new TempoRange(84, 90),
+        organizations: [],
+      }),
+      new DanceInstance({
+        style: "Country",
+        tempoRange: new TempoRange(80, 88),
+        organizations: [],
+      }),
+    ],
+  });
+  // groups is a plain field populated by DanceDatabase.onDeserialized() in production; set it
+  // directly here since we're building the fixture by hand.
+  dance.groups = [waltzGroup, countryGroup];
+  return dance;
+}
+
+function buildOtherDance(): DanceType {
+  return new DanceType({
+    internalId: "CHA",
+    internalName: "Cha Cha",
+    meter: new Meter(4, 4),
+    instances: [
+      new DanceInstance({
+        style: "American Rhythm",
+        tempoRange: new TempoRange(120, 128),
+        organizations: [],
+      }),
+    ],
+  });
+}
+
+describe("TempoList.vue", () => {
+  test("renders one row per dance, sorted by name ascending by default", () => {
+    const wrapper = mount(TempoList, {
+      props: { dances: [buildDance(), buildOtherDance()] },
+    });
+
+    const rows = wrapper.findAll("tbody tr");
+    expect(rows.length).toBe(2);
+    // "Cha Cha" sorts before "Slow Waltz"
+    expect(rows[0]!.text()).toContain("Cha Cha");
+    expect(rows[1]!.text()).toContain("Slow Waltz");
+  });
+
+  test("name cell links to the dance page", () => {
+    const wrapper = mount(TempoList, { props: { dances: [buildDance()] } });
+
+    const link = wrapper.find("a[href='/dances/slow-waltz']");
+    expect(link.exists()).toBe(true);
+    expect(link.text()).toBe("Slow Waltz");
+  });
+
+  test("meter, BPM, and MPM columns are formatted from the dance's tempo range", () => {
+    const wrapper = mount(TempoList, { props: { dances: [buildDance()] } });
+    const row = wrapper.find("tbody tr");
+
+    expect(row.text()).toContain("3/4");
+    // tempoRange spans both instances: 80-90
+    expect(row.text()).toContain("80-90");
+    // mpm = bpm / meter.numerator (3) = 26.7-30
+    expect(row.text()).toContain(new TempoRange(80, 90).mpm(3));
+  });
+
+  test("BPM and MPM cells link to the tempo-filtered search", () => {
+    const wrapper = mount(TempoList, { props: { dances: [buildDance()] } });
+
+    const links = wrapper
+      .findAll("a")
+      .filter((a) => a.attributes("href")?.includes("advancedsearch"));
+    expect(links.length).toBe(2);
+    expect(links[0]!.attributes("href")).toBe(
+      "/song/advancedsearch?dances=SWZ&tempomin=80&tempomax=90&sortorder=Dances",
+    );
+  });
+
+  test("type cell links using only the dance's first group", () => {
+    const wrapper = mount(TempoList, { props: { dances: [buildDance()] } });
+    const row = wrapper.find("tbody tr");
+
+    expect(row.text()).toContain("Waltz, Country");
+    const groupLink = wrapper.find("a[href='/dances/Waltz']");
+    expect(groupLink.exists()).toBe(true);
+    expect(wrapper.find("a[href='/dances/Country']").exists()).toBe(false);
+  });
+
+  test("multi-word styles link, single-word styles render as plain text", () => {
+    const wrapper = mount(TempoList, { props: { dances: [buildDance()] } });
+    const row = wrapper.find("tbody tr");
+
+    expect(row.text()).toContain("International Standard, Country");
+    expect(wrapper.find("a[href='/dances/international-standard']").exists()).toBe(true);
+    expect(wrapper.find("a[href='/dances/country']").exists()).toBe(false);
+  });
+
+  test("shows the empty-selection caption and no rows when there are no dances", () => {
+    const wrapper = mount(TempoList, { props: { dances: [] } });
+
+    expect(wrapper.text()).toContain("Please select at least one item from every drop-down");
+    expect(wrapper.findAll("tbody tr").length).toBe(0);
+  });
+});

--- a/m4d/ClientApp/src/pages/tempo-list/components/__tests__/TempoList.test.ts
+++ b/m4d/ClientApp/src/pages/tempo-list/components/__tests__/TempoList.test.ts
@@ -118,4 +118,54 @@ describe("TempoList.vue", () => {
     expect(wrapper.text()).toContain("Please select at least one item from every drop-down");
     expect(wrapper.findAll("tbody tr").length).toBe(0);
   });
+
+  describe("column chooser", () => {
+    function mountList() {
+      return mount(TempoList, { props: { dances: [buildDance()] } });
+    }
+
+    function columnCheckbox(wrapper: ReturnType<typeof mountList>, label: string) {
+      const match = wrapper
+        .find("#column-group")
+        .findAll(".form-check")
+        .find((fc) => fc.text() === label);
+      if (!match) {
+        throw new Error(`No checkbox labeled "${label}" found in #column-group`);
+      }
+      return match.find("input");
+    }
+
+    test("every optional column is visible by default", () => {
+      const wrapper = mountList();
+      const headerText = wrapper.find("thead").text();
+
+      expect(headerText).toContain("Meter");
+      expect(headerText).toContain("BPM");
+      expect(headerText).toContain("MPM");
+      expect(headerText).toContain("Type");
+      expect(headerText).toContain("Styles");
+    });
+
+    test("the Name column is always shown and isn't offered as a choice", () => {
+      const wrapper = mountList();
+      const labels = wrapper
+        .find("#column-group")
+        .findAll(".form-check")
+        .map((fc) => fc.text());
+
+      expect(labels).toEqual(["Meter", "BPM", "MPM", "Type", "Styles"]);
+    });
+
+    test("unchecking a column in the chooser removes it from the table", async () => {
+      const wrapper = mountList();
+
+      await columnCheckbox(wrapper, "BPM").setValue(false);
+
+      expect(wrapper.find("thead").text()).not.toContain("BPM");
+      // 80-90 is the BPM cell's content; MPM (a different formatted value) still shows.
+      expect(wrapper.find("tbody tr").text()).not.toContain("80-90");
+      const link = wrapper.find("a[href='/dances/slow-waltz']");
+      expect(link.exists()).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Documented the Tempo List page (`architecture/tempo-list-page.md`) and fixed several bugs found in the process: dances with no real tempo (Performance dances, Pattern) were leaking into the list, a dead "Performance" Type option lingered, organization-less "Social" dances were incorrectly hidden by default, and the Type column didn't narrow to the selected group(s) the way BPM/MPM/Styles already did.
- Added a name filter row (new shared `NameFilterInput.vue`, also adopted by `dance-index`) and a column chooser for the results table, so an advanced user can show/hide optional columns as more get added later.
- Fixed a pre-existing visual bug where the search icon next to dance-name filters wasn't a proper `BInputGroupText`, leaving the input with square corners.

## Test plan
- [x] `yarn type-check`
- [x] `yarn eslint` on touched files
- [x] `yarn vitest run` for `tempo-list`, `dance-index`, and dependents of the shared components (all passing, snapshots updated where markup intentionally changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)