### PR TITLE
Spotify playlist viewer: album support, paste-URL fix, performance

### DIFF
--- a/architecture/music-service-api-calls.md
+++ b/architecture/music-service-api-calls.md
@@ -236,51 +236,55 @@ Only runs when the song has exactly one dance rating. Uses `dance.ValidateTempo(
 
 ## Playlist Lookup
 
-### `LookupPlaylist(service, url, oldTrackList?, principal?)`
+### `LookupPlaylist(service, url, oldTrackList?, principal?, includeGenres = true, maxTracks = null)`
 
 1. Calls `service.BuildLookupRequest(url)` to translate a user-facing URL to an API URL.
    - Spotify album URL → `GET /v1/albums/{id}`
    - Spotify playlist URL → `GET /v1/playlists/{id}` (or `/v1/users/{user}/playlists/{id}`)
-2. Parses name, description, owner from top-level response.
-3. Calls `service.ParseSearchResults` for the track list (items array), filtering out `oldTrackList` IDs.
-4. Paginates via `NextMusicServiceResults` → `service.GetNextRequest(last)` → Spotify's `tracks.next`.
+2. Parses name, description, owner (or, for albums, the contributing artist(s) as a fallback) from
+   the top-level response, plus `TotalCount` from the response's own paging metadata
+   (`tracks.total`/`total`) — this is the *true* track count, independent of `maxTracks` below.
+3. Calls `service.ParseSearchResults` for the track list (items array), filtering out `oldTrackList`
+   IDs and passing `includeGenres` through to `ParseTrackResults`.
+4. Paginates via `NextMusicServiceResults` → `service.GetNextRequest(last)` → Spotify's `tracks.next`,
+   stopping early once `tracks.Count >= maxTracks` (when `maxTracks` is given) rather than always
+   fetching every page.
 5. Calls `ComputeTrackPurchaseInfo` to add purchase links.
 
-`LookupPlaylistWithAudioData` extends this by calling `FillEchoTracks` for Spotify playlists.
+`LookupPlaylistWithAudioData` extends this by calling `FillEchoTracks` for Spotify playlists, and
+forwards `includeGenres`/`maxTracks` unchanged.
 
-### Known Performance Issue: Per-Track Genre Enrichment
+### Per-Track Genre Enrichment (previously a performance problem — now fixed)
 
 `SongController.Playlist` (the read-only playlist/album viewer — see
 [[song-search-results]] § "Playlist") calls `LookupPlaylist` directly and only ever reads
 `TrackId`/`Name`/`Artist`/`ISRC` off the returned tracks to build its `ServiceIds/any(...)` catalog
-match. In practice, viewing a playlist of even moderate size can take multiple *minutes* — far more
-than the "one paginated fetch + one Azure Search round-trip" the feature should cost. Tracing the
-call chain:
+match. Viewing a playlist of even moderate size used to take multiple *minutes* — far more than the
+"one paginated fetch + one Azure Search round-trip" the feature should cost. Tracing the call chain:
 
 1. `service.ParseSearchResults` (`SpotifyService.cs`) parses each page's tracks in a `foreach` loop,
    `await`-ing `ParseTrackResults` **one track at a time** — no batching or parallelism.
-2. `ParseTrackResults` calls `BuildGenres(track, getResult)` for **every track**, which:
+2. `ParseTrackResults` called `BuildGenres(track, getResult)` for **every track**, which:
    - fetches the track's album via `GenresFromReference(track.album, getResult)` — one live
      `GET` to the album's `href` — to read its genre list, and
    - fetches **every artist on the track** the same way, one `GET` per artist.
    - Genres are never present inline on a track/playlist/album response; they only exist on the
      album/artist resources, so this is unavoidable *if genres are needed*.
 3. The cache that's supposed to dedupe repeated album/artist lookups
-   (`SpotifyService.s_results`, keyed by URL) is **dead code** — `GetResults` only ever reads it
-   (`s_results.TryGetValue`); nothing in the class ever writes to it. So even a 12-track album by one
-   artist, or a playlist full of tracks from the same album, re-fetches that album's/artist's genres
+   (`SpotifyService.s_results`, keyed by URL) was **dead code** — `GetResults` only ever read it
+   (`s_results.TryGetValue`); nothing in the class ever wrote to it. So even a 12-track album by one
+   artist, or a playlist full of tracks from the same album, re-fetched that album's/artist's genres
    from scratch on every track instead of once.
-4. Each of those calls goes through `GetMusicServiceManager.GetMusicServiceResults`, which retries
-   on `401`/`429` with a **blocking `Thread.Sleep(15_000)`** (rate-limited) or
-   `Thread.Sleep(3_000)` (pre-emptive throttle) — not `Task.Delay` — so once the inflated call
-   volume from (1)-(3) trips Spotify's per-app rate limit, a handful of tracks can each add a
-   synchronous 15-second stall. This is the likely source of the multi-*minute* outlier cases (as
-   opposed to the tens-of-seconds cost the uncached-but-not-rate-limited case would already imply).
+4. Each of those calls goes through `MusicServiceManager.GetMusicServiceResults`, which retries
+   on `401`/`429` with a **blocking `Thread.Sleep`** (15s rate-limited, 3s pre-emptive throttle,
+   60s iTunes-specific) — not `Task.Delay` — so once the inflated call volume from (1)-(3) tripped
+   Spotify's per-app rate limit, a handful of tracks could each add a synchronous multi-second
+   stall on a thread-pool thread. Likely source of the multi-*minute* outlier cases.
 5. `SongController.Playlist` bounds how many *displayed* tracks it wants via
-   `MatchLimitForSubscription` (10-500 depending on tier) — but that `.Take(matchLimit)` happens
-   **after** `LookupPlaylist` has already paginated through and genre-enriched the *entire*
-   playlist/album. A 2,000-track playlist costs the same to load as it would for a Gold-tier viewer
-   even when an anonymous visitor will only ever see 10 of those tracks.
+   `MatchLimitForSubscription` (10-500 depending on tier) — but that `.Take(matchLimit)` happened
+   **after** `LookupPlaylist` had already paginated through and genre-enriched the *entire*
+   playlist/album. A 2,000-track playlist cost the same to load as it would for a Gold-tier viewer
+   even when an anonymous visitor would only ever see 10 of those tracks.
 
 None of this enrichment is needed for the playlist-viewer's job (matching by Spotify id, falling
 back to ISRC — both already present inline on each track item with zero extra calls, per the
@@ -290,25 +294,31 @@ also used by genuinely genre-consuming paths — song creation/import
 `MusicServiceManager.cs:241`, as does `SongController.cs:1934` for the admin track-import flow) and
 the admin `PlayList` sync (`PlayListController.LoadServicePlaylist` also calls `LookupPlaylist`
 directly, likely for the same reason) — so trimming genre-fetching out of `ParseTrackResults`
-globally would regress those.
+globally would have regressed those.
 
-**Proposed fix** (not yet implemented — pending review):
+**Fix (implemented):**
 
-- Give `LookupPlaylist`/`ParseSearchResults`/`ParseTrackResults` a way to skip genre enrichment
-  (e.g. a `bool includeGenres = true` parameter threaded down to `BuildGenres`, or a cheaper
-  sibling method), and have `SongController.Playlist`'s call opt out of it — the two other callers
-  (`PlayListController.LoadServicePlaylist`, `ServicePlaylistController`'s
-  `LookupPlaylistWithAudioData`) keep the current behavior.
-- Fix `SpotifyService.s_results` to actually be written to in `GetResults`, so that even where
-  genre enrichment *is* requested, repeated albums/artists within one playlist are fetched once.
-  (Low-risk, purely additive — worth doing regardless of the above.)
-- Bound `LookupPlaylist`'s pagination/enrichment to `matchLimit` for the viewer path, so
-  `SongController.Playlist` never fetches or enriches tracks past what it's actually going to
-  display, instead of paginating the whole playlist and discarding the tail with `.Take`.
-- Lower priority: replace the `Thread.Sleep` retries in `GetMusicServiceResults` with `await
-  Task.Delay`, since a blocking sleep inside an `async` method ties up a thread-pool thread for the
-  duration — a pre-existing issue independent of this feature, but one the reduced call volume
-  above would make far less likely to matter in practice.
+- `ParseSearchResults`/`ParseTrackResults` (`MusicService` base, `SpotifyService`, `ITunesService`,
+  `ISRCService`) take an `includeGenres = true` parameter; `SpotifyService.ParseTrackResults` only
+  calls `BuildGenres` when it's true. `SongController.Playlist`'s call passes
+  `includeGenres: false`; the other two callers (`PlayListController.LoadServicePlaylist`,
+  `ServicePlaylistController`'s `LookupPlaylistWithAudioData`) keep the default, so genre tagging
+  for song creation/import and admin playlist sync is unaffected.
+- `SpotifyService.s_results` is now actually written to in `GetResults` (guarded by a
+  `s_resultsLock` around every read/write/eviction, since `Dictionary<>` isn't thread-safe and this
+  is hit concurrently by ASP.NET requests), so repeated albums/artists within one playlist are
+  fetched once — same unbounded-but-cleared-at-10k shape as `MusicServiceManager.s_trackCache`. A
+  failed/null lookup is never cached, so a transient Spotify error doesn't get memoized as
+  "no data" until the next eviction.
+- `LookupPlaylist` takes `maxTracks`, and `SongController.Playlist` passes its `matchLimit`, so
+  pagination (and therefore genre-fetching, when enabled) stops once enough tracks exist for the
+  viewer's subscription tier — instead of fetching/enriching the whole playlist and discarding the
+  tail with `.Take`. The true total is preserved separately as `GenericPlaylist.TotalCount`
+  (`PlaylistViewerModel.TotalCount` on the client), read from the response's paging metadata rather
+  than `Tracks.Count`.
+- The `Thread.Sleep` retries in `GetMusicServiceResults` (3s/15s/15s/60s) are now `await
+  Task.Delay`, so a throttled request no longer parks a thread-pool thread for the wait — this
+  benefits every caller, not just the playlist viewer.
 
 ---
 

--- a/architecture/music-service-api-calls.md
+++ b/architecture/music-service-api-calls.md
@@ -248,6 +248,68 @@ Only runs when the song has exactly one dance rating. Uses `dance.ValidateTempo(
 
 `LookupPlaylistWithAudioData` extends this by calling `FillEchoTracks` for Spotify playlists.
 
+### Known Performance Issue: Per-Track Genre Enrichment
+
+`SongController.Playlist` (the read-only playlist/album viewer — see
+[[song-search-results]] § "Playlist") calls `LookupPlaylist` directly and only ever reads
+`TrackId`/`Name`/`Artist`/`ISRC` off the returned tracks to build its `ServiceIds/any(...)` catalog
+match. In practice, viewing a playlist of even moderate size can take multiple *minutes* — far more
+than the "one paginated fetch + one Azure Search round-trip" the feature should cost. Tracing the
+call chain:
+
+1. `service.ParseSearchResults` (`SpotifyService.cs`) parses each page's tracks in a `foreach` loop,
+   `await`-ing `ParseTrackResults` **one track at a time** — no batching or parallelism.
+2. `ParseTrackResults` calls `BuildGenres(track, getResult)` for **every track**, which:
+   - fetches the track's album via `GenresFromReference(track.album, getResult)` — one live
+     `GET` to the album's `href` — to read its genre list, and
+   - fetches **every artist on the track** the same way, one `GET` per artist.
+   - Genres are never present inline on a track/playlist/album response; they only exist on the
+     album/artist resources, so this is unavoidable *if genres are needed*.
+3. The cache that's supposed to dedupe repeated album/artist lookups
+   (`SpotifyService.s_results`, keyed by URL) is **dead code** — `GetResults` only ever reads it
+   (`s_results.TryGetValue`); nothing in the class ever writes to it. So even a 12-track album by one
+   artist, or a playlist full of tracks from the same album, re-fetches that album's/artist's genres
+   from scratch on every track instead of once.
+4. Each of those calls goes through `GetMusicServiceManager.GetMusicServiceResults`, which retries
+   on `401`/`429` with a **blocking `Thread.Sleep(15_000)`** (rate-limited) or
+   `Thread.Sleep(3_000)` (pre-emptive throttle) — not `Task.Delay` — so once the inflated call
+   volume from (1)-(3) trips Spotify's per-app rate limit, a handful of tracks can each add a
+   synchronous 15-second stall. This is the likely source of the multi-*minute* outlier cases (as
+   opposed to the tens-of-seconds cost the uncached-but-not-rate-limited case would already imply).
+5. `SongController.Playlist` bounds how many *displayed* tracks it wants via
+   `MatchLimitForSubscription` (10-500 depending on tier) — but that `.Take(matchLimit)` happens
+   **after** `LookupPlaylist` has already paginated through and genre-enriched the *entire*
+   playlist/album. A 2,000-track playlist costs the same to load as it would for a Gold-tier viewer
+   even when an anonymous visitor will only ever see 10 of those tracks.
+
+None of this enrichment is needed for the playlist-viewer's job (matching by Spotify id, falling
+back to ISRC — both already present inline on each track item with zero extra calls, per the
+existing note in [[song-search-results]]). It exists because `ParseTrackResults` is a shared method
+also used by genuinely genre-consuming paths — song creation/import
+(`MusicServiceManager.UpdateFromTracks` reads `track.Genres` to tag a new song, per
+`MusicServiceManager.cs:241`, as does `SongController.cs:1934` for the admin track-import flow) and
+the admin `PlayList` sync (`PlayListController.LoadServicePlaylist` also calls `LookupPlaylist`
+directly, likely for the same reason) — so trimming genre-fetching out of `ParseTrackResults`
+globally would regress those.
+
+**Proposed fix** (not yet implemented — pending review):
+
+- Give `LookupPlaylist`/`ParseSearchResults`/`ParseTrackResults` a way to skip genre enrichment
+  (e.g. a `bool includeGenres = true` parameter threaded down to `BuildGenres`, or a cheaper
+  sibling method), and have `SongController.Playlist`'s call opt out of it — the two other callers
+  (`PlayListController.LoadServicePlaylist`, `ServicePlaylistController`'s
+  `LookupPlaylistWithAudioData`) keep the current behavior.
+- Fix `SpotifyService.s_results` to actually be written to in `GetResults`, so that even where
+  genre enrichment *is* requested, repeated albums/artists within one playlist are fetched once.
+  (Low-risk, purely additive — worth doing regardless of the above.)
+- Bound `LookupPlaylist`'s pagination/enrichment to `matchLimit` for the viewer path, so
+  `SongController.Playlist` never fetches or enriches tracks past what it's actually going to
+  display, instead of paginating the whole playlist and discarding the tail with `.Take`.
+- Lower priority: replace the `Thread.Sleep` retries in `GetMusicServiceResults` with `await
+  Task.Delay`, since a blocking sleep inside an `async` method ties up a thread-pool thread for the
+  duration — a pre-existing issue independent of this feature, but one the reduced call volume
+  above would make far less likely to matter in practice.
+
 ---
 
 ## Spotify Pagination

--- a/architecture/song-search-results.md
+++ b/architecture/song-search-results.md
@@ -140,15 +140,24 @@ through `DoAzureSearch`/`SongSearch` — see below.
 
 These return song lists but bypass `SongSearch` (and in some cases bypass Azure Search entirely).
 
-### `Playlist(string id)` — [SongController.cs:132](../m4d/Controllers/SongController.cs#L132)
+### `Playlist(string id, string type = "playlist")` — [SongController.cs:132](../m4d/Controllers/SongController.cs#L132)
 
 The endpoint this document was requested to set up for generalization. **Distinct from the admin
 playlist CRUD system** documented in [[playlist-management]] — that system manages persisted
 `PlayList` rows and periodic Spotify sync; this action is a stateless, anonymous, read-only viewer
-for an *arbitrary* Spotify playlist URL, matched on the fly:
+for an *arbitrary* Spotify playlist or album URL, matched on the fly:
 
-1. Looks up the Spotify playlist by ID via `MusicServiceManager.LookupPlaylist(spotify, "/playlist/{id}")`
-   (live Spotify API call, not the catalog).
+1. Looks up the Spotify playlist/album by ID via
+   `MusicServiceManager.LookupPlaylist(spotify, "/playlist/{id}")` or `"/album/{id}"` depending on
+   `type` (live Spotify API call, not the catalog). `SpotifyService.BuildLookupRequest` already
+   branched on `/album/` vs `/playlist/` before this was wired up here; the client-side matcher
+   (`ServiceMatcher.parseAlbum`, [ServiceMatcher.ts](../m4d/ClientApp/src/helpers/ServiceMatcher.ts))
+   and `useDropTarget`'s `checkService` route album links to `/song/playlist?id={id}&type=album`.
+   Since Spotify albums have no `owner`, `LookupPlaylist` falls back to the contributing artist(s)
+   for `OwnerName`/`OwnerId` when `owner` is absent, and stamps `GenericPlaylist.IsAlbum` from the
+   URL so `PlaylistViewerModel.IsAlbum` can drive the client's link-building
+   (`open.spotify.com/album/…`, `/embed/album/…`, `/artist/…` instead of `/playlist/…`,
+   `/embed/playlist/…`, `/user/…`).
 2. Builds an OData filter directly (`ServiceIds/any(id: search.in(id, 'S:track1,S:track2,...'))`)
    matching catalog songs whose Spotify service ID appears in the playlist's track list.
 3. Calls `SongIndex.Search(null, options, CruftFilter.NoCruft)` directly — no `SongFilter`, no
@@ -185,6 +194,22 @@ the next piece of work.
 > the matched/sorted results, same as a direct id match. This still costs exactly one extra Azure
 > Search round-trip per playlist view (not one per unmatched track), and is bounded by the same
 > subscription-tier `candidateTracks` list as the primary search.
+>
+> **Update**: `useDropTarget.checkServiceAndAdd` used to gate its call into `checkService` (the
+> function that actually recognizes playlist/album URLs) behind `ServiceMatcher.match`, which only
+> matches single-*track* id patterns anchored to the end of the string. A playlist/album URL copied
+> via Spotify's "Copy Link" share action carries a trailing `?si=...` tracking parameter, so it
+> never matched `match`'s end-anchored regex and the function returned before `checkService` (and
+> therefore `parsePlaylist`) ever ran — pasting such a link silently did nothing, while a
+> drag-and-dropped link (typically without the `?si=` suffix, so it happened to satisfy the
+> end-anchored regex by coincidence) worked. `checkServiceAndAdd` now calls `checkService`
+> unconditionally first, regardless of whether the input also matches a track-id pattern.
+>
+> **Update**: `LookupPlaylist`'s per-track genre enrichment (`SpotifyService.BuildGenres`, via
+> `ParseTrackResults`) issues a live Spotify API call per track album and per track artist, awaited
+> sequentially, and the cache meant to dedupe those (`SpotifyService.s_results`) is never written to
+> — see [[music-service-api-calls]] § "Known Performance Issue: Per-Track Genre Enrichment" for the
+> full investigation into why this view can take minutes for larger playlists. Not yet fixed.
 
 ### `List(IFormFile fileUpload)` — [SongController.cs:502](../m4d/Controllers/SongController.cs#L502)
 

--- a/architecture/song-search-results.md
+++ b/architecture/song-search-results.md
@@ -205,11 +205,16 @@ the next piece of work.
 > end-anchored regex by coincidence) worked. `checkServiceAndAdd` now calls `checkService`
 > unconditionally first, regardless of whether the input also matches a track-id pattern.
 >
-> **Update**: `LookupPlaylist`'s per-track genre enrichment (`SpotifyService.BuildGenres`, via
-> `ParseTrackResults`) issues a live Spotify API call per track album and per track artist, awaited
-> sequentially, and the cache meant to dedupe those (`SpotifyService.s_results`) is never written to
-> — see [[music-service-api-calls]] § "Known Performance Issue: Per-Track Genre Enrichment" for the
-> full investigation into why this view can take minutes for larger playlists. Not yet fixed.
+> **Update**: this view used to take minutes for larger playlists — `LookupPlaylist`'s per-track
+> genre enrichment (`SpotifyService.BuildGenres`, via `ParseTrackResults`) issued a live Spotify API
+> call per track album and per track artist, awaited sequentially, and the cache meant to dedupe
+> those (`SpotifyService.s_results`) was never written to. Fixed: this action now calls
+> `LookupPlaylist` with `includeGenres: false` (genres were never used here — only id/ISRC/name/
+> artist are), and passes `maxTracks: matchLimit` so pagination stops once enough tracks exist for
+> the viewer's subscription tier instead of fetching/enriching the whole playlist first and
+> discarding the tail with `.Take`. See [[music-service-api-calls]] § "Per-Track Genre Enrichment"
+> for the full investigation and the (now-implemented) fix, including the `s_results` cache fix and
+> the `Thread.Sleep` → `Task.Delay` change that benefits the callers that still request genres.
 
 ### `List(IFormFile fileUpload)` — [SongController.cs:502](../m4d/Controllers/SongController.cs#L502)
 

--- a/m4d/ClientApp/src/components/SpotifyPlayer.vue
+++ b/m4d/ClientApp/src/components/SpotifyPlayer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-const props = defineProps<{ playlist?: string }>();
+const props = defineProps<{ playlist?: string; isAlbum?: boolean }>();
 const spotifyLink = props.playlist
-  ? `https://open.spotify.com/embed/playlist/${props.playlist}`
+  ? `https://open.spotify.com/embed/${props.isAlbum ? "album" : "playlist"}/${props.playlist}`
   : undefined;
 </script>
 

--- a/m4d/ClientApp/src/composables/useDropTarget.ts
+++ b/m4d/ClientApp/src/composables/useDropTarget.ts
@@ -11,28 +11,33 @@ export function useDropTarget() {
     warn?: boolean,
     danceId?: string,
   ): Promise<void> {
+    // Playlist/album links are checked first, and unconditionally, since a URL with a Spotify
+    // share-link tracking suffix (`?si=...`) won't also match the single-track id patterns
+    // `matcher.match` looks for below.
+    const found = await checkService(input);
+    if (found) {
+      return;
+    }
+
     const service = matcher.match(input);
     if (!service) {
       return;
     }
-    const found = await checkService(input);
 
-    if (!found) {
-      let okay = false;
-      if (warn) {
-        const result = await create({
-          body: `It looks like you may have tried to search by ${service.name} id for a song not in the music4dance catalog. Would you like to add the song?`,
-          title: "Song not found",
-          okTitle: "Yes",
-          cancelTitle: "No",
-        }).show();
-        okay = typeof result === "boolean" ? result : ((result as BvTriggerableEvent)?.ok ?? false);
-      }
-      if (okay) {
-        const id = matcher.parseId(input, service);
-        const danceParam = danceId ? `&dance=${danceId}` : "";
-        window.location.href = `/song/augment?id=${id}${danceParam}`;
-      }
+    let okay = false;
+    if (warn) {
+      const result = await create({
+        body: `It looks like you may have tried to search by ${service.name} id for a song not in the music4dance catalog. Would you like to add the song?`,
+        title: "Song not found",
+        okTitle: "Yes",
+        cancelTitle: "No",
+      }).show();
+      okay = typeof result === "boolean" ? result : ((result as BvTriggerableEvent)?.ok ?? false);
+    }
+    if (okay) {
+      const id = matcher.parseId(input, service);
+      const danceParam = danceId ? `&dance=${danceId}` : "";
+      window.location.href = `/song/augment?id=${id}${danceParam}`;
     }
   }
 
@@ -44,6 +49,12 @@ export function useDropTarget() {
     const playlistId = matcher.parsePlaylist(input);
     if (playlistId) {
       window.location.href = `/song/playlist?id=${playlistId}`;
+      return true;
+    }
+
+    const albumId = matcher.parseAlbum(input);
+    if (albumId) {
+      window.location.href = `/song/playlist?id=${albumId}&type=album`;
       return true;
     }
 

--- a/m4d/ClientApp/src/helpers/ServiceMatcher.ts
+++ b/m4d/ClientApp/src/helpers/ServiceMatcher.ts
@@ -59,6 +59,11 @@ export class ServiceMatcher {
     return this.parse(patterns, id);
   }
 
+  public parseAlbum(id: string): string | null {
+    const patterns = [/https:\/\/open\.spotify\.com\/album\/([a-z0-9]{22})/gi];
+    return this.parse(patterns, id);
+  }
+
   public parseUser(id: string): string | null {
     const patterns = [/https:\/\/open\.spotify\.com\/user\/([^?/]*)/gi];
     return this.parse(patterns, id);

--- a/m4d/ClientApp/src/models/PlaylistViewerModel.ts
+++ b/m4d/ClientApp/src/models/PlaylistViewerModel.ts
@@ -5,6 +5,7 @@ import { UnmatchedTrack } from "./UnmatchedTrack";
 @jsonObject
 export class PlaylistViewerModel {
   @jsonMember(String) public id!: string;
+  @jsonMember(Boolean) public isAlbum?: boolean;
   @jsonArrayMember(SongHistory) public histories!: SongHistory[];
   @jsonMember(String) public name!: string;
   @jsonMember(String) public description?: string;

--- a/m4d/ClientApp/src/pages/playlist-viewer/App.vue
+++ b/m4d/ClientApp/src/pages/playlist-viewer/App.vue
@@ -8,8 +8,10 @@ declare const model_: string;
 const model = TypedJSON.parse(model_, PlaylistViewerModel)!;
 
 const hiddenColumns = ["length", "track"];
-const userLink = `https://open.spotify.com/user/${model.ownerId}`;
-const playlistLink = `https://open.spotify.com/playlist/${model.id}`;
+const kind = model.isAlbum ? "album" : "playlist";
+const typeParam = model.isAlbum ? "&type=album" : "";
+const userLink = `https://open.spotify.com/${model.isAlbum ? "artist" : "user"}/${model.ownerId}`;
+const playlistLink = `https://open.spotify.com/${kind}/${model.id}`;
 
 // We only checked part of the playlist, bounded by the viewer's subscription tier.
 const isPartial = computed(() => model.checkedCount < model.totalCount);
@@ -24,7 +26,8 @@ const unmatchedFields = [{ key: "title" }, { key: "artist" }, { key: "add", labe
 
 const addSongLink = (trackId: string): string => `/song/augment?id=${trackId}`;
 const loginLink = computed(
-  () => `/Identity/Account/Login?ReturnUrl=${encodeURIComponent(`/song/playlist?id=${model.id}`)}`,
+  () =>
+    `/Identity/Account/Login?ReturnUrl=${encodeURIComponent(`/song/playlist?id=${model.id}${typeParam}`)}`,
 );
 </script>
 
@@ -32,7 +35,7 @@ const loginLink = computed(
   <PageFrame id="app">
     <BAlert v-if="isPartial" show variant="info"
       >We checked the first {{ model.checkedCount }} of {{ model.totalCount }} songs in this
-      playlist for music4dance matches. <a href="/Home/Contribute">Upgrade your membership</a> to
+      {{ kind }} for music4dance matches. <a href="/Home/Contribute">Upgrade your membership</a> to
       have us check more. See our
       <a
         href="https://music4dance.blog/music4dance-help/subscriptions/"
@@ -50,7 +53,7 @@ const loginLink = computed(
       <a href="https://music4dance.blog/feedback/" target="_blank" rel="noopener noreferrer"
         >contact us</a
       >
-      if you would like us to support a specific playlist.</BAlert
+      if you would like us to support a specific {{ kind }}.</BAlert
     >
     <h1>
       <BLink
@@ -68,10 +71,10 @@ const loginLink = computed(
     </h1>
     <p v-html="model.description" />
     <BAlert v-if="isEmptyPlaylist" show variant="warning"
-      >This Spotify playlist doesn't have any tracks.</BAlert
+      >This Spotify {{ kind }} doesn't have any tracks.</BAlert
     >
     <BAlert v-else-if="noMatches" show variant="warning"
-      >None of the songs in this playlist are in the music4dance catalog yet.</BAlert
+      >None of the songs in this {{ kind }} are in the music4dance catalog yet.</BAlert
     >
     <SongTable
       v-else
@@ -80,7 +83,7 @@ const loginLink = computed(
       :hide-sort="true"
       :hidden-columns="hiddenColumns"
     />
-    <SpotifyPlayer v-if="!isEmptyPlaylist" :playlist="model.id" />
+    <SpotifyPlayer v-if="!isEmptyPlaylist" :playlist="model.id" :is-album="model.isAlbum" />
     <p>
       by
       <BLink :href="userLink" target="_blank" rel="noopener noreferrer">{{
@@ -92,8 +95,8 @@ const loginLink = computed(
       <p>
         {{
           noMatches
-            ? "None of the songs in this playlist are in music4dance yet"
-            : "These songs from the playlist aren't in music4dance yet"
+            ? `None of the songs in this ${kind} are in music4dance yet`
+            : `These songs from the ${kind} aren't in music4dance yet`
         }}
         &mdash; add them so you (and everyone else) can dance to them.
       </p>

--- a/m4d/ClientApp/src/pages/playlist-viewer/__tests__/__snapshots__/playlist-viewer.test.ts.snap
+++ b/m4d/ClientApp/src/pages/playlist-viewer/__tests__/__snapshots__/playlist-viewer.test.ts.snap
@@ -1,5 +1,1531 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Playlist Viewer > renders a Spotify album with artist attribution and album links 1`] = `
+"<div><span context="[object Object]">MainMenu</span>
+  <!--v-if-->
+  <!--v-if-->
+  <div id="body-content" class="container-fluid body-content">
+    <div class="mt-2"></div>
+    <div>
+      <!--v-if-->
+      <!--v-if-->
+      <h1><a class="link-underline link-underline-opacity-0" target="_blank" href="https://open.spotify.com/album/4PGMLc2lfy6hsdmyj2rm2x" rel="noopener noreferrer" to="" replace="false" title="Open in Spotify"><img class="b-img" src="/images/icons/spotify-logo.png" loading="eager" alt="Spotify Logo" style="vertical-align: middle;"><span class="ps-2">Nine Sinatra Songs (Music From The Ballet)</span></a></h1>
+      <p></p>
+      <div data-v-a7ef304f="">
+        <table data-v-a7ef304f="" id="BootstrapVueNext__ID__v-0__" class="table b-table table-borderless table-hover table-striped" aria-busy="false">
+          <!---->
+          <thead class="">
+            <tr class="">
+              <th scope="col" class="">
+                <div data-v-a7ef304f="" class="likeHeader">Like/Play</div>
+              </th>
+              <th scope="col" class=""><span data-v-a7ef304f=""><a class="link-underline-light" href="#" to="" replace="false" id="Title">Title<!--v-if--></a><span id="BootstrapVueNext__ID__v-3__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-3__popover___" class="tooltip b-tooltip fade bs-tooltip-top" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <!---->
+                      <div class="tooltip-inner">
+                        <!--v-if--> Click on the song title to view the song details
+                      </div>
+                    </div>
+                  </div>
+                </transition-stub></span>
+              </th>
+              <th scope="col" class=""><span data-v-a7ef304f=""><a class="link-underline-light" href="#" to="" replace="false" id="Artist">Artist<!--v-if--></a><span id="BootstrapVueNext__ID__v-4__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-4__popover___" class="tooltip b-tooltip fade bs-tooltip-top" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <!---->
+                      <div class="tooltip-inner">
+                        <!--v-if--> Click on the artist name to view a list of songs by that artist
+                      </div>
+                    </div>
+                  </div>
+                </transition-stub></span>
+              </th>
+              <th scope="col" class=""><span data-v-a7ef304f=""><a class="link-underline-light" href="#" to="" replace="false" id="Tempo">Tempo (BPM)<!--v-if--></a><span id="BootstrapVueNext__ID__v-5__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-5__popover___" class="tooltip b-tooltip fade bs-tooltip-top" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <!---->
+                      <div class="tooltip-inner">
+                        <!--v-if--> Tempo in beats per minute (BPM) - click a tempo to view dances danced to that tempo.
+                      </div>
+                    </div>
+                  </div>
+                </transition-stub></span>
+              </th>
+              <th scope="col" class="">
+                <div data-v-a7ef304f="" class="echoHeader"><span data-v-a7ef304f=""><a class="link-underline-light" href="#" to="" replace="false" id="Beat"><img data-v-a7ef304f="" src="/src/assets/images/icons/beat-10.png" width="25" height="25"><!--v-if--></a><span id="BootstrapVueNext__ID__v-6__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-6__popover___" class="tooltip b-tooltip fade bs-tooltip-top" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <!---->
+                        <div class="tooltip-inner">
+                          <!--v-if--> Strength of the beat (fuller icons represent a stronger beat).
+                        </div>
+                      </div>
+                    </div>
+                  </transition-stub></span><span data-v-a7ef304f=""><a class="link-underline-light" href="#" to="" replace="false" id="Energy"><img data-v-a7ef304f="" src="/src/assets/images/icons/Energy-10.png" width="25" height="25"><!--v-if--></a><span id="BootstrapVueNext__ID__v-7__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-7__popover___" class="tooltip b-tooltip fade bs-tooltip-top" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <!---->
+                        <div class="tooltip-inner">
+                          <!--v-if--> Energy of the song (fuller icons represent a higher energy).
+                        </div>
+                      </div>
+                    </div>
+                  </transition-stub></span><span data-v-a7ef304f=""><a class="link-underline-light" href="#" to="" replace="false" id="Mood"><img data-v-a7ef304f="" src="/src/assets/images/icons/mood-10.png" width="25" height="25"><!--v-if--></a><span id="BootstrapVueNext__ID__v-8__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-8__popover___" class="tooltip b-tooltip fade bs-tooltip-top" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <!---->
+                        <div class="tooltip-inner">
+                          <!--v-if--> Mood of the song (fuller icons represent a happier mood).
+                        </div>
+                      </div>
+                    </div>
+                  </transition-stub></span>
+                </div>
+              </th>
+              <th scope="col" class=""><span data-v-a7ef304f=""><a class="link-underline-light" href="#" to="" replace="false" id="Dances">Dances<!--v-if--></a><span id="BootstrapVueNext__ID__v-9__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-9__popover___" class="tooltip b-tooltip fade bs-tooltip-top" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <!---->
+                      <div class="tooltip-inner">
+                        <!--v-if--> A list of dances for the song. Click on a dance to view more actions and to vote on the dance for the song.
+                      </div>
+                    </div>
+                  </div>
+                </transition-stub></span>
+              </th>
+              <th scope="col" class=""><span data-v-a7ef304f=""><a class="link-underline-light" href="#" to="" replace="false" id="Tags">Tags<!--v-if--></a><span id="BootstrapVueNext__ID__v-10__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-10__popover___" class="tooltip b-tooltip fade bs-tooltip-top" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <!---->
+                      <div class="tooltip-inner">
+                        <!--v-if--> A list of tags associated with the song. Click on a tag to filter by it.
+                      </div>
+                    </div>
+                  </div>
+                </transition-stub></span>
+              </th>
+              <th scope="col" class=""><span data-v-a7ef304f="" class="orderHeader"><a class="link-underline-light" href="#" to="" replace="false" id="Order"><svg data-v-a7ef304f="" viewBox="0 0 16 16" width="1.2em" height="1.2em"><path fill="currentColor" d="M8 0a1 1 0 0 1 1 1v5.268l4.562-2.634a1 1 0 1 1 1 1.732L10 8l4.562 2.634a1 1 0 1 1-1 1.732L9 9.732V15a1 1 0 1 1-2 0V9.732l-4.562 2.634a1 1 0 1 1-1-1.732L6 8L1.438 5.366a1 1 0 0 1 1-1.732L7 6.268V1a1 1 0 0 1 1-1"></path></svg><!--v-if--></a><span id="BootstrapVueNext__ID__v-11__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-11__popover___" class="tooltip b-tooltip fade bs-tooltip-top" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <!---->
+                      <div class="tooltip-inner">
+                        <!--v-if--> Values represent last modified date
+                      </div>
+                    </div>
+                  </div>
+                </transition-stub></span>
+              </th>
+            </tr>
+            <!---->
+          </thead>
+          <tbody class="">
+            <!---->
+            <tr class="">
+              <td class="">
+                <!----><span data-v-a7ef304f=""><!--v-if--><span><a id="like-button-2b68a13b-2e35-46d9-acaa-41cd50d2b3f2" href="#" role="button"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="color: black; font-size: 1.5em;"><path fill="currentColor" d="m8 2.748l-.717-.737C5.6.281 2.514.878 1.4 3.053c-.523 1.023-.641 2.5.314 4.385c.92 1.815 2.834 3.989 6.286 6.357c3.452-2.368 5.365-4.542 6.286-6.357c.955-1.886.838-3.362.314-4.385C13.486.878 10.4.28 8.717 2.01zM8 15C-7.333 4.868 3.279-3.04 7.824 1.143q.09.083.176.171a3 3 0 0 1 .176-.17C12.72-3.042 23.333 4.867 8 15"></path></svg></a><span id="BootstrapVueNext__ID__v-12__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-12__popover___" triggers="hover" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <div class="position-sticky top-0 tooltip-inner">Log in to like/dislike this song.</div>
+                      <!---->
+                    </div>
+                  </div>
+                </transition-stub></span><a href="#" role="button" class="ms-1"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" class="ms-1" style="font-size: 1.5em;">
+                    <path fill="currentColor" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M6.79 5.093A.5.5 0 0 0 6 5.5v5a.5.5 0 0 0 .79.407l3.5-2.5a.5.5 0 0 0 0-.814z"></path>
+                  </svg></a></span>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" href="/song/details/2b68a13b-2e35-46d9-acaa-41cd50d2b3f2?filter=v2-index">Softly, As I Leave You</a>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" href="/song/artist/?name=Frank%20Sinatra">Frank Sinatra</a>
+              </td>
+              <td class="">
+                <!---->
+                <div data-v-a7ef304f="" style="display: flex; flex-direction: column; align-items: center;"><a data-v-a7ef304f="" href="/home/tempi">81</a><a data-v-4d7308ba="" data-v-a7ef304f="" href="https://music4dance.blog/music4dance-help/song-list/#tempo-note" target="_blank" rel="noopener noreferrer" title="This tempo was algorithmically generated. Click to learn more." class="algo-generated-icon stacked"><svg data-v-4d7308ba="" viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                      <g fill="currentColor">
+                        <path d="M6.5 6a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5z"></path>
+                        <path d="M5.5.5a.5.5 0 0 0-1 0V2A2.5 2.5 0 0 0 2 4.5H.5a.5.5 0 0 0 0 1H2v1H.5a.5.5 0 0 0 0 1H2v1H.5a.5.5 0 0 0 0 1H2v1H.5a.5.5 0 0 0 0 1H2A2.5 2.5 0 0 0 4.5 14v1.5a.5.5 0 0 0 1 0V14h1v1.5a.5.5 0 0 0 1 0V14h1v1.5a.5.5 0 0 0 1 0V14h1v1.5a.5.5 0 0 0 1 0V14a2.5 2.5 0 0 0 2.5-2.5h1.5a.5.5 0 0 0 0-1H14v-1h1.5a.5.5 0 0 0 0-1H14v-1h1.5a.5.5 0 0 0 0-1H14v-1h1.5a.5.5 0 0 0 0-1H14A2.5 2.5 0 0 0 11.5 2V.5a.5.5 0 0 0-1 0V2h-1V.5a.5.5 0 0 0-1 0V2h-1V.5a.5.5 0 0 0-1 0V2h-1zm1 4.5h3A1.5 1.5 0 0 1 11 6.5v3A1.5 1.5 0 0 1 9.5 11h-3A1.5 1.5 0 0 1 5 9.5v-3A1.5 1.5 0 0 1 6.5 5"></path>
+                      </g>
+                    </svg></a></div>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" id="__m4d__000073" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#beat" target="_blank"><img src="/images/icons/beat-3.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-13__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-13__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a beat strength of 0.28 where 1.00 is the strongest beat.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a><a data-v-a7ef304f="" id="__m4d__000074" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#energy" target="_blank"><img src="/images/icons/energy-4.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-14__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-14__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a energy level of 0.34 where 1.00 is the highest energy.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a><a data-v-a7ef304f="" id="__m4d__000075" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#mood" target="_blank"><img src="/images/icons/mood-4.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-15__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-15__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a mood level of 0.34 where 1.00 is the happiest.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a>
+              </td>
+              <td class="">
+                <!----><button data-v-a7ef304f="" class="btn btn-sm btn-dance" type="button" title="Castle Foxtrot" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
+                      <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
+                    </g>
+                  </svg> Castle Foxtrot <span class="badge text-bg-light">1</span>
+                  <!--v-if-->
+                </button>
+                <!--v-if-->
+              </td>
+              <td class="">
+                <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71z"></path>
+                      <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16m7-8A7 7 0 1 1 1 8a7 7 0 0 1 14 0"></path>
+                    </g>
+                  </svg> 4/4
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Adult Standards" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Adult Standards
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Big Band" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Big Band
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Christmas" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Christmas
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Jazz" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Jazz
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Swing Music" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Swing Music
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Swing" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Swing
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Vocal Jazz" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Vocal Jazz
+                  <!--v-if-->
+                </button>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" class="link-underline-light" href="#" to="" replace="false" id="order_tip__2b68a13b-2e35-46d9-acaa-41cd50d2b3f2">M</a><span id="BootstrapVueNext__ID__v-16__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-16__popover___" auto-hide="false" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <!---->
+                      <div class="tooltip-inner">Last Modified 10-Jun-2025 11:54:14 AM (months ago)</div>
+                    </div>
+                  </div>
+                </transition-stub>
+              </td>
+            </tr>
+            <!---->
+            <tr class="">
+              <td class="">
+                <!----><span data-v-a7ef304f=""><!--v-if--><span><a id="like-button-f1dce40d-142f-404a-818f-5f5fc71a9330" href="#" role="button"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="color: black; font-size: 1.5em;"><path fill="currentColor" d="m8 2.748l-.717-.737C5.6.281 2.514.878 1.4 3.053c-.523 1.023-.641 2.5.314 4.385c.92 1.815 2.834 3.989 6.286 6.357c3.452-2.368 5.365-4.542 6.286-6.357c.955-1.886.838-3.362.314-4.385C13.486.878 10.4.28 8.717 2.01zM8 15C-7.333 4.868 3.279-3.04 7.824 1.143q.09.083.176.171a3 3 0 0 1 .176-.17C12.72-3.042 23.333 4.867 8 15"></path></svg></a><span id="BootstrapVueNext__ID__v-17__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-17__popover___" triggers="hover" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <div class="position-sticky top-0 tooltip-inner">Log in to like/dislike this song.</div>
+                      <!---->
+                    </div>
+                  </div>
+                </transition-stub></span><a href="#" role="button" class="ms-1"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" class="ms-1" style="font-size: 1.5em;">
+                    <path fill="currentColor" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M6.79 5.093A.5.5 0 0 0 6 5.5v5a.5.5 0 0 0 .79.407l3.5-2.5a.5.5 0 0 0 0-.814z"></path>
+                  </svg></a></span>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" href="/song/details/f1dce40d-142f-404a-818f-5f5fc71a9330?filter=v2-index">Strangers In The Night</a>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" href="/song/artist/?name=Frank%20Sinatra">Frank Sinatra</a>
+              </td>
+              <td class="">
+                <!---->
+                <div data-v-a7ef304f="" style="display: flex; flex-direction: column; align-items: center;"><a data-v-a7ef304f="" href="/home/tempi">94</a>
+                  <!--v-if-->
+                </div>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" id="__m4d__000076" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#beat" target="_blank"><img src="/images/icons/beat-3.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-18__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-18__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a beat strength of 0.27 where 1.00 is the strongest beat.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a><a data-v-a7ef304f="" id="__m4d__000077" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#energy" target="_blank"><img src="/images/icons/energy-5.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-19__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-19__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a energy level of 0.48 where 1.00 is the highest energy.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a><a data-v-a7ef304f="" id="__m4d__000078" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#mood" target="_blank"><img src="/images/icons/mood-6.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-20__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-20__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a mood level of 0.56 where 1.00 is the happiest.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a>
+              </td>
+              <td class="">
+                <!----><button data-v-a7ef304f="" class="btn btn-sm btn-dance" type="button" title="Rumba" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
+                      <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
+                    </g>
+                  </svg> Rumba <span class="badge text-bg-light">3</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
+                    <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
+                  </svg></button>
+                <!--v-if-->
+              </td>
+              <td class="">
+                <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1960S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M6 4.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m-1 0a.5.5 0 1 0-1 0a.5.5 0 0 0 1 0"></path>
+                      <path d="M2 1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 1 6.586V2a1 1 0 0 1 1-1m0 5.586l7 7L13.586 9l-7-7H2z"></path>
+                    </g>
+                  </svg> 1960S
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71z"></path>
+                      <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16m7-8A7 7 0 1 1 1 8a7 7 0 0 1 14 0"></path>
+                    </g>
+                  </svg> 4/4
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Adult Standards" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Adult Standards
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Easy Listening" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Easy Listening
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="First Dance" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M6 4.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m-1 0a.5.5 0 1 0-1 0a.5.5 0 0 0 1 0"></path>
+                      <path d="M2 1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 1 6.586V2a1 1 0 0 1 1-1m0 5.586l7 7L13.586 9l-7-7H2z"></path>
+                    </g>
+                  </svg> First Dance
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Jazz" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Jazz
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Lounge" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Lounge
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Pop
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Vocal Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Vocal Pop
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Vocal" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Vocal
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="Wedding" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M6 4.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m-1 0a.5.5 0 1 0-1 0a.5.5 0 0 0 1 0"></path>
+                      <path d="M2 1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 1 6.586V2a1 1 0 0 1 1-1m0 5.586l7 7L13.586 9l-7-7H2z"></path>
+                    </g>
+                  </svg> Wedding
+                  <!--v-if-->
+                </button>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" class="link-underline-light" href="#" to="" replace="false" id="order_tip__f1dce40d-142f-404a-818f-5f5fc71a9330">M</a><span id="BootstrapVueNext__ID__v-21__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-21__popover___" auto-hide="false" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <!---->
+                      <div class="tooltip-inner">Last Modified 19-Jun-2025 08:20:59 PM (months ago)</div>
+                    </div>
+                  </div>
+                </transition-stub>
+              </td>
+            </tr>
+            <!---->
+            <tr class="">
+              <td class="">
+                <!----><span data-v-a7ef304f=""><!--v-if--><span><a id="like-button-3ccfb240-fa9c-4bee-864c-d3fadce1e93d" href="#" role="button"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="color: black; font-size: 1.5em;"><path fill="currentColor" d="m8 2.748l-.717-.737C5.6.281 2.514.878 1.4 3.053c-.523 1.023-.641 2.5.314 4.385c.92 1.815 2.834 3.989 6.286 6.357c3.452-2.368 5.365-4.542 6.286-6.357c.955-1.886.838-3.362.314-4.385C13.486.878 10.4.28 8.717 2.01zM8 15C-7.333 4.868 3.279-3.04 7.824 1.143q.09.083.176.171a3 3 0 0 1 .176-.17C12.72-3.042 23.333 4.867 8 15"></path></svg></a><span id="BootstrapVueNext__ID__v-22__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-22__popover___" triggers="hover" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <div class="position-sticky top-0 tooltip-inner">Log in to like/dislike this song.</div>
+                      <!---->
+                    </div>
+                  </div>
+                </transition-stub></span><a href="#" role="button" class="ms-1"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" class="ms-1" style="font-size: 1.5em;">
+                    <path fill="currentColor" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M6.79 5.093A.5.5 0 0 0 6 5.5v5a.5.5 0 0 0 .79.407l3.5-2.5a.5.5 0 0 0 0-.814z"></path>
+                  </svg></a></span>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" href="/song/details/3ccfb240-fa9c-4bee-864c-d3fadce1e93d?filter=v2-index">One For My Baby [And One More For The Road] [The Frank Sinatra Collection] [1966 Live At The Sands Album Version]</a>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" href="/song/artist/?name=Frank%20Sinatra">Frank Sinatra</a>
+              </td>
+              <td class="">
+                <!---->
+                <div data-v-a7ef304f="" style="display: flex; flex-direction: column; align-items: center;"><a data-v-a7ef304f="" href="/home/tempi">94</a>
+                  <!--v-if-->
+                </div>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" id="__m4d__000079" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#beat" target="_blank"><img src="/images/icons/beat-6.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-23__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-23__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a beat strength of 0.51 where 1.00 is the strongest beat.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a><a data-v-a7ef304f="" id="__m4d__000080" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#energy" target="_blank"><img src="/images/icons/energy-2.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-24__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-24__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a energy level of 0.16 where 1.00 is the highest energy.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a><a data-v-a7ef304f="" id="__m4d__000081" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#mood" target="_blank"><img src="/images/icons/mood-5.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-25__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-25__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a mood level of 0.44 where 1.00 is the happiest.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a>
+              </td>
+              <td class="">
+                <!----><button data-v-a7ef304f="" class="btn btn-sm btn-dance" type="button" title="Castle Foxtrot" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
+                      <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
+                    </g>
+                  </svg> Castle Foxtrot <span class="badge text-bg-light">1</span>
+                  <!--v-if-->
+                </button>
+                <!--v-if-->
+              </td>
+              <td class="">
+                <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71z"></path>
+                      <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16m7-8A7 7 0 1 1 1 8a7 7 0 0 1 14 0"></path>
+                    </g>
+                  </svg> 4/4
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Jazz" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Jazz
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Pop
+                  <!--v-if-->
+                </button>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" class="link-underline-light" href="#" to="" replace="false" id="order_tip__3ccfb240-fa9c-4bee-864c-d3fadce1e93d">M</a><span id="BootstrapVueNext__ID__v-26__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-26__popover___" auto-hide="false" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <!---->
+                      <div class="tooltip-inner">Last Modified 10-Jun-2025 12:01:59 PM (months ago)</div>
+                    </div>
+                  </div>
+                </transition-stub>
+              </td>
+            </tr>
+            <!---->
+            <tr class="">
+              <td class="">
+                <!----><span data-v-a7ef304f=""><!--v-if--><span><a id="like-button-c7a4b10e-7ad7-41e5-8f32-479e6c07deeb" href="#" role="button"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="color: black; font-size: 1.5em;"><path fill="currentColor" d="m8 2.748l-.717-.737C5.6.281 2.514.878 1.4 3.053c-.523 1.023-.641 2.5.314 4.385c.92 1.815 2.834 3.989 6.286 6.357c3.452-2.368 5.365-4.542 6.286-6.357c.955-1.886.838-3.362.314-4.385C13.486.878 10.4.28 8.717 2.01zM8 15C-7.333 4.868 3.279-3.04 7.824 1.143q.09.083.176.171a3 3 0 0 1 .176-.17C12.72-3.042 23.333 4.867 8 15"></path></svg></a><span id="BootstrapVueNext__ID__v-27__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-27__popover___" triggers="hover" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <div class="position-sticky top-0 tooltip-inner">Log in to like/dislike this song.</div>
+                      <!---->
+                    </div>
+                  </div>
+                </transition-stub></span><a href="#" role="button" class="ms-1"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" class="ms-1" style="font-size: 1.5em;">
+                    <path fill="currentColor" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M6.79 5.093A.5.5 0 0 0 6 5.5v5a.5.5 0 0 0 .79.407l3.5-2.5a.5.5 0 0 0 0-.814z"></path>
+                  </svg></a></span>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" href="/song/details/c7a4b10e-7ad7-41e5-8f32-479e6c07deeb?filter=v2-index">My Way</a>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" href="/song/artist/?name=Frank%20Sinatra">Frank Sinatra</a>
+              </td>
+              <td class="">
+                <!---->
+                <div data-v-a7ef304f="" style="display: flex; flex-direction: column; align-items: center;"><a data-v-a7ef304f="" href="/home/tempi">135</a>
+                  <!--v-if-->
+                </div>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" id="__m4d__000082" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#beat" target="_blank"><img src="/images/icons/beat-3.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-28__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-28__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a beat strength of 0.28 where 1.00 is the strongest beat.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a><a data-v-a7ef304f="" id="__m4d__000083" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#energy" target="_blank"><img src="/images/icons/energy-5.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-29__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-29__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a energy level of 0.45 where 1.00 is the highest energy.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a><a data-v-a7ef304f="" id="__m4d__000084" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#mood" target="_blank"><img src="/images/icons/mood-3.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-30__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-30__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a mood level of 0.22 where 1.00 is the happiest.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a>
+              </td>
+              <td class="">
+                <!----><button data-v-a7ef304f="" class="btn btn-sm btn-dance" type="button" title="Rumba" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
+                      <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
+                    </g>
+                  </svg> Rumba <span class="badge text-bg-light">2</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
+                    <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
+                  </svg></button>
+                <!--v-if-->
+              </td>
+              <td class="">
+                <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1960S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M6 4.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m-1 0a.5.5 0 1 0-1 0a.5.5 0 0 0 1 0"></path>
+                      <path d="M2 1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 1 6.586V2a1 1 0 0 1 1-1m0 5.586l7 7L13.586 9l-7-7H2z"></path>
+                    </g>
+                  </svg> 1960S
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71z"></path>
+                      <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16m7-8A7 7 0 1 1 1 8a7 7 0 0 1 14 0"></path>
+                    </g>
+                  </svg> 4/4
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Adult Standards" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Adult Standards
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Big Band" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Big Band
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Christmas" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Christmas
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="DWTS" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M6 4.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m-1 0a.5.5 0 1 0-1 0a.5.5 0 0 0 1 0"></path>
+                      <path d="M2 1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 1 6.586V2a1 1 0 0 1 1-1m0 5.586l7 7L13.586 9l-7-7H2z"></path>
+                    </g>
+                  </svg> DWTS
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Easy Listening" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Easy Listening
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="Episode 5a" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M6 4.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m-1 0a.5.5 0 1 0-1 0a.5.5 0 0 0 1 0"></path>
+                      <path d="M2 1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 1 6.586V2a1 1 0 0 1 1-1m0 5.586l7 7L13.586 9l-7-7H2z"></path>
+                    </g>
+                  </svg> Episode 5a
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Jazz" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Jazz
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="Last Dance" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M6 4.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m-1 0a.5.5 0 1 0-1 0a.5.5 0 0 0 1 0"></path>
+                      <path d="M2 1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 1 6.586V2a1 1 0 0 1 1-1m0 5.586l7 7L13.586 9l-7-7H2z"></path>
+                    </g>
+                  </svg> Last Dance
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="Most Memorable Year" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M6 4.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m-1 0a.5.5 0 1 0-1 0a.5.5 0 0 0 1 0"></path>
+                      <path d="M2 1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 1 6.586V2a1 1 0 0 1 1-1m0 5.586l7 7L13.586 9l-7-7H2z"></path>
+                    </g>
+                  </svg> Most Memorable Year
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Pop
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="Season 31" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M6 4.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m-1 0a.5.5 0 1 0-1 0a.5.5 0 0 0 1 0"></path>
+                      <path d="M2 1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 1 6.586V2a1 1 0 0 1 1-1m0 5.586l7 7L13.586 9l-7-7H2z"></path>
+                    </g>
+                  </svg> Season 31
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Swing Music" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Swing Music
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="United States" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M6 4.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m-1 0a.5.5 0 1 0-1 0a.5.5 0 0 0 1 0"></path>
+                      <path d="M2 1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 1 6.586V2a1 1 0 0 1 1-1m0 5.586l7 7L13.586 9l-7-7H2z"></path>
+                    </g>
+                  </svg> United States
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Vocal Jazz" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Vocal Jazz
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Vocal Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Vocal Pop
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Vocal" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Vocal
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="Wedding" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M6 4.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m-1 0a.5.5 0 1 0-1 0a.5.5 0 0 0 1 0"></path>
+                      <path d="M2 1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 1 6.586V2a1 1 0 0 1 1-1m0 5.586l7 7L13.586 9l-7-7H2z"></path>
+                    </g>
+                  </svg> Wedding
+                  <!--v-if-->
+                </button>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" class="link-underline-light" href="#" to="" replace="false" id="order_tip__c7a4b10e-7ad7-41e5-8f32-479e6c07deeb">M</a><span id="BootstrapVueNext__ID__v-31__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-31__popover___" auto-hide="false" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <!---->
+                      <div class="tooltip-inner">Last Modified 19-Jun-2025 08:22:45 PM (months ago)</div>
+                    </div>
+                  </div>
+                </transition-stub>
+              </td>
+            </tr>
+            <!---->
+            <tr class="">
+              <td class="">
+                <!----><span data-v-a7ef304f=""><!--v-if--><span><a id="like-button-084fd54b-6ca0-467a-926d-d28d2c2ef8f8" href="#" role="button"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="color: black; font-size: 1.5em;"><path fill="currentColor" d="m8 2.748l-.717-.737C5.6.281 2.514.878 1.4 3.053c-.523 1.023-.641 2.5.314 4.385c.92 1.815 2.834 3.989 6.286 6.357c3.452-2.368 5.365-4.542 6.286-6.357c.955-1.886.838-3.362.314-4.385C13.486.878 10.4.28 8.717 2.01zM8 15C-7.333 4.868 3.279-3.04 7.824 1.143q.09.083.176.171a3 3 0 0 1 .176-.17C12.72-3.042 23.333 4.867 8 15"></path></svg></a><span id="BootstrapVueNext__ID__v-32__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-32__popover___" triggers="hover" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <div class="position-sticky top-0 tooltip-inner">Log in to like/dislike this song.</div>
+                      <!---->
+                    </div>
+                  </div>
+                </transition-stub></span><a href="#" role="button" class="ms-1"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" class="ms-1" style="font-size: 1.5em;">
+                    <path fill="currentColor" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M6.79 5.093A.5.5 0 0 0 6 5.5v5a.5.5 0 0 0 .79.407l3.5-2.5a.5.5 0 0 0 0-.814z"></path>
+                  </svg></a></span>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" href="/song/details/084fd54b-6ca0-467a-926d-d28d2c2ef8f8?filter=v2-index">Somethin' Stupid</a>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" href="/song/artist/?name=Frank%20Sinatra">Frank Sinatra</a>
+              </td>
+              <td class="">
+                <!---->
+                <div data-v-a7ef304f="" style="display: flex; flex-direction: column; align-items: center;"><a data-v-a7ef304f="" href="/home/tempi">207</a><a data-v-4d7308ba="" data-v-a7ef304f="" href="https://music4dance.blog/music4dance-help/song-list/#tempo-note" target="_blank" rel="noopener noreferrer" title="This tempo was algorithmically generated. Click to learn more." class="algo-generated-icon stacked"><svg data-v-4d7308ba="" viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                      <g fill="currentColor">
+                        <path d="M6.5 6a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5z"></path>
+                        <path d="M5.5.5a.5.5 0 0 0-1 0V2A2.5 2.5 0 0 0 2 4.5H.5a.5.5 0 0 0 0 1H2v1H.5a.5.5 0 0 0 0 1H2v1H.5a.5.5 0 0 0 0 1H2v1H.5a.5.5 0 0 0 0 1H2A2.5 2.5 0 0 0 4.5 14v1.5a.5.5 0 0 0 1 0V14h1v1.5a.5.5 0 0 0 1 0V14h1v1.5a.5.5 0 0 0 1 0V14h1v1.5a.5.5 0 0 0 1 0V14a2.5 2.5 0 0 0 2.5-2.5h1.5a.5.5 0 0 0 0-1H14v-1h1.5a.5.5 0 0 0 0-1H14v-1h1.5a.5.5 0 0 0 0-1H14v-1h1.5a.5.5 0 0 0 0-1H14A2.5 2.5 0 0 0 11.5 2V.5a.5.5 0 0 0-1 0V2h-1V.5a.5.5 0 0 0-1 0V2h-1V.5a.5.5 0 0 0-1 0V2h-1zm1 4.5h3A1.5 1.5 0 0 1 11 6.5v3A1.5 1.5 0 0 1 9.5 11h-3A1.5 1.5 0 0 1 5 9.5v-3A1.5 1.5 0 0 1 6.5 5"></path>
+                      </g>
+                    </svg></a></div>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" id="__m4d__000085" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#beat" target="_blank"><img src="/images/icons/beat-3.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-33__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-33__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a beat strength of 0.26 where 1.00 is the strongest beat.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a><a data-v-a7ef304f="" id="__m4d__000086" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#energy" target="_blank"><img src="/images/icons/energy-4.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-34__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-34__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a energy level of 0.34 where 1.00 is the highest energy.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a><a data-v-a7ef304f="" id="__m4d__000087" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#mood" target="_blank"><img src="/images/icons/mood-6.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-35__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-35__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a mood level of 0.54 where 1.00 is the happiest.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a>
+              </td>
+              <td class="">
+                <!----><button data-v-a7ef304f="" class="btn btn-sm btn-dance" type="button" title="Rumba" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
+                      <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
+                    </g>
+                  </svg> Rumba <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
+                    <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
+                  </svg></button>
+                <!--v-if-->
+              </td>
+              <td class="">
+                <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1960S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M6 4.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m-1 0a.5.5 0 1 0-1 0a.5.5 0 0 0 1 0"></path>
+                      <path d="M2 1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 1 6.586V2a1 1 0 0 1 1-1m0 5.586l7 7L13.586 9l-7-7H2z"></path>
+                    </g>
+                  </svg> 1960S
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71z"></path>
+                      <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16m7-8A7 7 0 1 1 1 8a7 7 0 0 1 14 0"></path>
+                    </g>
+                  </svg> 4/4
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Adult Standards" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Adult Standards
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Brill Building Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Brill Building Pop
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Easy Listening" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Easy Listening
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Folk Rock" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Folk Rock
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Jazz" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Jazz
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Lounge" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Lounge
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Vocal Jazz" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Vocal Jazz
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Vocal Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Vocal Pop
+                  <!--v-if-->
+                </button>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" class="link-underline-light" href="#" to="" replace="false" id="order_tip__084fd54b-6ca0-467a-926d-d28d2c2ef8f8">Y</a><span id="BootstrapVueNext__ID__v-36__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-36__popover___" auto-hide="false" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <!---->
+                      <div class="tooltip-inner">Last Modified 27-May-2023 11:41:37 PM (years ago)</div>
+                    </div>
+                  </div>
+                </transition-stub>
+              </td>
+            </tr>
+            <!---->
+            <tr class="">
+              <td class="">
+                <!----><span data-v-a7ef304f=""><!--v-if--><span><a id="like-button-45b88f9c-0536-4868-9061-eeb515975420" href="#" role="button"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="color: black; font-size: 1.5em;"><path fill="currentColor" d="m8 2.748l-.717-.737C5.6.281 2.514.878 1.4 3.053c-.523 1.023-.641 2.5.314 4.385c.92 1.815 2.834 3.989 6.286 6.357c3.452-2.368 5.365-4.542 6.286-6.357c.955-1.886.838-3.362.314-4.385C13.486.878 10.4.28 8.717 2.01zM8 15C-7.333 4.868 3.279-3.04 7.824 1.143q.09.083.176.171a3 3 0 0 1 .176-.17C12.72-3.042 23.333 4.867 8 15"></path></svg></a><span id="BootstrapVueNext__ID__v-37__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-37__popover___" triggers="hover" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <div class="position-sticky top-0 tooltip-inner">Log in to like/dislike this song.</div>
+                      <!---->
+                    </div>
+                  </div>
+                </transition-stub></span><a href="#" role="button" class="ms-1"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" class="ms-1" style="font-size: 1.5em;">
+                    <path fill="currentColor" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M6.79 5.093A.5.5 0 0 0 6 5.5v5a.5.5 0 0 0 .79.407l3.5-2.5a.5.5 0 0 0 0-.814z"></path>
+                  </svg></a></span>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" href="/song/details/45b88f9c-0536-4868-9061-eeb515975420?filter=v2-index">All the Way</a>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" href="/song/artist/?name=Frank%20Sinatra">Frank Sinatra</a>
+              </td>
+              <td class="">
+                <!---->
+                <div data-v-a7ef304f="" style="display: flex; flex-direction: column; align-items: center;"><a data-v-a7ef304f="" href="/home/tempi">76</a><a data-v-4d7308ba="" data-v-a7ef304f="" href="https://music4dance.blog/music4dance-help/song-list/#tempo-note" target="_blank" rel="noopener noreferrer" title="This tempo was algorithmically generated. Click to learn more." class="algo-generated-icon stacked"><svg data-v-4d7308ba="" viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                      <g fill="currentColor">
+                        <path d="M6.5 6a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5z"></path>
+                        <path d="M5.5.5a.5.5 0 0 0-1 0V2A2.5 2.5 0 0 0 2 4.5H.5a.5.5 0 0 0 0 1H2v1H.5a.5.5 0 0 0 0 1H2v1H.5a.5.5 0 0 0 0 1H2v1H.5a.5.5 0 0 0 0 1H2A2.5 2.5 0 0 0 4.5 14v1.5a.5.5 0 0 0 1 0V14h1v1.5a.5.5 0 0 0 1 0V14h1v1.5a.5.5 0 0 0 1 0V14h1v1.5a.5.5 0 0 0 1 0V14a2.5 2.5 0 0 0 2.5-2.5h1.5a.5.5 0 0 0 0-1H14v-1h1.5a.5.5 0 0 0 0-1H14v-1h1.5a.5.5 0 0 0 0-1H14v-1h1.5a.5.5 0 0 0 0-1H14A2.5 2.5 0 0 0 11.5 2V.5a.5.5 0 0 0-1 0V2h-1V.5a.5.5 0 0 0-1 0V2h-1V.5a.5.5 0 0 0-1 0V2h-1zm1 4.5h3A1.5 1.5 0 0 1 11 6.5v3A1.5 1.5 0 0 1 9.5 11h-3A1.5 1.5 0 0 1 5 9.5v-3A1.5 1.5 0 0 1 6.5 5"></path>
+                      </g>
+                    </svg></a></div>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" id="__m4d__000088" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#beat" target="_blank"><img src="/images/icons/beat-2.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-38__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-38__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a beat strength of 0.20 where 1.00 is the strongest beat.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a><a data-v-a7ef304f="" id="__m4d__000089" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#energy" target="_blank"><img src="/images/icons/energy-3.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-39__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-39__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a energy level of 0.28 where 1.00 is the highest energy.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a><a data-v-a7ef304f="" id="__m4d__000090" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#mood" target="_blank"><img src="/images/icons/mood-3.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-40__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-40__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a mood level of 0.20 where 1.00 is the happiest.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a>
+              </td>
+              <td class="">
+                <!----><button data-v-a7ef304f="" class="btn btn-sm btn-dance" type="button" title="Bolero" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
+                      <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
+                    </g>
+                  </svg> Bolero <span class="badge text-bg-light">1</span>
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-dance" type="button" title="Castle Foxtrot" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
+                      <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
+                    </g>
+                  </svg> Castle Foxtrot <span class="badge text-bg-light">2</span>
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-dance" type="button" title="Rumba" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
+                      <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
+                    </g>
+                  </svg> Rumba <span class="badge text-bg-light">1</span>
+                  <!--v-if-->
+                </button>
+                <!--v-if-->
+              </td>
+              <td class="">
+                <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="3/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71z"></path>
+                      <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16m7-8A7 7 0 1 1 1 8a7 7 0 0 1 14 0"></path>
+                    </g>
+                  </svg> 3/4
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71z"></path>
+                      <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16m7-8A7 7 0 1 1 1 8a7 7 0 0 1 14 0"></path>
+                    </g>
+                  </svg> 4/4
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Classical" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Classical
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Easy Listening" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Easy Listening
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="First Dance" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M6 4.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m-1 0a.5.5 0 1 0-1 0a.5.5 0 0 0 1 0"></path>
+                      <path d="M2 1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 1 6.586V2a1 1 0 0 1 1-1m0 5.586l7 7L13.586 9l-7-7H2z"></path>
+                    </g>
+                  </svg> First Dance
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Jazz" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Jazz
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="More" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> More
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Pop
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Vocal Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Vocal Pop
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Vocal" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Vocal
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="Wedding" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M6 4.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m-1 0a.5.5 0 1 0-1 0a.5.5 0 0 0 1 0"></path>
+                      <path d="M2 1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 1 6.586V2a1 1 0 0 1 1-1m0 5.586l7 7L13.586 9l-7-7H2z"></path>
+                    </g>
+                  </svg> Wedding
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="World" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> World
+                  <!--v-if-->
+                </button>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" class="link-underline-light" href="#" to="" replace="false" id="order_tip__45b88f9c-0536-4868-9061-eeb515975420">M</a><span id="BootstrapVueNext__ID__v-41__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-41__popover___" auto-hide="false" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <!---->
+                      <div class="tooltip-inner">Last Modified 19-Jun-2025 08:34:49 PM (months ago)</div>
+                    </div>
+                  </div>
+                </transition-stub>
+              </td>
+            </tr>
+            <!---->
+            <tr class="">
+              <td class="">
+                <!----><span data-v-a7ef304f=""><!--v-if--><span><a id="like-button-c367c1de-2192-4123-95f8-f3485e93b71f" href="#" role="button"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="color: black; font-size: 1.5em;"><path fill="currentColor" d="m8 2.748l-.717-.737C5.6.281 2.514.878 1.4 3.053c-.523 1.023-.641 2.5.314 4.385c.92 1.815 2.834 3.989 6.286 6.357c3.452-2.368 5.365-4.542 6.286-6.357c.955-1.886.838-3.362.314-4.385C13.486.878 10.4.28 8.717 2.01zM8 15C-7.333 4.868 3.279-3.04 7.824 1.143q.09.083.176.171a3 3 0 0 1 .176-.17C12.72-3.042 23.333 4.867 8 15"></path></svg></a><span id="BootstrapVueNext__ID__v-42__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-42__popover___" triggers="hover" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <div class="position-sticky top-0 tooltip-inner">Log in to like/dislike this song.</div>
+                      <!---->
+                    </div>
+                  </div>
+                </transition-stub></span><a href="#" role="button" class="ms-1"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" class="ms-1" style="font-size: 1.5em;">
+                    <path fill="currentColor" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M6.79 5.093A.5.5 0 0 0 6 5.5v5a.5.5 0 0 0 .79.407l3.5-2.5a.5.5 0 0 0 0-.814z"></path>
+                  </svg></a></span>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" href="/song/details/c367c1de-2192-4123-95f8-f3485e93b71f?filter=v2-index">Forget domani</a>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" href="/song/artist/?name=Perry%20Como">Perry Como</a>
+              </td>
+              <td class="">
+                <!---->
+                <div data-v-a7ef304f="" style="display: flex; flex-direction: column; align-items: center;"><a data-v-a7ef304f="" href="/home/tempi">87</a><a data-v-4d7308ba="" data-v-a7ef304f="" href="https://music4dance.blog/music4dance-help/song-list/#tempo-note" target="_blank" rel="noopener noreferrer" title="This tempo was algorithmically generated. Click to learn more." class="algo-generated-icon stacked"><svg data-v-4d7308ba="" viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                      <g fill="currentColor">
+                        <path d="M6.5 6a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5z"></path>
+                        <path d="M5.5.5a.5.5 0 0 0-1 0V2A2.5 2.5 0 0 0 2 4.5H.5a.5.5 0 0 0 0 1H2v1H.5a.5.5 0 0 0 0 1H2v1H.5a.5.5 0 0 0 0 1H2v1H.5a.5.5 0 0 0 0 1H2A2.5 2.5 0 0 0 4.5 14v1.5a.5.5 0 0 0 1 0V14h1v1.5a.5.5 0 0 0 1 0V14h1v1.5a.5.5 0 0 0 1 0V14h1v1.5a.5.5 0 0 0 1 0V14a2.5 2.5 0 0 0 2.5-2.5h1.5a.5.5 0 0 0 0-1H14v-1h1.5a.5.5 0 0 0 0-1H14v-1h1.5a.5.5 0 0 0 0-1H14v-1h1.5a.5.5 0 0 0 0-1H14A2.5 2.5 0 0 0 11.5 2V.5a.5.5 0 0 0-1 0V2h-1V.5a.5.5 0 0 0-1 0V2h-1V.5a.5.5 0 0 0-1 0V2h-1zm1 4.5h3A1.5 1.5 0 0 1 11 6.5v3A1.5 1.5 0 0 1 9.5 11h-3A1.5 1.5 0 0 1 5 9.5v-3A1.5 1.5 0 0 1 6.5 5"></path>
+                      </g>
+                    </svg></a></div>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" id="__m4d__000091" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#beat" target="_blank"><img src="/images/icons/beat-8.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-43__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-43__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a beat strength of 0.72 where 1.00 is the strongest beat.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a><a data-v-a7ef304f="" id="__m4d__000092" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#energy" target="_blank"><img src="/images/icons/energy-5.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-44__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-44__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a energy level of 0.43 where 1.00 is the highest energy.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a><a data-v-a7ef304f="" id="__m4d__000093" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#mood" target="_blank"><img src="/images/icons/mood-8.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-45__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-45__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a mood level of 0.78 where 1.00 is the happiest.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a>
+              </td>
+              <td class="">
+                <!----><button data-v-a7ef304f="" class="btn btn-sm btn-dance" type="button" title="Castle Foxtrot" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
+                      <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
+                    </g>
+                  </svg> Castle Foxtrot <span class="badge text-bg-light">1</span>
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-dance" type="button" title="Night Club Two Step" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
+                      <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
+                    </g>
+                  </svg> Night Club Two Step <span class="badge text-bg-light">1</span>
+                  <!--v-if-->
+                </button>
+                <!--v-if-->
+              </td>
+              <td class="">
+                <!----><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71z"></path>
+                      <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16m7-8A7 7 0 1 1 1 8a7 7 0 0 1 14 0"></path>
+                    </g>
+                  </svg> 4/4
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Adult Standards" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Adult Standards
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Christmas" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Christmas
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Pop
+                  <!--v-if-->
+                </button>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" class="link-underline-light" href="#" to="" replace="false" id="order_tip__c367c1de-2192-4123-95f8-f3485e93b71f">M</a><span id="BootstrapVueNext__ID__v-46__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-46__popover___" auto-hide="false" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <!---->
+                      <div class="tooltip-inner">Last Modified 11-Jun-2025 02:28:29 PM (months ago)</div>
+                    </div>
+                  </div>
+                </transition-stub>
+              </td>
+            </tr>
+            <!---->
+            <tr class="">
+              <td class="">
+                <!----><span data-v-a7ef304f=""><!--v-if--><span><a id="like-button-0249be9e-3b55-4470-b8dc-4e654e1bda1d" href="#" role="button"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="color: black; font-size: 1.5em;"><path fill="currentColor" d="m8 2.748l-.717-.737C5.6.281 2.514.878 1.4 3.053c-.523 1.023-.641 2.5.314 4.385c.92 1.815 2.834 3.989 6.286 6.357c3.452-2.368 5.365-4.542 6.286-6.357c.955-1.886.838-3.362.314-4.385C13.486.878 10.4.28 8.717 2.01zM8 15C-7.333 4.868 3.279-3.04 7.824 1.143q.09.083.176.171a3 3 0 0 1 .176-.17C12.72-3.042 23.333 4.867 8 15"></path></svg></a><span id="BootstrapVueNext__ID__v-47__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-47__popover___" triggers="hover" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <div class="position-sticky top-0 tooltip-inner">Log in to like/dislike this song.</div>
+                      <!---->
+                    </div>
+                  </div>
+                </transition-stub></span><a href="#" role="button" class="ms-1"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" class="ms-1" style="font-size: 1.5em;">
+                    <path fill="currentColor" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M6.79 5.093A.5.5 0 0 0 6 5.5v5a.5.5 0 0 0 .79.407l3.5-2.5a.5.5 0 0 0 0-.814z"></path>
+                  </svg></a></span>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" href="/song/details/0249be9e-3b55-4470-b8dc-4e654e1bda1d?filter=v2-index">That's Life</a>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" href="/song/artist/?name=Frank%20Sinatra">Frank Sinatra</a>
+              </td>
+              <td class="">
+                <!---->
+                <div data-v-a7ef304f="" style="display: flex; flex-direction: column; align-items: center;"><a data-v-a7ef304f="" href="/home/tempi">101</a>
+                  <!--v-if-->
+                </div>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" id="__m4d__000094" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#beat" target="_blank"><img src="/images/icons/beat-5.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-48__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-48__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a beat strength of 0.46 where 1.00 is the strongest beat.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a><a data-v-a7ef304f="" id="__m4d__000095" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#energy" target="_blank"><img src="/images/icons/energy-7.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-49__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-49__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a energy level of 0.69 where 1.00 is the highest energy.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a><a data-v-a7ef304f="" id="__m4d__000096" href="https://music4dance.blog/music4dance-help/playing-or-purchasing-songs/echonest/#mood" target="_blank"><img src="/images/icons/mood-6.png" width="25" height="25"><span id="BootstrapVueNext__ID__v-50__popover____placeholder" style="display: none;"></span>
+                  <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                    <div id="BootstrapVueNext__ID__v-50__popover___" triggers="hover click blur" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                      <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                      <div class="overflow-auto b-floating-size">
+                        <div class="position-sticky top-0 tooltip-inner">This song has a mood level of 0.58 where 1.00 is the happiest.</div>
+                        <!---->
+                      </div>
+                    </div>
+                  </transition-stub>
+                </a>
+              </td>
+              <td class="">
+                <!----><button data-v-a7ef304f="" class="btn btn-sm btn-dance" type="button" title="West Coast Swing" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M9.669.864L8 0L6.331.864l-1.858.282l-.842 1.68l-1.337 1.32L2.6 6l-.306 1.854l1.337 1.32l.842 1.68l1.858.282L8 12l1.669-.864l1.858-.282l.842-1.68l1.337-1.32L13.4 6l.306-1.854l-1.337-1.32l-.842-1.68zm1.196 1.193l.684 1.365l1.086 1.072L12.387 6l.248 1.506l-1.086 1.072l-.684 1.365l-1.51.229L8 10.874l-1.355-.702l-1.51-.229l-.684-1.365l-1.086-1.072L3.614 6l-.25-1.506l1.087-1.072l.684-1.365l1.51-.229L8 1.126l1.356.702z"></path>
+                      <path d="M4 11.794V16l4-1l4 1v-4.206l-2.018.306L8 13.126L6.018 12.1z"></path>
+                    </g>
+                  </svg> West Coast Swing <span class="badge text-bg-light">1</span><svg viewBox="0 0 16 16" width="1.2em" height="1.2em" style="margin-left: 0.25em;">
+                    <path fill="currentColor" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1zm4 3.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"></path>
+                  </svg></button>
+                <!--v-if-->
+              </td>
+              <td class="">
+                <!----><button data-v-a7ef304f="" class="btn btn-sm btn-other" type="button" title="1940S" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M6 4.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m-1 0a.5.5 0 1 0-1 0a.5.5 0 0 0 1 0"></path>
+                      <path d="M2 1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 1 6.586V2a1 1 0 0 1 1-1m0 5.586l7 7L13.586 9l-7-7H2z"></path>
+                    </g>
+                  </svg> 1940S
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-tempo" type="button" title="4/4" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71z"></path>
+                      <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16m7-8A7 7 0 1 1 1 8a7 7 0 0 1 14 0"></path>
+                    </g>
+                  </svg> 4/4
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Easy Listening" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Easy Listening
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Jazz" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Jazz
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Pop
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Vocal Jazz" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Vocal Jazz
+                  <!--v-if-->
+                </button><button data-v-a7ef304f="" class="btn btn-sm btn-music" type="button" title="Vocal Pop" style="margin-inline-end: 0.25em; margin-bottom: 0.25em;"><svg viewBox="0 0 16 16" width="1.2em" height="1.2em">
+                    <g fill="currentColor">
+                      <path d="M12 13c0 1.105-1.12 2-2.5 2S7 14.105 7 13s1.12-2 2.5-2s2.5.895 2.5 2"></path>
+                      <path fill-rule="evenodd" d="M12 3v10h-1V3z"></path>
+                      <path d="M11 2.82a1 1 0 0 1 .804-.98l3-.6A1 1 0 0 1 16 2.22V4l-5 1z"></path>
+                      <path fill-rule="evenodd" d="M0 11.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 7H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5m0-4A.5.5 0 0 1 .5 3H8a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"></path>
+                    </g>
+                  </svg> Vocal Pop
+                  <!--v-if-->
+                </button>
+              </td>
+              <td class="">
+                <!----><a data-v-a7ef304f="" class="link-underline-light" href="#" to="" replace="false" id="order_tip__0249be9e-3b55-4470-b8dc-4e654e1bda1d">Y</a><span id="BootstrapVueNext__ID__v-51__popover____placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="BootstrapVueNext__ID__v-51__popover___" auto-hide="false" class="tooltip b-tooltip fade bs-tooltip-start" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <!---->
+                      <div class="tooltip-inner">Last Modified 27-May-2023 11:41:15 PM (years ago)</div>
+                    </div>
+                  </div>
+                </transition-stub>
+              </td>
+            </tr>
+            <!---->
+            <!---->
+          </tbody>
+          <!---->
+          <!---->
+        </table>
+        <!--teleport start-->
+        <!--teleport end-->
+        <!--teleport start-->
+        <!--teleport end-->
+        <!--teleport start-->
+        <!--teleport end-->
+        <!--teleport start-->
+        <!--teleport end-->
+        <!--teleport start-->
+        <!--teleport end-->
+        <!--teleport start-->
+        <!--teleport end-->
+      </div>
+      <section id="spotify-player"><iframe src="https://open.spotify.com/embed/album/4PGMLc2lfy6hsdmyj2rm2x" frameborder="0" width="300" height="80" allowtransparency="true" allow="encrypted-media"></iframe></section>
+      <p> by <a class="" target="_blank" href="https://open.spotify.com/artist/1Mxqyy3pSjf8kZZL4QVxS0" rel="noopener noreferrer" to="" replace="false">Frank Sinatra</a></p>
+      <!--v-if-->
+    </div>
+  </div>
+  <div id="footer-content">
+    <hr>
+    <footer>
+      <p> © 2026 - <a href="https://www.music4dance.net">Music4Dance.net</a> - <a href="https://www.music4dance.net/home/sitemap">Site Map</a> - <a href="https://www.music4dance.net/home/termsofservice">Terms of Service</a> - <a href="https://www.music4dance.net/home/privacypolicy">Privacy Policy</a> - <a href="https://www.music4dance.net/home/credits">Credits</a> - <a href="https://github.com/music4dance/music4dance" target="_blank">Code</a> - <a>Help</a></p>
+    </footer>
+  </div>
+</div>"
+`;
+
 exports[`Playlist Viewer > renders a message and add table when nothing matched 1`] = `
 "<div><span context="[object Object]">MainMenu</span>
   <!--v-if-->

--- a/m4d/ClientApp/src/pages/playlist-viewer/__tests__/model.ts
+++ b/m4d/ClientApp/src/pages/playlist-viewer/__tests__/model.ts
@@ -4438,6 +4438,18 @@ export const anonymousUnmatchedModel = {
   unmatched: [],
 };
 
+// Variant for a Spotify album instead of a playlist — exercises the artist/album-specific
+// wording and link targets (open.spotify.com/album/... and /artist/... rather than
+// /playlist/... and /user/...).
+export const albumModel = {
+  ...model,
+  isAlbum: true,
+  name: "Nine Sinatra Songs (Music From The Ballet)",
+  description: undefined,
+  ownerId: "1Mxqyy3pSjf8kZZL4QVxS0",
+  ownerName: "Frank Sinatra",
+};
+
 // Variant where every checked track is missing from the catalog (signed in, so the
 // add-songs table covers all of them).
 export const noMatchesModel = {

--- a/m4d/ClientApp/src/pages/playlist-viewer/__tests__/playlist-viewer.test.ts
+++ b/m4d/ClientApp/src/pages/playlist-viewer/__tests__/playlist-viewer.test.ts
@@ -6,6 +6,7 @@ import {
   emptyPlaylistModel,
   noMatchesModel,
   anonymousUnmatchedModel,
+  albumModel,
 } from "./model";
 import App from "../App.vue";
 
@@ -37,5 +38,9 @@ describe("Playlist Viewer", () => {
 
   test("renders a sign-in call to action with returnUrl for anonymous viewers", () => {
     testPageSnapshot(App, anonymousUnmatchedModel);
+  }, 50000);
+
+  test("renders a Spotify album with artist attribution and album links", () => {
+    testPageSnapshot(App, albumModel);
   }, 50000);
 });

--- a/m4d/Controllers/SongController.cs
+++ b/m4d/Controllers/SongController.cs
@@ -139,9 +139,18 @@ public class SongController : ContentController
         var isAlbum = string.Equals(type, "album", StringComparison.OrdinalIgnoreCase);
         var kind = isAlbum ? "album" : "playlist";
 
+        var canAddSongs = Identity.IsAuthenticated;
+        var matchLimit = MatchLimitForSubscription(await GetSubscriptionLevel());
+
         var spotify = MusicService.GetService(ServiceType.Spotify);
+
+        // Matching costs an Azure Search round-trip sized to the number of tracks in the
+        // filter, so only fetch as many playlist/album tracks (in order) as this viewer's
+        // subscription tier will actually display, rather than paging through (and, worse,
+        // genre-enriching - see MusicServiceManager.LookupPlaylist) a large playlist just to
+        // discard everything past matchLimit.
         var playlist = await MusicServiceManager.LookupPlaylist(
-                spotify, $"/{kind}/{id}");
+                spotify, $"/{kind}/{id}", includeGenres: false, maxTracks: matchLimit);
 
         if (playlist == null)
         {
@@ -149,13 +158,6 @@ public class SongController : ContentController
                 $"{(isAlbum ? "Album" : "Playlist")} {id} doesn't exist or is empty.");
         }
 
-        var canAddSongs = Identity.IsAuthenticated;
-        var matchLimit = MatchLimitForSubscription(await GetSubscriptionLevel());
-
-        // Matching costs an Azure Search round-trip sized to the number of tracks in the
-        // filter, so only check as many playlist tracks (in playlist order) as this viewer's
-        // subscription tier will actually display, rather than matching the whole playlist
-        // and discarding the rest.
         var candidateTracks = playlist.Tracks.Take(matchLimit).ToList();
 
         try
@@ -279,7 +281,7 @@ public class SongController : ContentController
                 Description = playlist.Description,
                 OwnerId = playlist.OwnerId,
                 OwnerName = playlist.OwnerName,
-                TotalCount = playlist.Tracks.Count(),
+                TotalCount = playlist.TotalCount,
                 CheckedCount = candidateTracks.Count,
                 MatchedCount = matchedTrackIds.Count,
                 CanAddSongs = canAddSongs,

--- a/m4d/Controllers/SongController.cs
+++ b/m4d/Controllers/SongController.cs
@@ -129,21 +129,24 @@ public class SongController : ContentController
     }
 
     [AllowAnonymous]
-    public async Task<ActionResult> Playlist(string id)
+    public async Task<ActionResult> Playlist(string id, string type = "playlist")
     {
         if (string.IsNullOrWhiteSpace(id))
         {
             return ReturnError(HttpStatusCode.NotFound, "Playlist id is empty.");
         }
 
+        var isAlbum = string.Equals(type, "album", StringComparison.OrdinalIgnoreCase);
+        var kind = isAlbum ? "album" : "playlist";
+
         var spotify = MusicService.GetService(ServiceType.Spotify);
         var playlist = await MusicServiceManager.LookupPlaylist(
-                spotify, $"/playlist/{id}");
+                spotify, $"/{kind}/{id}");
 
         if (playlist == null)
         {
             return ReturnError(HttpStatusCode.NotFound,
-                $"Playlist {id} doesn't exist or is empty.");
+                $"{(isAlbum ? "Album" : "Playlist")} {id} doesn't exist or is empty.");
         }
 
         var canAddSongs = Identity.IsAuthenticated;
@@ -270,6 +273,7 @@ public class SongController : ContentController
             var model = new PlaylistViewerModel
             {
                 Id = id,
+                IsAlbum = isAlbum,
                 Histories = await AnonymizeSongs(sorted.Select(x => x.song).ToList()),
                 Name = playlist.Name,
                 Description = playlist.Description,

--- a/m4d/Utilities/MusicServiceManager.cs
+++ b/m4d/Utilities/MusicServiceManager.cs
@@ -540,7 +540,8 @@ public class MusicServiceManager(IConfiguration configuration)
     private static readonly Dictionary<string, ServiceTrack> s_trackCache = [];
 
     public async Task<GenericPlaylist> LookupPlaylist(MusicService service, string url,
-        IEnumerable<string> oldTrackList = null, IPrincipal principal = null)
+        IEnumerable<string> oldTrackList = null, IPrincipal principal = null,
+        bool includeGenres = true, int? maxTracks = null)
     {
         var results =
             await GetMusicServiceResults(service.BuildLookupRequest(url), service, principal);
@@ -553,6 +554,7 @@ public class MusicServiceManager(IConfiguration configuration)
         var description = results.description?.ToString();
         var ownerId = results.owner?.id?.ToString();
         var ownerName = results.owner?.display_name?.ToString();
+        int? totalTracks = (int?)(results.tracks?.total ?? results.total);
 
         if (string.IsNullOrEmpty(ownerName))
         {
@@ -581,8 +583,15 @@ public class MusicServiceManager(IConfiguration configuration)
             results,
             (Func<string, Task<dynamic>>)(req => GetMusicServiceResults(req, service)),
             // ReSharper disable once PossibleMultipleEnumeration
-            oldTrackList);
-        while ((results = await NextMusicServiceResults(results, service, principal)) != null)
+            oldTrackList,
+            includeGenres);
+
+        // Once the caller has as many tracks as it will ever use (e.g. the playlist viewer's
+        // subscription-tier match limit), stop paginating - fetching (and, if includeGenres,
+        // genre-enriching) the rest of a large playlist/album is otherwise pure waste. TotalCount
+        // (captured above, from the API's own paging metadata) still reflects the true size.
+        while ((maxTracks == null || tracks.Count < maxTracks.Value) &&
+               (results = await NextMusicServiceResults(results, service, principal)) != null)
         {
             var t = tracks as List<ServiceTrack> ?? [.. tracks];
             t.AddRange(
@@ -590,7 +599,8 @@ public class MusicServiceManager(IConfiguration configuration)
                     results,
                     (Func<string, Task<dynamic>>)(req => GetMusicServiceResults(req, service)),
                     // ReSharper disable once PossibleMultipleEnumeration
-                    oldTrackList));
+                    oldTrackList,
+                    includeGenres));
             tracks = t;
         }
 
@@ -608,14 +618,16 @@ public class MusicServiceManager(IConfiguration configuration)
             OwnerId = ownerId,
             OwnerName = ownerName,
             IsAlbum = url.Contains("/album/"),
+            TotalCount = totalTracks ?? tracks.Count,
             Tracks = tracks
         };
     }
 
     public async Task<GenericPlaylist> LookupPlaylistWithAudioData(MusicService service, string url,
-        IEnumerable<string> oldTrackList = null, IPrincipal principal = null)
+        IEnumerable<string> oldTrackList = null, IPrincipal principal = null,
+        bool includeGenres = true, int? maxTracks = null)
     {
-        var playlist = await LookupPlaylist(service, url, oldTrackList, principal);
+        var playlist = await LookupPlaylist(service, url, oldTrackList, principal, includeGenres, maxTracks);
         if (playlist != null && service.Id == ServiceType.Spotify)
         {
             await FillEchoTracks(playlist);
@@ -1269,7 +1281,7 @@ public class MusicServiceManager(IConfiguration configuration)
                         Trace.WriteLineIf(
                             TraceLevels.General.TraceInfo,
                             $"Excedeed EchoNest Limits: Pre-emptive {remaining} - used = {GetRateInfo(response.Headers, "X-RateLimit-Used")} - limit = {GetRateInfo(response.Headers, "X-RateLimit-Limit")}");
-                        Thread.Sleep(3 * 1000);
+                        await Task.Delay(3 * 1000);
                     }
                 }
                 else if ((int)response.StatusCode == 429 /*HttpStatusCode.TooManyRequests*/)
@@ -1278,7 +1290,7 @@ public class MusicServiceManager(IConfiguration configuration)
                     Trace.WriteLineIf(
                         TraceLevels.General.TraceInfo,
                         "Exceeded EchoNest Limits: Caught");
-                    Thread.Sleep(15 * 1000);
+                    await Task.Delay(15 * 1000);
                     continue;
                 }
                 else if (response.StatusCode == HttpStatusCode.Unauthorized && authRetries-- > 0)
@@ -1314,7 +1326,7 @@ public class MusicServiceManager(IConfiguration configuration)
                     if (statusCode == 429)
                     {
                         Logger.LogInformation("Exceeded EchoNest Limits: Caught");
-                        Thread.Sleep(15 * 1000);
+                        await Task.Delay(15 * 1000);
                         continue;
                     }
 
@@ -1327,7 +1339,7 @@ public class MusicServiceManager(IConfiguration configuration)
                                 $"Exceeded " +
                                 $"Itunes" +
                                 $" Limits: {5 - retries} {req.RequestUri}");
-                            Thread.Sleep(60 * 1000);
+                            await Task.Delay(60 * 1000);
                             continue;
                         }
 

--- a/m4d/Utilities/MusicServiceManager.cs
+++ b/m4d/Utilities/MusicServiceManager.cs
@@ -550,9 +550,32 @@ public class MusicServiceManager(IConfiguration configuration)
         }
 
         var name = results.name.ToString();
-        var description = results.description.ToString();
+        var description = results.description?.ToString();
         var ownerId = results.owner?.id?.ToString();
         var ownerName = results.owner?.display_name?.ToString();
+
+        if (string.IsNullOrEmpty(ownerName))
+        {
+            // Albums have no "owner" the way playlists do; fall back to the contributing
+            // artist(s) so the viewer has someone to attribute/link the album to.
+            var artistNames = new List<string>();
+            string firstArtistId = null;
+            dynamic artists = results.artists;
+            if (artists != null)
+            {
+                foreach (var artist in artists)
+                {
+                    firstArtistId ??= (string)artist.id;
+                    artistNames.Add((string)artist.name);
+                }
+            }
+
+            if (artistNames.Count > 0)
+            {
+                ownerId = firstArtistId;
+                ownerName = string.Join(", ", artistNames);
+            }
+        }
 
         IList<ServiceTrack> tracks = await service.ParseSearchResults(
             results,
@@ -584,6 +607,7 @@ public class MusicServiceManager(IConfiguration configuration)
             Description = description,
             OwnerId = ownerId,
             OwnerName = ownerName,
+            IsAlbum = url.Contains("/album/"),
             Tracks = tracks
         };
     }

--- a/m4d/ViewModels/SongListModel.cs
+++ b/m4d/ViewModels/SongListModel.cs
@@ -20,6 +20,7 @@ public class CustomSearchModel : SongListModel
 public class PlaylistViewerModel
 {
     public string Id { get; set; }
+    public bool IsAlbum { get; set; }
     public List<SongHistory> Histories { get; set; }
     public string Name { get; set; }
     public string Description { get; set; }

--- a/m4dModels/ISRCService.cs
+++ b/m4dModels/ISRCService.cs
@@ -23,6 +23,6 @@ public class ISRCService() : MusicService(ServiceType.ISRC, 'R', "ISRC", null, n
 
     public override Task<IList<ServiceTrack>> ParseSearchResults(
         dynamic results, Func<string, Task<dynamic>> getResult,
-        IEnumerable<string> excludeTracks)
+        IEnumerable<string> excludeTracks, bool includeGenres = true)
         => Task.FromResult<IList<ServiceTrack>>([]);
 }

--- a/m4dModels/ITunesService.cs
+++ b/m4dModels/ITunesService.cs
@@ -24,7 +24,7 @@ public class ITunesService : MusicService
 
     public override async Task<IList<ServiceTrack>> ParseSearchResults(
         dynamic results, Func<string, Task<dynamic>> getResult,
-        IEnumerable<string> excludeTracks)
+        IEnumerable<string> excludeTracks, bool includeGenres = true)
     {
         var ret = new List<ServiceTrack>();
 
@@ -46,7 +46,7 @@ public class ITunesService : MusicService
     }
 
     public override Task<ServiceTrack> ParseTrackResults(dynamic results,
-        Func<string, Task<dynamic>> getResult)
+        Func<string, Task<dynamic>> getResult, bool includeGenres = true)
     {
         if (results == null)
         {

--- a/m4dModels/MusicService.cs
+++ b/m4dModels/MusicService.cs
@@ -150,13 +150,13 @@ public class MusicService
 
     public virtual Task<IList<ServiceTrack>> ParseSearchResults(
         dynamic results, Func<string, Task<dynamic>> getResult,
-        IEnumerable<string> excludeTracks)
+        IEnumerable<string> excludeTracks, bool includeGenres = true)
     {
         throw new NotImplementedException();
     }
 
     public virtual Task<ServiceTrack> ParseTrackResults(dynamic results,
-        Func<string, Task<dynamic>> getResult)
+        Func<string, Task<dynamic>> getResult, bool includeGenres = true)
     {
         throw new NotImplementedException();
     }

--- a/m4dModels/PlayList.cs
+++ b/m4dModels/PlayList.cs
@@ -120,6 +120,10 @@ public class GenericPlaylist
     public string OwnerId { get; set; }
     public string OwnerName { get; set; }
     public bool IsAlbum { get; set; }
+
+    /// <summary>The playlist/album's true track count, from the API's own paging metadata -
+    /// independent of how many tracks were actually fetched (see LookupPlaylist's maxTracks).</summary>
+    public int TotalCount { get; set; }
     public IList<ServiceTrack> Tracks { get; set; }
 }
 

--- a/m4dModels/PlayList.cs
+++ b/m4dModels/PlayList.cs
@@ -119,6 +119,7 @@ public class GenericPlaylist
     public string Description { get; set; }
     public string OwnerId { get; set; }
     public string OwnerName { get; set; }
+    public bool IsAlbum { get; set; }
     public IList<ServiceTrack> Tracks { get; set; }
 }
 

--- a/m4dModels/SpotifyService.cs
+++ b/m4dModels/SpotifyService.cs
@@ -10,6 +10,10 @@ internal class SpotifyService : MusicService
     private static readonly Dictionary<string, dynamic> s_results =
         [];
 
+    // Dictionary<> isn't thread-safe and this is hit concurrently by ASP.NET requests -
+    // guards every read/write/eviction of s_results.
+    private static readonly object s_resultsLock = new();
+
     private static readonly TextInfo s_textInfo = CultureInfo.CurrentCulture.TextInfo;
 
     public SpotifyService() :
@@ -303,9 +307,12 @@ internal class SpotifyService : MusicService
 
     private async Task<dynamic> GetResults(string url, Func<string, Task<dynamic>> getResult)
     {
-        if (s_results.TryGetValue(url, out var result))
+        lock (s_resultsLock)
         {
-            return result;
+            if (s_results.TryGetValue(url, out var cached))
+            {
+                return cached;
+            }
         }
 
         if (getResult == null)
@@ -313,8 +320,10 @@ internal class SpotifyService : MusicService
             return null;
         }
 
+        dynamic result;
         try
         {
+            // Await the live call without holding the lock - it's a network round-trip.
             result = await getResult(url);
         }
         catch (Exception e)
@@ -325,16 +334,26 @@ internal class SpotifyService : MusicService
             return null;
         }
 
-        // Same unbounded-but-periodically-cleared cache shape as
-        // MusicServiceManager.s_trackCache - a handful of tracks sharing the same
-        // album/artist (common within one playlist) would otherwise re-fetch that
-        // album's/artist's genres from scratch on every track.
-        if (s_results.Count > 10000)
+        // Don't memoize a miss/failure as "no data" - only cache a result we actually got,
+        // so a transient Spotify error just means the next lookup retries instead of being
+        // stuck returning null until the cache clears.
+        if (result != null)
         {
-            s_results.Clear();
+            lock (s_resultsLock)
+            {
+                // Same unbounded-but-periodically-cleared cache shape as
+                // MusicServiceManager.s_trackCache - a handful of tracks sharing the same
+                // album/artist (common within one playlist) would otherwise re-fetch that
+                // album's/artist's genres from scratch on every track.
+                if (s_results.Count > 10000)
+                {
+                    s_results.Clear();
+                }
+
+                s_results[url] = result;
+            }
         }
 
-        s_results[url] = result;
         return result;
     }
 

--- a/m4dModels/SpotifyService.cs
+++ b/m4dModels/SpotifyService.cs
@@ -74,7 +74,7 @@ internal class SpotifyService : MusicService
 
     public override async Task<IList<ServiceTrack>> ParseSearchResults(
         dynamic results, Func<string, Task<dynamic>> getResult,
-        IEnumerable<string> excludeTracks)
+        IEnumerable<string> excludeTracks, bool includeGenres = true)
     {
         var excludeMap = new HashSet<string>(excludeTracks ?? []);
 
@@ -115,7 +115,7 @@ internal class SpotifyService : MusicService
             string trackId = trackT.id;
             if (trackId != null && !excludeMap.Contains(trackId))
             {
-                ret.Add(await ParseTrackResults(trackT, getResult));
+                ret.Add(await ParseTrackResults(trackT, getResult, includeGenres));
             }
         }
 
@@ -142,7 +142,7 @@ internal class SpotifyService : MusicService
     }
 
     public override async Task<ServiceTrack> ParseTrackResults(dynamic track,
-        Func<string, Task<dynamic>> getResult)
+        Func<string, Task<dynamic>> getResult, bool includeGenres = true)
     {
         if (track == null)
         {
@@ -219,7 +219,7 @@ internal class SpotifyService : MusicService
                 CollectionId = album?.id,
                 ImageUrl = imageUrl,
                 //ReleaseDate = track.ReleaseDate,
-                Genres = await BuildGenres(track, getResult),
+                Genres = includeGenres ? await BuildGenres(track, getResult) : null,
                 Duration = (track.duration_ms + 500) / 1000,
                 TrackNumber = trackNum,
                 IsPlayable = isPlayable,
@@ -315,7 +315,7 @@ internal class SpotifyService : MusicService
 
         try
         {
-            return await getResult(url);
+            result = await getResult(url);
         }
         catch (Exception e)
         {
@@ -324,6 +324,18 @@ internal class SpotifyService : MusicService
                 $"Error attempting to call Spotify: {e.Message}");
             return null;
         }
+
+        // Same unbounded-but-periodically-cleared cache shape as
+        // MusicServiceManager.s_trackCache - a handful of tracks sharing the same
+        // album/artist (common within one playlist) would otherwise re-fetch that
+        // album's/artist's genres from scratch on every track.
+        if (s_results.Count > 10000)
+        {
+            s_results.Clear();
+        }
+
+        s_results[url] = result;
+        return result;
     }
 
     private static string CleanupGenre(string genre)


### PR DESCRIPTION
## Summary

Three improvements to the Spotify playlist viewer (`SongController.Playlist` / `playlist-viewer` Vue page):

- **Spotify album support** — the viewer now works for `open.spotify.com/album/...` links, not just playlists. `SpotifyService.BuildLookupRequest` already branched on `/album/` vs `/playlist/`, but nothing called it with an album URL. Added a `type` param to the `Playlist` action, an artist-name fallback for `OwnerName`/`OwnerId` (albums have no `owner`), and fixed a latent crash where `results.description.ToString()` would throw for albums (which have no `description` field). Client-side link-building (Spotify link, embed player, owner/artist link) now branches on `IsAlbum`.

- **Fixed: pasting a playlist/album link silently did nothing.** `useDropTarget.checkServiceAndAdd` gated its call into the playlist/album-matching code behind `ServiceMatcher.match`, which only recognizes single-*track* id patterns anchored to the end of the string. A link copied via Spotify's "Copy Link" share action carries a trailing `?si=...` tracking param, so it never matched that end-anchored regex and the function returned early — before the playlist/album check ever ran. A drag-and-dropped link (often without the `?si=` suffix) worked only by coincidence. Playlist/album detection now runs unconditionally, first.

- **Performance: playlist views could take minutes.** Traced to `SpotifyService.BuildGenres`, which made a live Spotify API call per track's album *and* per track's artist — data the viewer never uses — sequentially, for every track. The intended dedup cache for those calls (`s_results`) was dead code (never written to), and the subscription-tier track limit was applied only after the entire playlist had already been fetched and enriched. Fixes:
  - `ParseSearchResults`/`ParseTrackResults` take an `includeGenres` flag; the viewer path opts out (it only needs id/ISRC/name/artist, already present inline with no extra calls). Other callers (admin playlist sync, user's-own-playlist import) keep genre enrichment.
  - `SpotifyService.s_results` is now actually populated, so repeated albums/artists within one playlist are fetched once.
  - `LookupPlaylist` takes a `maxTracks` bound and stops paginating once it has enough tracks for the viewer's subscription tier, instead of fetching the whole playlist and discarding the tail. The true total is still reported correctly via a new `GenericPlaylist.TotalCount`, read from the API's paging metadata.
  - Replaced four blocking `Thread.Sleep` retry waits in `GetMusicServiceResults` with `await Task.Delay`, so a throttled request doesn't park a thread-pool thread.

Investigation and rationale are written up in `architecture/music-service-api-calls.md` and `architecture/song-search-results.md`.

## Test plan

- [x] `dotnet build` — clean
- [x] `m4d.Tests` (164 tests) and `m4dModels.Tests` (457 tests) — all passing
- [x] Client `yarn type-check` / `yarn lint` on changed files — clean
- [x] Full client test suite (825 tests) — passing, including a new album-viewer snapshot test
- [x] Manually verified album lookup and the paste-URL fix against a live playlist/album

🤖 Generated with [Claude Code](https://claude.com/claude-code)