### PR TITLE
Hide dance ratings with only unconfirmed (auto-import) votes by default

### DIFF
--- a/architecture/song-filter.md
+++ b/architecture/song-filter.md
@@ -88,9 +88,9 @@ Azure query.
 | `Purchase`     | (no class — `SongFilter.SplitPurchase`/`splitPurchase` static helper) | service-code letters, optionally split by a literal `N`: `{include}[N{exclude}]`                                             | Which `MusicService` codes (`I`=ITunes, `S`=Spotify, `R`=ISRC/admin-only, etc.) a song must/must-not be available on                                                                                                                                                             |
 
 `TempoMin`/`TempoMax`, `LengthMin`/`LengthMax`, `Page`, and `Level` (a `CruftFilter` bitmask — "not
-in a publisher catalog" / "not categorized by dance") are plain scalar cells with no sub-class. See
-[[unconfirmed-dance-votes]] for a proposed third `CruftFilter` bit (songs whose only dance votes
-come from an unconfirmed/auto-import source).
+in a publisher catalog" / "not categorized by dance" / "not confirmed by a dancer") are plain
+scalar cells with no sub-class. See [[unconfirmed-dance-votes]] for the third `CruftFilter` bit
+(songs whose only dance votes come from an unconfirmed/auto-import source).
 
 **Always go through these classes to build or parse a filter field** — this is the same rule as
 [[../CLAUDE.md]]'s "Filter / Tag Construction" guidance, and this table is the map of which class

--- a/architecture/song-filter.md
+++ b/architecture/song-filter.md
@@ -88,7 +88,9 @@ Azure query.
 | `Purchase`     | (no class — `SongFilter.SplitPurchase`/`splitPurchase` static helper) | service-code letters, optionally split by a literal `N`: `{include}[N{exclude}]`                                             | Which `MusicService` codes (`I`=ITunes, `S`=Spotify, `R`=ISRC/admin-only, etc.) a song must/must-not be available on                                                                                                                                                             |
 
 `TempoMin`/`TempoMax`, `LengthMin`/`LengthMax`, `Page`, and `Level` (a `CruftFilter` bitmask — "not
-in a publisher catalog" / "not categorized by dance") are plain scalar cells with no sub-class.
+in a publisher catalog" / "not categorized by dance") are plain scalar cells with no sub-class. See
+[[unconfirmed-dance-votes]] for a proposed third `CruftFilter` bit (songs whose only dance votes
+come from an unconfirmed/auto-import source).
 
 **Always go through these classes to build or parse a filter field** — this is the same rule as
 [[../CLAUDE.md]]'s "Filter / Tag Construction" guidance, and this table is the map of which class

--- a/architecture/unconfirmed-dance-votes.md
+++ b/architecture/unconfirmed-dance-votes.md
@@ -1,124 +1,84 @@
-# Unconfirmed Dance Votes: Design
+# Unconfirmed Dance Votes
 
-## Problem
+## Overview
 
-There is currently one user account (`dgsnure`, a pseudo user driving Spotify-playlist
-auto-import — with more sources like it expected over time) whose dance votes are lower-confidence
-than a typical human curator's: they're applied in bulk by an automated process rather than a
-person actually judging the song. We don't want to purge this data — it's still a useful signal and
-a starting point for human correction — but a song whose **only** dance categorization comes from
-an unconfirmed source shouldn't clutter default search results, the same way a song with **no**
-dance categorization at all doesn't today (`CruftFilter.NoDances`, [[song-filter]]).
+A dance rating whose current weight traces back entirely to an **unconfirmed vote source** — a
+user account (currently just `dgsnure`, the Spotify-playlist auto-import account) whose votes are
+applied in bulk by an automated process rather than a person judging the song — is excluded from
+default search results, the same way a song with no dance categorization at all is
+(`CruftFilter.NoDances`, [[song-filter]]).
 
-This doc proposes treating "only unconfirmed votes" as a new kind of cruft, filtered out by default
-and opt-in visible via the existing `CruftFilter`/"Bonus content" mechanism — **without adding any
-field to the Azure Search index schema**, by reusing two fields (`dance_{id}/Votes`,
-`dance_ALL/Votes`) that already exist and are already nullable/sentinel-friendly.
+The data isn't deleted or hidden entirely: it's still visible on the song's detail page, still
+counted in `DanceTags`, and can be brought back into search results via the "Not confirmed by a
+dancer" option on Advanced Search, or the equivalent Raw Search checkbox. Only the *default*
+search path treats an unconfirmed-only dance as absent.
 
-**Public-facing wording**: "unconfirmed" (not "low quality") throughout UI text — e.g. Advanced
-Search's new checkbox reads **"Not confirmed by a dancer"** — decided below. This doc uses
-"unconfirmed" in code-facing names too, for consistency with the UI and to keep the concept
-value-neutral (a source can move from unconfirmed to confirmed over time as real users vote).
+This is implemented **without any Azure Search index schema change** — no new field, no
+`SongIndexNext`/`CodeVersion` migration ([[search-index-versioning]]). It reuses two fields that
+already existed (`dance_{id}/Votes`, `dance_ALL/Votes`) via a sentinel value.
 
 ---
 
-## Terminology: this is not `IsPseudo`
+## Where "unconfirmed source" is not `IsPseudo`
 
-`ApplicationUser`/`ModifiedRecord.IsPseudo` (`m4dModels/ModifiedRecord.cs:31`) already exists, but
-it means something different: it marks **batch/system accounts** (`batch-a`, `batch-s`, `batch-i`,
-`tempo-bot`, `automerge`) for two unrelated purposes — display formatting (`DecoratedName`) and
-exemption from the ±1-per-user-per-dance vote cap (`TryGetCappedDelta`, `Song.cs:4291-4317`, and
-its near-duplicate in `LoadProperties`, `Song.cs:1604`). A batch account is trusted automation
-acting on behalf of the system (tempo correction, merges) — its votes aren't "unconfirmed," they're
-just uncapped.
+`ApplicationUser`/`ModifiedRecord.IsPseudo` (`m4dModels/ModifiedRecord.cs:31`) marks
+**batch/system accounts** (`batch-a`, `batch-s`, `batch-i`, `tempo-bot`, `automerge`) for two
+unrelated purposes: display formatting (`DecoratedName`) and exemption from the ±1-per-user-per-dance
+vote cap (`Song.TryGetCappedDelta`, `m4dModels/Song.cs:4322`). A batch account is trusted automation
+acting on behalf of the system — its votes aren't "unconfirmed," they're just uncapped.
 
-The account this doc is about is a *different* axis: **vote trust**, not automation-vs-human. It
-needs its own concept — call it an **unconfirmed source** — orthogonal to `IsPseudo`. A future
-unconfirmed source could be a regular (non-batch, capped) account; a batch account could remain
-fully trusted. Don't conflate the two lists.
-
-`dgsnure` itself *is* pseudo (`IsPseudo = true`), which matters for a different reason: it means
-`dgsnure`'s votes may already be exempt from the ±1 cap today, or may not — `TryGetCappedDelta`'s
-current check is `user.StartsWith("batch")` / `user == "tempo-bot"`, neither of which matches
-`dgsnure`. Confirm during implementation whether `dgsnure` is capped at ±1/dance today or exempted
-some other way; if it's currently capped, that limits how much volume a single unconfirmed source
-can contribute per dance, which is still useful context for judging how urgent this feature is.
-Either way, this is exactly the scenario the feature targets: an uncapped or high-volume pseudo
-account can dominate a dance's vote weight without a single real dancer ever weighing in.
-
-**Registry**: follow the exact precedent already in the code (`TryGetCappedDelta`'s
-`user == null || user.StartsWith("batch") || user == "tempo-bot"`, `Song.cs:4297`) — a small
-hardcoded static check:
+Unconfirmed-source status is a separate, orthogonal concept — **vote trust**, not
+automation-vs-human — tracked by its own hardcoded registry right next to `TryGetCappedDelta`
+(`Song.cs:4350-4361`):
 
 ```csharp
 private static readonly HashSet<string> s_unconfirmedVoteSources =
     new(StringComparer.OrdinalIgnoreCase) { "dgsnure" };
 
-private static bool IsUnconfirmedSource(string user) =>
-    user != null && s_unconfirmedVoteSources.Contains(user);
-```
-
-**On the `|P` suffix** — no need to encode it. By the time `user` is available at the call site
-(`Song.cs:1595-1596`, `currentModified = new ModifiedRecord(prop.Value); user = currentModified.UserName;`),
-`ModifiedRecord`'s constructor has already split `"dgsnure|P"` into `UserName = "dgsnure"` and
-`IsPseudo = true` (`ModifiedRecord.cs:13-20`) — `user` is always the bare name. `IsUnconfirmedSource`
-should compare against `"dgsnure"` only, and does so independent of `IsPseudo`, consistent with
-"Terminology" above (the two flags are orthogonal, so matching shouldn't require both).
-
-This needs no DI, no config file, no schema/migration — consistent with how the codebase already
-hardcodes the batch/tempo-bot exemption list right next to the logic that uses it. Confirmed
-acceptable for now (hardcoded is fine); promote to config or an admin-editable list later if the
-roster grows past a handful of names or needs to change without a deploy.
-
----
-
-## Where per-user, per-dance attribution actually lives today
-
-`DanceRating.Weight` (`m4dModels/DanceRating.cs:67`) is only ever a net aggregate `int` — there is
-no persisted per-voter breakdown, and no SQL table for songs/votes at all (songs live entirely as
-Azure Search documents, `PropertiesField` holding a compressed, ordered log of `SongProperty`
-edits — see [[song-properties-compression]]). But that ordered log **is** the source of truth, and
-it's already replayed with per-user attribution every time a `Song` is materialized:
-
-- `Song.LoadProperties` (`m4dModels/Song.cs:1570`, called from every `Song.Create`/`Song.Load`
-  path — i.e. every read and every save) tracks the current `user` from `UserField`/`UserProxy`
-  properties as it walks the log, and calls `TryGetCappedDelta(drd, user, userDanceContributions,
-  out var effective)` (`Song.cs:1604`) before applying each `DanceRatingField` delta — this is what
-  enforces the ±1-per-real-user cap per dance today.
-- `Song.SetRatingsFromProperties` (`Song.cs:4247`) is a second, near-identical implementation of
-  the same replay+cap logic, used by an admin "recompute ratings" action
-  (`SongController.cs:1538`) rather than the normal load path. The two are already duplicated (the
-  comment at `Song.cs:4255-4256` acknowledges this) — this doc's change has to be made in **both**
-  places, which is a good forcing function to finally extract the shared logic into one method both
-  call, but that refactor is optional/separable from the feature itself.
-
-Both places already have exactly what's needed: they know, for every `DanceRatingField` delta, both
-the dance and the user who cast it (post-cap). Extending them to also classify each contributor as
-unconfirmed or not, and roll that up per dance, requires no new data source — just more bookkeeping
-in a loop that already exists.
-
-### Proposed extension
-
-Alongside the existing `userDanceContributions` dictionary (used for the cap), track a second,
-smaller one — net weight contributed by **confirmed** (non-unconfirmed) users, per dance:
-
-```csharp
-var confirmedNet = new Dictionary<string, int>(); // danceId -> net weight from confirmed users
-
-// ...inside the DanceRatingField case, after TryGetCappedDelta produces `effective`:
-if (TryGetCappedDelta(drd, user, userDanceContributions, out var effective))
+private static bool IsUnconfirmedSource(string user)
 {
-    var del = SoftUpdateDanceRating(effective);
-    if (!IsUnconfirmedSource(user))
-    {
-        confirmedNet[effective.DanceId] = confirmedNet.GetValueOrDefault(effective.DanceId) + effective.Delta;
-    }
-    if (del != null) { drDelete.Add(del); }
+    return user != null && s_unconfirmedVoteSources.Contains(user);
 }
 ```
 
-Then, once the log has been fully replayed and the usual zero/negative cleanup has run (`Song.cs:
-1789-1799` / the equivalent in `SetRatingsFromProperties`), stamp each surviving `DanceRating`:
+`dgsnure` is itself a pseudo user, but its username doesn't start with `batch` and isn't
+`tempo-bot`, so it is **not** exempt from `TryGetCappedDelta`'s ±1-per-dance cap — a single
+unconfirmed source can't currently push a dance's weight past 1 through repeated votes. That
+changes only if a future unconfirmed source is also given batch-style cap exemption.
+
+By the time `IsUnconfirmedSource` is checked, the `|P` pseudo-flag suffix has already been
+stripped: `ModifiedRecord`'s constructor splits `"dgsnure|P"` into `UserName = "dgsnure"` and
+`IsPseudo = true` (`ModifiedRecord.cs:13-20`) before `user` is ever read, so the registry only
+ever needs to hold bare usernames.
+
+Adding another unconfirmed source is a one-line change to `s_unconfirmedVoteSources`. If the
+roster grows past a handful of names, or needs to change without a deploy, promote it to config or
+an admin-editable list — not needed at the current scale.
+
+---
+
+## Attribution: `DanceRating.IsUnconfirmedOnly`
+
+There's no persisted per-voter breakdown of a dance's vote weight — `DanceRating.Weight`
+(`m4dModels/DanceRating.cs:67`) is only ever a net aggregate `int`, and songs aren't stored in SQL
+at all (they live as Azure Search documents whose `PropertiesField` holds a compressed, ordered log
+of `SongProperty` edits). What *is* available is that ordered log, which is already replayed with
+per-user attribution every time a `Song` is materialized — that's how the ±1-per-user cap works
+today. Both replay paths were extended to also track, per dance, how much of the current net weight
+came from **confirmed** (non-unconfirmed-source) voters, and stamp a transient flag once the replay
+finishes:
+
+- `Song.LoadProperties` (`m4dModels/Song.cs:1570`) — the path every `Song.Create`/`Song.Load` goes
+  through, i.e. every read and every save.
+- `Song.SetRatingsFromProperties` (`Song.cs:4263`) — a second, near-duplicate implementation of the
+  same replay+cap logic used by an admin "recompute ratings" action
+  (`SongController.cs`). The duplication predates this feature; both copies needed the same
+  extension.
+
+Both track a `confirmedNet` dictionary (danceId → net weight from confirmed voters) alongside the
+existing per-user cap dictionary, incrementing it with the post-cap `effective.Delta` whenever the
+voting user is *not* an unconfirmed source. After the replay (and the usual removal of any rating
+whose weight settled at or below zero), every surviving `DanceRating` is stamped:
 
 ```csharp
 foreach (var dr in DanceRatings)
@@ -127,89 +87,75 @@ foreach (var dr in DanceRatings)
 }
 ```
 
-Because a surviving `DanceRating.Weight` is always `> 0` (any rating that would go `<= 0` is
-already removed — `Song.cs:2904-2907`, `Song.cs:4208-4211`), `confirmedNet <= 0` for a surviving
-rating can only mean every unit of its positive weight traces back to unconfirmed contributors
-(possibly netted against a real user's downvote — still "no genuine positive signal").
-
-### New field on `DanceRating`
+Because a surviving `DanceRating.Weight` is always `> 0` (a rating that would go to zero or below is
+removed rather than kept — `Song.cs:2904-2907`, `Song.cs:4208-4211`), `confirmedNet <= 0` for a
+surviving rating can only mean every unit of its positive weight traces back to unconfirmed
+contributors — possibly netted against a real user's downvote, which still counts as "no genuine
+positive signal."
 
 ```csharp
-// m4dModels/DanceRating.cs
+// m4dModels/DanceRating.cs:85
 // Computed during property replay (LoadProperties / SetRatingsFromProperties); never
-// persisted — no [DataMember], so it's excluded from any DataContract-based serialization
-// and doesn't round-trip through SongProperties.
+// persisted - no [DataMember], so it's excluded from DataContract serialization and
+// doesn't round-trip through SongProperties.
 public bool IsUnconfirmedOnly { get; set; }
 ```
 
-`DanceRating` isn't exposed through any client-facing view model today (confirmed — no
-`m4d/ViewModels` type maps it), so there's no accidental leakage to worry about, but keep it
-un-annotated (no `[DataMember]`) defensively so it can never be picked up if that changes.
+`DanceRating` isn't exposed through any client-facing view model, so this flag never leaves the
+server.
 
 ---
 
-## Index encoding — reusing existing fields, no schema change
+## Index encoding: reusing existing fields
 
-`SongIndex.DocumentFromSong` (`m4dModels/SongIndex.cs:1806`) is where a `Song` becomes the Azure
-Search document. Two edits, both reusing fields that already exist:
+`SongIndex.DocumentFromSong` (`m4dModels/SongIndex.cs:1816`) is where a `Song` becomes the Azure
+Search document.
 
-### 1. Per-dance `Votes` sentinel
+**Per-dance `Votes` sentinel** (`SongIndex.cs:1927`):
 
 ```csharp
-// SongIndex.cs:1909, inside the `foreach (var dr in song.DanceRatings)` loop
 doc[BuildDanceFieldName(dr.DanceId)] = new Dictionary<string, object>
 {
-    { Votes, dr.IsUnconfirmedOnly ? -1 : dr.Weight },   // was: dr.Weight
+    { Votes, dr.IsUnconfirmedOnly ? -1 : dr.Weight },
     ...
 };
 ```
 
-`-1` is a safe, collision-free sentinel: `Votes` for a real rating is always `>= 0` today (see
-above), and it's confirmed nowhere in the codebase does a legitimate dance ever carry a negative
-weight in the index (`EditDanceRating`/`SoftUpdateDanceRating` remove the rating instead of letting
-it go negative). By default (cruft bit unset) this makes `dance_{id}/Votes ge {threshold}` — the
-clause `DanceQuery.GetODataFilter` already emits for every dance-scoped query (`DanceQuery.cs:151`)
-— naturally exclude unconfirmed-only dances from specific-dance search. Bringing them back on opt-in
-is handled in "New `CruftFilter` bit" below — it's a small, deliberate addition to `DanceQuery`, not
-left out.
+`-1` is a safe, collision-free sentinel — `Votes` for a real rating is always `>= 0` (see above).
+This alone makes `dance_{id}/Votes ge {threshold}` — the clause `DanceQuery.GetODataFilter` emits
+for every dance-scoped query (`DanceQuery.cs:155`) — exclude unconfirmed-only dances from any
+specific-dance search by default.
 
-### 2. `dance_ALL/Votes` aggregate
+**`dance_ALL/Votes` aggregate** (`SongIndex.cs:1945-1946`):
 
 ```csharp
-// SongIndex.cs:1928
-var all = song.DanceRatings.Where(dr => !dr.IsUnconfirmedOnly).Sum(dr => dr.Weight); // was: .Sum(...)
+// Excludes unconfirmed-only dances, so "does this song have any confirmed dance rating
+// at all" can be answered with "dance_ALL/Votes ne null" - see CruftFilter.UnconfirmedDances.
+var all = song.DanceRatings.Where(dr => !dr.IsUnconfirmedOnly).Sum(dr => dr.Weight);
 doc["dance_ALL"] = new Dictionary<string, object>
 {
-    { Votes, all == 0 ? null : all },   // unchanged — reuses the existing null-when-empty rule
+    { Votes, all == 0 ? null : all },
     ...
 };
 ```
 
-This is the piece that answers "does this song have **any** real dance categorization at all,
-regardless of which dance" — the browse/aggregate-level equivalent of the per-dance case above —
-using the field that already exists for exactly this kind of "has an overall rating" signal
-(`dance_ALL/Votes` is already `null` for a song with zero dance ratings; now it's also `null` for a
-song whose only ratings are unconfirmed-only). No new field.
+This answers "does this song have any confirmed dance rating at all, regardless of which dance" —
+reusing the field's existing null-when-empty behavior rather than adding a new one. One side
+effect: default "Sort by Dance Rating" (`dance_ALL/Votes desc` when 2+ or no dances are selected,
+`DanceQuery.cs:186`) ranks an unconfirmed-only song's rating as absent instead of boosting it on
+fabricated confidence, and the existing numeric-sort-guard
+(`(dance_ALL/Votes ne null) and (dance_ALL/Votes ne 0)`, `SongFilter.cs:724-725`) already drops
+null values from that sort.
 
-Side effect (desirable, not a regression): default "Sort by Dance Rating" — which, with 2+ or no
-dances selected, sorts by `dance_ALL/Votes desc` (`DanceQuery.cs:186`) — will rank an
-unconfirmed-only song's rating as absent rather than boosting it on fabricated confidence, and the
-existing numeric-sort-guard (`(dance_ALL/Votes ne null) and (dance_ALL/Votes ne 0)`,
-`SongFilter.cs:724-725`) already drops null values from that sort for free.
-
-### `DanceTags` — deliberately left untouched
-
-The `Song.DanceTags` collection (`SongIndex.cs:1884`, driven by `TagSummary`, independent of
-`DanceRating.Weight`) keeps listing the dance whether or not its votes are unconfirmed-only. This
-is intentional: it's what the user asked for ("don't want to completely remove them... they do
-provide some value") — the dance still shows up on the song's detail page, in tag search, and in
-`CruftFilter.NoDances`'s `DanceTags/any()` check (a song with only an unconfirmed-only dance still
-counts as "categorized" for that older, coarser cruft bit). Only the *vote-weight* signal is
-suppressed, via the two `Votes` fields above.
+**`DanceTags` is untouched.** The `Song.DanceTags` collection (`SongIndex.cs`, driven by
+`TagSummary`, independent of `DanceRating.Weight`) still lists the dance whether or not its votes
+are unconfirmed-only — it still shows on the song's detail page, in tag search, and satisfies the
+older, coarser `CruftFilter.NoDances`'s `DanceTags/any()` check. Only the *vote-weight* signal is
+suppressed.
 
 ---
 
-## New `CruftFilter` bit — and bringing unconfirmed votes back for a specific dance
+## `CruftFilter.UnconfirmedDances`
 
 ```csharp
 // m4dModels/CruftFilter.cs
@@ -219,21 +165,20 @@ public enum CruftFilter
     NoCruft = 0x00,
     NoPublishers = 0x01,
     NoDances = 0x02,
-    UnconfirmedDances = 0x04,  // NEW
-    AllCruft = 0x07,           // was 0x03 — MUST include the new bit
+    UnconfirmedDances = 0x04,
+    AllCruft = 0x07
 }
 ```
 
-**`AllCruft` must be updated.** It's not just "everything OR'd together" cosmetically — `SongIndex`'s
-full-index backup stream passes it explicitly to bypass all cruft filtering
-(`DoSearch(searchString, parameters, CruftFilter.AllCruft)`, `SongIndex.cs:2065`, used by
-`BackupIndexStreamingAsync`, which every index migration/rebuild depends on, [[search-index-versioning]]).
-If `AllCruft` isn't extended to include the new bit, a full backup would silently start skipping
-unconfirmed-only songs.
+`AllCruft` includes the new bit because `SongIndex`'s full-index backup stream passes it explicitly
+to bypass all cruft filtering (`DoSearch(searchString, parameters, CruftFilter.AllCruft)`,
+`SongIndex.cs`, used by `BackupIndexStreamingAsync`) — every index backup/rebuild needs to see
+unconfirmed-only songs too.
 
 ### The aggregate/browse case — `AddCruftInfo`
 
-`SongIndex.AddCruftInfo` (`SongIndex.cs:1471`) gets a third clause, symmetric with the existing two:
+`SongIndex.AddCruftInfo` (`SongIndex.cs:1471`) has a third clause alongside `Purchase/any()` and
+`DanceTags/any()`:
 
 ```csharp
 if ((cruft & CruftFilter.UnconfirmedDances) != CruftFilter.UnconfirmedDances)
@@ -243,35 +188,32 @@ if ((cruft & CruftFilter.UnconfirmedDances) != CruftFilter.UnconfirmedDances)
 }
 ```
 
-Same bit semantics as the existing two: bit **unset** (default, `NoCruft = 0`) → the restrictive
-clause is added → unconfirmed-only songs are hidden from a general/keyword browse. Bit **set** →
-clause omitted → they're included in the browse.
+Same bit semantics as the other two: bit **unset** (default) → the restrictive clause is added →
+unconfirmed-only songs are hidden from a general/keyword browse. Bit **set** → clause omitted →
+they're included.
 
-### The specific-dance case — this is the core use case, and it's simple
+### The specific-dance case — `DanceQuery.GetODataFilter`
 
-Turns out threading the opt-in into a per-dance query isn't the complexity risk originally flagged
-— `SongFilter` already owns both `CruftFilter` and the call site that builds the per-dance clause,
-so there's no piping problem, just one parameter and one extra `or`:
+Selecting a specific dance and opting in also brings back that dance's unconfirmed-only matches.
+`SongFilter` already owns both `CruftFilter` (`SongFilter.cs:248`) and the call site that builds the
+per-dance clause, so this is just a parameter and an extra `or`:
 
 ```csharp
-// DanceQuery.cs — GetODataFilter gains a parameter
+// DanceQuery.cs:124
 public virtual string GetODataFilter(DanceMusicCoreService dms, bool includeUnconfirmed = false)
 {
     ...
-    var subFilters = matches.Select(d =>
+    var voteClause =
+        $"{danceField}/Votes {(item.Threshold > 0 ? "ge" : "le")} {Math.Abs(item.Threshold)}";
+    if (includeUnconfirmed)
     {
-        var danceField = $"dance_{d.Id}";
-        var voteClause = $"{danceField}/Votes {(item.Threshold > 0 ? "ge" : "le")} {Math.Abs(item.Threshold)}";
-        if (includeUnconfirmed)
-        {
-            voteClause = $"({voteClause} or {danceField}/Votes eq -1)";
-        }
-        var filterParts = new List<string> { voteClause };
-        ...
+        voteClause = $"({voteClause} or {danceField}/Votes eq -1)";
+    }
+    ...
 ```
 
 ```csharp
-// SongFilter.cs:760 — GetDanceODataFilter already has CruftFilter (SongFilter.cs:248) on `this`
+// SongFilter.cs:760
 private string GetDanceODataFilter(DanceMusicCoreService dms)
 {
     return IsRaw
@@ -280,27 +222,27 @@ private string GetDanceODataFilter(DanceMusicCoreService dms)
 }
 ```
 
-With the checkbox on, selecting "West Coast Swing" now emits
-`(dance_wcs/Votes ge 1 or dance_wcs/Votes eq -1)` — exactly "bring back the unconfirmed votes for
-this dance," which is the stated core use case.
+With the checkbox on, selecting "West Coast Swing" emits
+`(dance_wcs/Votes ge 1 or dance_wcs/Votes eq -1)`.
 
-**One real tradeoff, not a complexity concern**: the sentinel only records *that* a dance's votes
-are unconfirmed-only, not their magnitude (that's the cost of not adding a schema field — the real
-weight only lives in the in-memory `Song`, never in the index). So `eq -1` can't respect a
-threshold — `WCS+1` and `WCS+3` both become `(... ge {n} or ... eq -1)`, and *any* unconfirmed-only
-match for that dance is included once the box is checked, regardless of the threshold you set. In
-practice this is probably fine (there's no real per-vote magnitude behind an unconfirmed rating to
-threshold against anyway — it's binary, "an auto-import matched this dance" or not), but worth
-being explicit about since it's a genuine information loss versus a schema change, not an
-implementation shortcut.
+**Known limitation**: the sentinel only records *that* a dance's votes are unconfirmed-only, not
+their magnitude — the real weight lives only in the in-memory `Song`, never in the index. So
+`eq -1` can't respect a threshold: `WCS+1` and `WCS+3` both become `(... ge {n} or ... eq -1)`, and
+*any* unconfirmed-only match for that dance is included once the box is checked, regardless of the
+requested threshold. This is the tradeoff of not adding a schema field.
 
-`RawDanceQuery`/raw filters are **not** given this treatment — raw filters are hand-built OData by
-an admin (`RawSearch`, [[song-filter]]'s "Raw filters" section) who already has full manual control
-and can write `dance_wcs/Votes eq -1` directly if needed.
+Negative-threshold dance queries (`Votes le n`) also match `Votes = -1` even with the cruft bit
+unset, since `-1 le n` is true for any `n >= -1` — a "weakly/not rated" query correctly includes a
+dance with zero genuine votes.
 
-### `RawSearch.cs` admin checkbox
+`RawDanceQuery`/raw filters don't get this treatment — an admin building a raw OData filter
+(`RawSearch`, [[song-filter]]'s "Raw filters" section) already has full manual control and can write
+`dance_wcs/Votes eq -1` directly.
+
+### Admin Raw Search checkbox
 
 ```csharp
+// m4dModels/RawSearch.cs
 [Display(Name = @"Exclude songs with unconfirmed-only dance votes")]
 public bool ExcludeUnconfirmedDances
 {
@@ -311,118 +253,62 @@ public bool ExcludeUnconfirmedDances
 }
 ```
 
-(Note: the existing two `RawSearch` properties are named "Exclude..." but bound the opposite way
-round from what the name implies — `HasFlag` true is actually the "*don't* exclude, i.e. show
-cruft" state, per `AddCruftInfo` above. That's a pre-existing naming quirk in the admin-only form,
-not something this doc needs to fix, but worth keeping the new property consistent with its
-siblings rather than "fixing" it in isolation.)
+Rendered in `m4d/Views/Song/RawSearchForm.cshtml` alongside `ExcludePublishers`/`ExcludeDances`.
+(Note: as with those two, the property name and its `HasFlag` semantics read backwards from each
+other — `true` means the bit that *stops* the restriction from being added, i.e. cruft is
+*shown*. Pre-existing quirk in the admin form, not specific to this feature.)
 
----
+### Advanced Search checkbox
 
-## Advanced Search UX
-
-`m4d/ClientApp/src/pages/advanced-search/App.vue`'s "Bonus content:" checkbox group
-(`App.vue:627-635`) already renders the two existing bits as opt-in checkboxes:
+`m4d/ClientApp/src/pages/advanced-search/App.vue`'s "Bonus content:" checkbox group has a third
+option alongside "Not found in any publisher catalog" / "Not categorized by dance":
 
 ```html
-<BFormGroup id="bonuses-group" class="mx-2 mb-2" label="Bonus content:" label-for="bonuses">
-  <BFormCheckboxGroup id="bonuses" v-model="bonuses">
-    <BFormCheckbox value="P">Not found in any publisher catalog</BFormCheckbox>
-    <BFormCheckbox value="D">Not categorized by dance</BFormCheckbox>
-    <BFormCheckbox value="U">Not confirmed by a dancer</BFormCheckbox> <!-- NEW -->
-  </BFormCheckboxGroup>
-  ...
-</BFormGroup>
+<BFormCheckbox value="U">Not confirmed by a dancer</BFormCheckbox>
 ```
 
-`computeBonuses()`/the `songFilter` computed (`App.vue:161-167`, `308-317`) get the third bit:
-
-```ts
-if (bonuses.value.indexOf("P") !== -1) level = 1;
-if (bonuses.value.indexOf("D") !== -1) level += 2;
-if (bonuses.value.indexOf("U") !== -1) level += 4; // NEW
-```
-
-No wire-format change: `SongFilter.level` (`m4d/ClientApp/src/models/SongFilter.ts:47,131`) is
-already a generic int cell — this is purely a UI/bitmask change on both ends, nothing new to parse
-or serialize.
-
-"Not confirmed by a dancer" was chosen over alternatives ("Not yet confirmed by the community", "Only
-matched by automatic playlist import") specifically because it doesn't name the mechanism
-(Spotify/auto-import) — it'll keep reading correctly once other unconfirmed sources exist beyond
-`dgsnure`, and it avoids "low quality" or similar value-laden language while staying accurate: the
-one true fact being encoded is "no dancer has confirmed this."
+wired to bit `4` in the `level` cell (`filter.level`), the same generic int cell `Level`/`CruftFilter`
+has always used — no wire-format change was needed. "Not confirmed by a dancer" was chosen
+deliberately over wording that names the mechanism ("automatic playlist import") or uses
+value-laden language ("low quality") — it stays accurate and reads correctly for any future
+unconfirmed source, not just `dgsnure`.
 
 ---
 
-## Rollout — a data-content change, not a schema migration
+## Rollout
 
-This deliberately sidesteps the whole `SongIndexNext`/`CodeVersion` apparatus documented in
-[[search-index-versioning]] — no new field is added to `BuildIndex()`, so none of that machinery
-(index version bump, `SEARCHINDEXVERSION`, dual-schema `TODOIDX` shims, `UpdateSearchIdx` cutover)
-is needed. This is the main practical payoff of the "no schema change" constraint.
+This was a pure data-content change, not a schema migration — no new field, so none of the
+`SongIndexNext`/`CodeVersion` apparatus ([[search-index-versioning]]) was needed. Existing index
+documents needed one re-serialize-and-reupload pass (the same `BackupIndexStreamingAsync` +
+`UploadIndex`/`SaveSongs` building blocks used for index migrations, targeting the same
+index/version rather than a new one) to pick up the new `Votes`/`dance_ALL.Votes` values for
+already-unconfirmed-only dances; every save since deploy computes them automatically via
+`DocumentFromSong`.
 
-What **is** needed: every document already sitting in the live index was serialized under the old
-logic and still holds real (non-sentinel) `Votes`/`dance_ALL.Votes` values for any unconfirmed-only
-dance — they won't reflect the new suppression until re-serialized. After deploying the code change:
-
-- Re-run the existing "stream every song, re-run `DocumentFromSong`, re-upload" backfill pattern —
-  the same building block `BackupIndexStreamingAsync` + `UploadIndex`/`SaveSongs` already provides
-  for index migrations (`AdminController.cs` around `IndexBackup`/`UpdateSearchIdx`,
-  `SongIndex.cs:889-894`), just targeting the **same** index/version rather than a new one. No
-  index reset, no name change, no version bump.
-- New saves/edits after deploy get correct values automatically — `DocumentFromSong` always runs on
-  the current `Song` state, so this is self-healing for any song touched after rollout even without
-  the backfill; the backfill just makes existing untouched songs correct immediately rather than
-  gradually.
+A pre-existing, cruder mechanism served a similar purpose before this feature: `SongController`'s
+`NewMusic` action explicitly excluded any song `dgsnure` had ever touched
+(`Filter.User = new UserQuery("dgsnure", false).Query`) from the New Music page. That's been
+removed — the new mechanism supersedes it and is strictly more precise, since it only suppresses
+dance ratings that are actually unconfirmed-only rather than every song the account ever edited
+(including ones with genuine confirmed dance votes from other users).
 
 ---
-
-## Edge cases & interactions
-
-- **`VoteSearch`/`PostSearch` (user-specific "did I vote for this dance" queries, [[song-search-service]])
-  are unaffected.** Those reconstruct real `Song` objects from the property log and read actual
-  `DanceRating`/vote state in memory — they never touch the index's `Votes` sentinel, so a user's
-  own real vote history is never misrepresented by this change.
-- **Negative-threshold dance queries** (`DanceQueryItem`'s `-n` syntax, `Votes le n`,
-  `DanceQuery.cs:151`) will also match an unconfirmed-only dance's `Votes = -1` even with the cruft
-  bit unset, since `-1 le n` is true for any `n >= -1`. This reads as semantically correct — a
-  "weakly/not rated" query should include a dance with zero genuine votes — but call it out
-  explicitly since it wasn't the primary target of this feature.
-- **Opt-in for a specific dance shows all-or-nothing, not threshold-scoped**, per the tradeoff
-  described above — checking "Not confirmed by a dancer" while filtering on "West Coast Swing +3"
-  will include any unconfirmed-only WCS match, not just ones that would have hit a weight of 3.
-
----
-
-## Implementation checklist
-
-| File | Change |
-| --- | --- |
-| `m4dModels/DanceRating.cs` | Add transient `IsUnconfirmedOnly` bool (no `[DataMember]`) |
-| `m4dModels/Song.cs` | `LoadProperties` (~1570) and `SetRatingsFromProperties` (~4247): add `IsUnconfirmedSource` check, `confirmedNet` tracking, post-loop stamping. Confirm whether `dgsnure` is already covered by `TryGetCappedDelta`'s batch-exemption check or still capped at ±1/dance today. Consider extracting the now-triple-duplicated cap/attribution logic into one shared helper both call. |
-| `m4dModels/SongIndex.cs` | `DocumentFromSong` (~1806): per-dance `Votes` sentinel (~1911), `dance_ALL` aggregate (~1928). `AddCruftInfo` (~1471): new clause. |
-| `m4dModels/CruftFilter.cs` | Add `UnconfirmedDances = 0x04`; bump `AllCruft` to `0x07` |
-| `m4dModels/DanceQuery.cs` | `GetODataFilter`: new `includeUnconfirmed` parameter, `or {danceField}/Votes eq -1` clause |
-| `m4dModels/SongFilter.cs` | `GetDanceODataFilter` (~760): pass `CruftFilter.HasFlag(CruftFilter.UnconfirmedDances)` through to `DanceQuery.GetODataFilter` |
-| `m4dModels/RawSearch.cs` | New `ExcludeUnconfirmedDances` checkbox-bool property |
-| `m4d/ClientApp/src/pages/advanced-search/App.vue` | New "Bonus content" checkbox ("Not confirmed by a dancer") + bitmask wiring |
-| Tests | `m4dModels.Tests/DanceRatingCapTests.cs` (extend for the new attribution logic, both `LoadProperties` and `SetRatingsFromProperties` paths), `SongIndex` doc-building tests (assert `-1` sentinel and `dance_ALL/Votes` null-when-unconfirmed-only), `DanceQueryTest.cs` (assert the `or ... eq -1` clause appears only when the cruft bit is set), `CruftFilter`/`AddCruftInfo`/`RawSearch` tests for the new bit |
-| Backfill | One-time admin re-serialize-and-reupload pass over the live index after deploy (existing `BackupIndexStreamingAsync`/`UploadIndex` building blocks — no version bump) |
 
 ## Related Code
 
 | File | Purpose |
 | --- | --- |
-| `m4dModels/DanceRating.cs` | `Weight` (aggregate), new `IsUnconfirmedOnly` |
-| `m4dModels/Song.cs` | `LoadProperties`, `SetRatingsFromProperties`, `TryGetCappedDelta`, `EditDanceRating` |
-| `m4dModels/ModifiedRecord.cs` | Existing `IsPseudo` — a different concept, see "Terminology" above |
+| `m4dModels/DanceRating.cs` | `Weight` (aggregate), `IsUnconfirmedOnly` |
+| `m4dModels/Song.cs` | `LoadProperties`, `SetRatingsFromProperties`, `TryGetCappedDelta`, `IsUnconfirmedSource`, `s_unconfirmedVoteSources` |
+| `m4dModels/ModifiedRecord.cs` | `IsPseudo` — a different, orthogonal concept, see "Where 'unconfirmed source' is not `IsPseudo`" above |
 | `m4dModels/SongIndex.cs` | `DocumentFromSong`, `AddCruftInfo`, `BackupIndexStreamingAsync`/`UploadIndex` |
-| `m4dModels/CruftFilter.cs` | The bitmask this doc adds a member to |
-| `m4dModels/RawSearch.cs` | Admin Raw Search checkbox shim over `CruftFilter` |
-| `m4dModels/DanceQuery.cs` | Per-dance OData (`Votes ge/le`) — gains the `includeUnconfirmed` opt-in clause |
+| `m4dModels/CruftFilter.cs` | `UnconfirmedDances` bit, `AllCruft` |
+| `m4dModels/DanceQuery.cs` | Per-dance OData (`Votes ge/le`), `includeUnconfirmed` opt-in clause |
 | `m4dModels/SongFilter.cs` | `CruftFilter`, `GetDanceODataFilter` — where the opt-in threads through |
-| `m4d/ClientApp/src/pages/advanced-search/App.vue` | "Bonus content" checkboxes |
+| `m4dModels/RawSearch.cs` | `ExcludeUnconfirmedDances` admin checkbox shim over `CruftFilter` |
+| `m4d/Views/Song/RawSearchForm.cshtml` | Renders the admin checkbox |
+| `m4d/ClientApp/src/pages/advanced-search/App.vue` | "Bonus content" checkboxes, `level` bitmask |
+| `m4dModels.Tests/UnconfirmedDanceVoteTests.cs` | Attribution, index encoding, `AddCruftInfo`, `DanceQuery`/`SongFilter` opt-in coverage |
 | [[song-filter]] | `CruftFilter`/`Level` field, `AddCruftInfo`, wire format |
-| [[song-search-service]] | `VoteSearch`/`PostSearch` — confirmed unaffected |
-| [[search-index-versioning]] | Why this change doesn't need it |
+| [[song-search-service]] | `VoteSearch`/`PostSearch` — unaffected by this feature (they reconstruct real `Song` objects and never touch the index sentinel) |
+| [[search-index-versioning]] | Why this feature didn't need it |

--- a/architecture/unconfirmed-dance-votes.md
+++ b/architecture/unconfirmed-dance-votes.md
@@ -184,9 +184,16 @@ unconfirmed-only songs too.
 if ((cruft & CruftFilter.UnconfirmedDances) != CruftFilter.UnconfirmedDances)
 {
     if (extra.Length > 0) { _ = extra.Append(" and "); }
-    _ = extra.Append("dance_ALL/Votes ne null");
+    _ = extra.Append("(not DanceTags/any() or dance_ALL/Votes ne null)");
 }
 ```
+
+The `not DanceTags/any() or ...` guard keeps this clause independent of `NoDances`: a song with no
+dance tags at all also has a null `dance_ALL/Votes` (there's nothing to aggregate), so without the
+guard this clause would re-exclude exactly the uncategorized songs that the `NoDances` bit is
+supposed to opt back in. The guard lets those through unconditionally and reserves the
+`dance_ALL/Votes ne null` check for songs that *do* have dance tags but whose only votes are
+unconfirmed.
 
 Same bit semantics as the other two: bit **unset** (default) → the restrictive clause is added →
 unconfirmed-only songs are hidden from a general/keyword browse. Bit **set** → clause omitted →
@@ -257,6 +264,17 @@ Rendered in `m4d/Views/Song/RawSearchForm.cshtml` alongside `ExcludePublishers`/
 (Note: as with those two, the property name and its `HasFlag` semantics read backwards from each
 other — `true` means the bit that *stops* the restriction from being added, i.e. cruft is
 *shown*. Pre-existing quirk in the admin form, not specific to this feature.)
+
+The `Song/RawSearch` GET action model-binds with a restrictive allow-list
+(`SongController.cs:438-439`) rather than binding the whole `RawSearch` model, so a new checkbox
+property has to be added to that `[Bind("...")]` list explicitly or it silently posts as its
+default (`false`) and can never be toggled on from the form:
+
+```csharp
+[Bind(
+    "SearchText,ODataFilter,SortFields,SearchFields,Description,IsLucene,ExcludePublishers,ExcludeDances,ExcludeUnconfirmedDances")]
+RawSearch rawSearch
+```
 
 ### Advanced Search checkbox
 

--- a/architecture/unconfirmed-dance-votes.md
+++ b/architecture/unconfirmed-dance-votes.md
@@ -1,0 +1,428 @@
+# Unconfirmed Dance Votes: Design
+
+## Problem
+
+There is currently one user account (`dgsnure`, a pseudo user driving Spotify-playlist
+auto-import — with more sources like it expected over time) whose dance votes are lower-confidence
+than a typical human curator's: they're applied in bulk by an automated process rather than a
+person actually judging the song. We don't want to purge this data — it's still a useful signal and
+a starting point for human correction — but a song whose **only** dance categorization comes from
+an unconfirmed source shouldn't clutter default search results, the same way a song with **no**
+dance categorization at all doesn't today (`CruftFilter.NoDances`, [[song-filter]]).
+
+This doc proposes treating "only unconfirmed votes" as a new kind of cruft, filtered out by default
+and opt-in visible via the existing `CruftFilter`/"Bonus content" mechanism — **without adding any
+field to the Azure Search index schema**, by reusing two fields (`dance_{id}/Votes`,
+`dance_ALL/Votes`) that already exist and are already nullable/sentinel-friendly.
+
+**Public-facing wording**: "unconfirmed" (not "low quality") throughout UI text — e.g. Advanced
+Search's new checkbox reads **"Not confirmed by a dancer"** — decided below. This doc uses
+"unconfirmed" in code-facing names too, for consistency with the UI and to keep the concept
+value-neutral (a source can move from unconfirmed to confirmed over time as real users vote).
+
+---
+
+## Terminology: this is not `IsPseudo`
+
+`ApplicationUser`/`ModifiedRecord.IsPseudo` (`m4dModels/ModifiedRecord.cs:31`) already exists, but
+it means something different: it marks **batch/system accounts** (`batch-a`, `batch-s`, `batch-i`,
+`tempo-bot`, `automerge`) for two unrelated purposes — display formatting (`DecoratedName`) and
+exemption from the ±1-per-user-per-dance vote cap (`TryGetCappedDelta`, `Song.cs:4291-4317`, and
+its near-duplicate in `LoadProperties`, `Song.cs:1604`). A batch account is trusted automation
+acting on behalf of the system (tempo correction, merges) — its votes aren't "unconfirmed," they're
+just uncapped.
+
+The account this doc is about is a *different* axis: **vote trust**, not automation-vs-human. It
+needs its own concept — call it an **unconfirmed source** — orthogonal to `IsPseudo`. A future
+unconfirmed source could be a regular (non-batch, capped) account; a batch account could remain
+fully trusted. Don't conflate the two lists.
+
+`dgsnure` itself *is* pseudo (`IsPseudo = true`), which matters for a different reason: it means
+`dgsnure`'s votes may already be exempt from the ±1 cap today, or may not — `TryGetCappedDelta`'s
+current check is `user.StartsWith("batch")` / `user == "tempo-bot"`, neither of which matches
+`dgsnure`. Confirm during implementation whether `dgsnure` is capped at ±1/dance today or exempted
+some other way; if it's currently capped, that limits how much volume a single unconfirmed source
+can contribute per dance, which is still useful context for judging how urgent this feature is.
+Either way, this is exactly the scenario the feature targets: an uncapped or high-volume pseudo
+account can dominate a dance's vote weight without a single real dancer ever weighing in.
+
+**Registry**: follow the exact precedent already in the code (`TryGetCappedDelta`'s
+`user == null || user.StartsWith("batch") || user == "tempo-bot"`, `Song.cs:4297`) — a small
+hardcoded static check:
+
+```csharp
+private static readonly HashSet<string> s_unconfirmedVoteSources =
+    new(StringComparer.OrdinalIgnoreCase) { "dgsnure" };
+
+private static bool IsUnconfirmedSource(string user) =>
+    user != null && s_unconfirmedVoteSources.Contains(user);
+```
+
+**On the `|P` suffix** — no need to encode it. By the time `user` is available at the call site
+(`Song.cs:1595-1596`, `currentModified = new ModifiedRecord(prop.Value); user = currentModified.UserName;`),
+`ModifiedRecord`'s constructor has already split `"dgsnure|P"` into `UserName = "dgsnure"` and
+`IsPseudo = true` (`ModifiedRecord.cs:13-20`) — `user` is always the bare name. `IsUnconfirmedSource`
+should compare against `"dgsnure"` only, and does so independent of `IsPseudo`, consistent with
+"Terminology" above (the two flags are orthogonal, so matching shouldn't require both).
+
+This needs no DI, no config file, no schema/migration — consistent with how the codebase already
+hardcodes the batch/tempo-bot exemption list right next to the logic that uses it. Confirmed
+acceptable for now (hardcoded is fine); promote to config or an admin-editable list later if the
+roster grows past a handful of names or needs to change without a deploy.
+
+---
+
+## Where per-user, per-dance attribution actually lives today
+
+`DanceRating.Weight` (`m4dModels/DanceRating.cs:67`) is only ever a net aggregate `int` — there is
+no persisted per-voter breakdown, and no SQL table for songs/votes at all (songs live entirely as
+Azure Search documents, `PropertiesField` holding a compressed, ordered log of `SongProperty`
+edits — see [[song-properties-compression]]). But that ordered log **is** the source of truth, and
+it's already replayed with per-user attribution every time a `Song` is materialized:
+
+- `Song.LoadProperties` (`m4dModels/Song.cs:1570`, called from every `Song.Create`/`Song.Load`
+  path — i.e. every read and every save) tracks the current `user` from `UserField`/`UserProxy`
+  properties as it walks the log, and calls `TryGetCappedDelta(drd, user, userDanceContributions,
+  out var effective)` (`Song.cs:1604`) before applying each `DanceRatingField` delta — this is what
+  enforces the ±1-per-real-user cap per dance today.
+- `Song.SetRatingsFromProperties` (`Song.cs:4247`) is a second, near-identical implementation of
+  the same replay+cap logic, used by an admin "recompute ratings" action
+  (`SongController.cs:1538`) rather than the normal load path. The two are already duplicated (the
+  comment at `Song.cs:4255-4256` acknowledges this) — this doc's change has to be made in **both**
+  places, which is a good forcing function to finally extract the shared logic into one method both
+  call, but that refactor is optional/separable from the feature itself.
+
+Both places already have exactly what's needed: they know, for every `DanceRatingField` delta, both
+the dance and the user who cast it (post-cap). Extending them to also classify each contributor as
+unconfirmed or not, and roll that up per dance, requires no new data source — just more bookkeeping
+in a loop that already exists.
+
+### Proposed extension
+
+Alongside the existing `userDanceContributions` dictionary (used for the cap), track a second,
+smaller one — net weight contributed by **confirmed** (non-unconfirmed) users, per dance:
+
+```csharp
+var confirmedNet = new Dictionary<string, int>(); // danceId -> net weight from confirmed users
+
+// ...inside the DanceRatingField case, after TryGetCappedDelta produces `effective`:
+if (TryGetCappedDelta(drd, user, userDanceContributions, out var effective))
+{
+    var del = SoftUpdateDanceRating(effective);
+    if (!IsUnconfirmedSource(user))
+    {
+        confirmedNet[effective.DanceId] = confirmedNet.GetValueOrDefault(effective.DanceId) + effective.Delta;
+    }
+    if (del != null) { drDelete.Add(del); }
+}
+```
+
+Then, once the log has been fully replayed and the usual zero/negative cleanup has run (`Song.cs:
+1789-1799` / the equivalent in `SetRatingsFromProperties`), stamp each surviving `DanceRating`:
+
+```csharp
+foreach (var dr in DanceRatings)
+{
+    dr.IsUnconfirmedOnly = confirmedNet.GetValueOrDefault(dr.DanceId) <= 0;
+}
+```
+
+Because a surviving `DanceRating.Weight` is always `> 0` (any rating that would go `<= 0` is
+already removed — `Song.cs:2904-2907`, `Song.cs:4208-4211`), `confirmedNet <= 0` for a surviving
+rating can only mean every unit of its positive weight traces back to unconfirmed contributors
+(possibly netted against a real user's downvote — still "no genuine positive signal").
+
+### New field on `DanceRating`
+
+```csharp
+// m4dModels/DanceRating.cs
+// Computed during property replay (LoadProperties / SetRatingsFromProperties); never
+// persisted — no [DataMember], so it's excluded from any DataContract-based serialization
+// and doesn't round-trip through SongProperties.
+public bool IsUnconfirmedOnly { get; set; }
+```
+
+`DanceRating` isn't exposed through any client-facing view model today (confirmed — no
+`m4d/ViewModels` type maps it), so there's no accidental leakage to worry about, but keep it
+un-annotated (no `[DataMember]`) defensively so it can never be picked up if that changes.
+
+---
+
+## Index encoding — reusing existing fields, no schema change
+
+`SongIndex.DocumentFromSong` (`m4dModels/SongIndex.cs:1806`) is where a `Song` becomes the Azure
+Search document. Two edits, both reusing fields that already exist:
+
+### 1. Per-dance `Votes` sentinel
+
+```csharp
+// SongIndex.cs:1909, inside the `foreach (var dr in song.DanceRatings)` loop
+doc[BuildDanceFieldName(dr.DanceId)] = new Dictionary<string, object>
+{
+    { Votes, dr.IsUnconfirmedOnly ? -1 : dr.Weight },   // was: dr.Weight
+    ...
+};
+```
+
+`-1` is a safe, collision-free sentinel: `Votes` for a real rating is always `>= 0` today (see
+above), and it's confirmed nowhere in the codebase does a legitimate dance ever carry a negative
+weight in the index (`EditDanceRating`/`SoftUpdateDanceRating` remove the rating instead of letting
+it go negative). By default (cruft bit unset) this makes `dance_{id}/Votes ge {threshold}` — the
+clause `DanceQuery.GetODataFilter` already emits for every dance-scoped query (`DanceQuery.cs:151`)
+— naturally exclude unconfirmed-only dances from specific-dance search. Bringing them back on opt-in
+is handled in "New `CruftFilter` bit" below — it's a small, deliberate addition to `DanceQuery`, not
+left out.
+
+### 2. `dance_ALL/Votes` aggregate
+
+```csharp
+// SongIndex.cs:1928
+var all = song.DanceRatings.Where(dr => !dr.IsUnconfirmedOnly).Sum(dr => dr.Weight); // was: .Sum(...)
+doc["dance_ALL"] = new Dictionary<string, object>
+{
+    { Votes, all == 0 ? null : all },   // unchanged — reuses the existing null-when-empty rule
+    ...
+};
+```
+
+This is the piece that answers "does this song have **any** real dance categorization at all,
+regardless of which dance" — the browse/aggregate-level equivalent of the per-dance case above —
+using the field that already exists for exactly this kind of "has an overall rating" signal
+(`dance_ALL/Votes` is already `null` for a song with zero dance ratings; now it's also `null` for a
+song whose only ratings are unconfirmed-only). No new field.
+
+Side effect (desirable, not a regression): default "Sort by Dance Rating" — which, with 2+ or no
+dances selected, sorts by `dance_ALL/Votes desc` (`DanceQuery.cs:186`) — will rank an
+unconfirmed-only song's rating as absent rather than boosting it on fabricated confidence, and the
+existing numeric-sort-guard (`(dance_ALL/Votes ne null) and (dance_ALL/Votes ne 0)`,
+`SongFilter.cs:724-725`) already drops null values from that sort for free.
+
+### `DanceTags` — deliberately left untouched
+
+The `Song.DanceTags` collection (`SongIndex.cs:1884`, driven by `TagSummary`, independent of
+`DanceRating.Weight`) keeps listing the dance whether or not its votes are unconfirmed-only. This
+is intentional: it's what the user asked for ("don't want to completely remove them... they do
+provide some value") — the dance still shows up on the song's detail page, in tag search, and in
+`CruftFilter.NoDances`'s `DanceTags/any()` check (a song with only an unconfirmed-only dance still
+counts as "categorized" for that older, coarser cruft bit). Only the *vote-weight* signal is
+suppressed, via the two `Votes` fields above.
+
+---
+
+## New `CruftFilter` bit — and bringing unconfirmed votes back for a specific dance
+
+```csharp
+// m4dModels/CruftFilter.cs
+[Flags]
+public enum CruftFilter
+{
+    NoCruft = 0x00,
+    NoPublishers = 0x01,
+    NoDances = 0x02,
+    UnconfirmedDances = 0x04,  // NEW
+    AllCruft = 0x07,           // was 0x03 — MUST include the new bit
+}
+```
+
+**`AllCruft` must be updated.** It's not just "everything OR'd together" cosmetically — `SongIndex`'s
+full-index backup stream passes it explicitly to bypass all cruft filtering
+(`DoSearch(searchString, parameters, CruftFilter.AllCruft)`, `SongIndex.cs:2065`, used by
+`BackupIndexStreamingAsync`, which every index migration/rebuild depends on, [[search-index-versioning]]).
+If `AllCruft` isn't extended to include the new bit, a full backup would silently start skipping
+unconfirmed-only songs.
+
+### The aggregate/browse case — `AddCruftInfo`
+
+`SongIndex.AddCruftInfo` (`SongIndex.cs:1471`) gets a third clause, symmetric with the existing two:
+
+```csharp
+if ((cruft & CruftFilter.UnconfirmedDances) != CruftFilter.UnconfirmedDances)
+{
+    if (extra.Length > 0) { _ = extra.Append(" and "); }
+    _ = extra.Append("dance_ALL/Votes ne null");
+}
+```
+
+Same bit semantics as the existing two: bit **unset** (default, `NoCruft = 0`) → the restrictive
+clause is added → unconfirmed-only songs are hidden from a general/keyword browse. Bit **set** →
+clause omitted → they're included in the browse.
+
+### The specific-dance case — this is the core use case, and it's simple
+
+Turns out threading the opt-in into a per-dance query isn't the complexity risk originally flagged
+— `SongFilter` already owns both `CruftFilter` and the call site that builds the per-dance clause,
+so there's no piping problem, just one parameter and one extra `or`:
+
+```csharp
+// DanceQuery.cs — GetODataFilter gains a parameter
+public virtual string GetODataFilter(DanceMusicCoreService dms, bool includeUnconfirmed = false)
+{
+    ...
+    var subFilters = matches.Select(d =>
+    {
+        var danceField = $"dance_{d.Id}";
+        var voteClause = $"{danceField}/Votes {(item.Threshold > 0 ? "ge" : "le")} {Math.Abs(item.Threshold)}";
+        if (includeUnconfirmed)
+        {
+            voteClause = $"({voteClause} or {danceField}/Votes eq -1)";
+        }
+        var filterParts = new List<string> { voteClause };
+        ...
+```
+
+```csharp
+// SongFilter.cs:760 — GetDanceODataFilter already has CruftFilter (SongFilter.cs:248) on `this`
+private string GetDanceODataFilter(DanceMusicCoreService dms)
+{
+    return IsRaw
+        ? RawDanceQuery?.GetODataFilter(dms)
+        : DanceQuery?.GetODataFilter(dms, CruftFilter.HasFlag(CruftFilter.UnconfirmedDances));
+}
+```
+
+With the checkbox on, selecting "West Coast Swing" now emits
+`(dance_wcs/Votes ge 1 or dance_wcs/Votes eq -1)` — exactly "bring back the unconfirmed votes for
+this dance," which is the stated core use case.
+
+**One real tradeoff, not a complexity concern**: the sentinel only records *that* a dance's votes
+are unconfirmed-only, not their magnitude (that's the cost of not adding a schema field — the real
+weight only lives in the in-memory `Song`, never in the index). So `eq -1` can't respect a
+threshold — `WCS+1` and `WCS+3` both become `(... ge {n} or ... eq -1)`, and *any* unconfirmed-only
+match for that dance is included once the box is checked, regardless of the threshold you set. In
+practice this is probably fine (there's no real per-vote magnitude behind an unconfirmed rating to
+threshold against anyway — it's binary, "an auto-import matched this dance" or not), but worth
+being explicit about since it's a genuine information loss versus a schema change, not an
+implementation shortcut.
+
+`RawDanceQuery`/raw filters are **not** given this treatment — raw filters are hand-built OData by
+an admin (`RawSearch`, [[song-filter]]'s "Raw filters" section) who already has full manual control
+and can write `dance_wcs/Votes eq -1` directly if needed.
+
+### `RawSearch.cs` admin checkbox
+
+```csharp
+[Display(Name = @"Exclude songs with unconfirmed-only dance votes")]
+public bool ExcludeUnconfirmedDances
+{
+    get => CruftFilter.HasFlag(CruftFilter.UnconfirmedDances);
+    set => CruftFilter = value
+        ? CruftFilter | CruftFilter.UnconfirmedDances
+        : CruftFilter & ~CruftFilter.UnconfirmedDances;
+}
+```
+
+(Note: the existing two `RawSearch` properties are named "Exclude..." but bound the opposite way
+round from what the name implies — `HasFlag` true is actually the "*don't* exclude, i.e. show
+cruft" state, per `AddCruftInfo` above. That's a pre-existing naming quirk in the admin-only form,
+not something this doc needs to fix, but worth keeping the new property consistent with its
+siblings rather than "fixing" it in isolation.)
+
+---
+
+## Advanced Search UX
+
+`m4d/ClientApp/src/pages/advanced-search/App.vue`'s "Bonus content:" checkbox group
+(`App.vue:627-635`) already renders the two existing bits as opt-in checkboxes:
+
+```html
+<BFormGroup id="bonuses-group" class="mx-2 mb-2" label="Bonus content:" label-for="bonuses">
+  <BFormCheckboxGroup id="bonuses" v-model="bonuses">
+    <BFormCheckbox value="P">Not found in any publisher catalog</BFormCheckbox>
+    <BFormCheckbox value="D">Not categorized by dance</BFormCheckbox>
+    <BFormCheckbox value="U">Not confirmed by a dancer</BFormCheckbox> <!-- NEW -->
+  </BFormCheckboxGroup>
+  ...
+</BFormGroup>
+```
+
+`computeBonuses()`/the `songFilter` computed (`App.vue:161-167`, `308-317`) get the third bit:
+
+```ts
+if (bonuses.value.indexOf("P") !== -1) level = 1;
+if (bonuses.value.indexOf("D") !== -1) level += 2;
+if (bonuses.value.indexOf("U") !== -1) level += 4; // NEW
+```
+
+No wire-format change: `SongFilter.level` (`m4d/ClientApp/src/models/SongFilter.ts:47,131`) is
+already a generic int cell — this is purely a UI/bitmask change on both ends, nothing new to parse
+or serialize.
+
+"Not confirmed by a dancer" was chosen over alternatives ("Not yet confirmed by the community", "Only
+matched by automatic playlist import") specifically because it doesn't name the mechanism
+(Spotify/auto-import) — it'll keep reading correctly once other unconfirmed sources exist beyond
+`dgsnure`, and it avoids "low quality" or similar value-laden language while staying accurate: the
+one true fact being encoded is "no dancer has confirmed this."
+
+---
+
+## Rollout — a data-content change, not a schema migration
+
+This deliberately sidesteps the whole `SongIndexNext`/`CodeVersion` apparatus documented in
+[[search-index-versioning]] — no new field is added to `BuildIndex()`, so none of that machinery
+(index version bump, `SEARCHINDEXVERSION`, dual-schema `TODOIDX` shims, `UpdateSearchIdx` cutover)
+is needed. This is the main practical payoff of the "no schema change" constraint.
+
+What **is** needed: every document already sitting in the live index was serialized under the old
+logic and still holds real (non-sentinel) `Votes`/`dance_ALL.Votes` values for any unconfirmed-only
+dance — they won't reflect the new suppression until re-serialized. After deploying the code change:
+
+- Re-run the existing "stream every song, re-run `DocumentFromSong`, re-upload" backfill pattern —
+  the same building block `BackupIndexStreamingAsync` + `UploadIndex`/`SaveSongs` already provides
+  for index migrations (`AdminController.cs` around `IndexBackup`/`UpdateSearchIdx`,
+  `SongIndex.cs:889-894`), just targeting the **same** index/version rather than a new one. No
+  index reset, no name change, no version bump.
+- New saves/edits after deploy get correct values automatically — `DocumentFromSong` always runs on
+  the current `Song` state, so this is self-healing for any song touched after rollout even without
+  the backfill; the backfill just makes existing untouched songs correct immediately rather than
+  gradually.
+
+---
+
+## Edge cases & interactions
+
+- **`VoteSearch`/`PostSearch` (user-specific "did I vote for this dance" queries, [[song-search-service]])
+  are unaffected.** Those reconstruct real `Song` objects from the property log and read actual
+  `DanceRating`/vote state in memory — they never touch the index's `Votes` sentinel, so a user's
+  own real vote history is never misrepresented by this change.
+- **Negative-threshold dance queries** (`DanceQueryItem`'s `-n` syntax, `Votes le n`,
+  `DanceQuery.cs:151`) will also match an unconfirmed-only dance's `Votes = -1` even with the cruft
+  bit unset, since `-1 le n` is true for any `n >= -1`. This reads as semantically correct — a
+  "weakly/not rated" query should include a dance with zero genuine votes — but call it out
+  explicitly since it wasn't the primary target of this feature.
+- **Opt-in for a specific dance shows all-or-nothing, not threshold-scoped**, per the tradeoff
+  described above — checking "Not confirmed by a dancer" while filtering on "West Coast Swing +3"
+  will include any unconfirmed-only WCS match, not just ones that would have hit a weight of 3.
+
+---
+
+## Implementation checklist
+
+| File | Change |
+| --- | --- |
+| `m4dModels/DanceRating.cs` | Add transient `IsUnconfirmedOnly` bool (no `[DataMember]`) |
+| `m4dModels/Song.cs` | `LoadProperties` (~1570) and `SetRatingsFromProperties` (~4247): add `IsUnconfirmedSource` check, `confirmedNet` tracking, post-loop stamping. Confirm whether `dgsnure` is already covered by `TryGetCappedDelta`'s batch-exemption check or still capped at ±1/dance today. Consider extracting the now-triple-duplicated cap/attribution logic into one shared helper both call. |
+| `m4dModels/SongIndex.cs` | `DocumentFromSong` (~1806): per-dance `Votes` sentinel (~1911), `dance_ALL` aggregate (~1928). `AddCruftInfo` (~1471): new clause. |
+| `m4dModels/CruftFilter.cs` | Add `UnconfirmedDances = 0x04`; bump `AllCruft` to `0x07` |
+| `m4dModels/DanceQuery.cs` | `GetODataFilter`: new `includeUnconfirmed` parameter, `or {danceField}/Votes eq -1` clause |
+| `m4dModels/SongFilter.cs` | `GetDanceODataFilter` (~760): pass `CruftFilter.HasFlag(CruftFilter.UnconfirmedDances)` through to `DanceQuery.GetODataFilter` |
+| `m4dModels/RawSearch.cs` | New `ExcludeUnconfirmedDances` checkbox-bool property |
+| `m4d/ClientApp/src/pages/advanced-search/App.vue` | New "Bonus content" checkbox ("Not confirmed by a dancer") + bitmask wiring |
+| Tests | `m4dModels.Tests/DanceRatingCapTests.cs` (extend for the new attribution logic, both `LoadProperties` and `SetRatingsFromProperties` paths), `SongIndex` doc-building tests (assert `-1` sentinel and `dance_ALL/Votes` null-when-unconfirmed-only), `DanceQueryTest.cs` (assert the `or ... eq -1` clause appears only when the cruft bit is set), `CruftFilter`/`AddCruftInfo`/`RawSearch` tests for the new bit |
+| Backfill | One-time admin re-serialize-and-reupload pass over the live index after deploy (existing `BackupIndexStreamingAsync`/`UploadIndex` building blocks — no version bump) |
+
+## Related Code
+
+| File | Purpose |
+| --- | --- |
+| `m4dModels/DanceRating.cs` | `Weight` (aggregate), new `IsUnconfirmedOnly` |
+| `m4dModels/Song.cs` | `LoadProperties`, `SetRatingsFromProperties`, `TryGetCappedDelta`, `EditDanceRating` |
+| `m4dModels/ModifiedRecord.cs` | Existing `IsPseudo` — a different concept, see "Terminology" above |
+| `m4dModels/SongIndex.cs` | `DocumentFromSong`, `AddCruftInfo`, `BackupIndexStreamingAsync`/`UploadIndex` |
+| `m4dModels/CruftFilter.cs` | The bitmask this doc adds a member to |
+| `m4dModels/RawSearch.cs` | Admin Raw Search checkbox shim over `CruftFilter` |
+| `m4dModels/DanceQuery.cs` | Per-dance OData (`Votes ge/le`) — gains the `includeUnconfirmed` opt-in clause |
+| `m4dModels/SongFilter.cs` | `CruftFilter`, `GetDanceODataFilter` — where the opt-in threads through |
+| `m4d/ClientApp/src/pages/advanced-search/App.vue` | "Bonus content" checkboxes |
+| [[song-filter]] | `CruftFilter`/`Level` field, `AddCruftInfo`, wire format |
+| [[song-search-service]] | `VoteSearch`/`PostSearch` — confirmed unaffected |
+| [[search-index-versioning]] | Why this change doesn't need it |

--- a/m4d/ClientApp/src/pages/advanced-search/App.vue
+++ b/m4d/ClientApp/src/pages/advanced-search/App.vue
@@ -165,6 +165,9 @@ const songFilter = computed(() => {
   if (bonuses.value.indexOf("D") !== -1) {
     level += 2;
   }
+  if (bonuses.value.indexOf("U") !== -1) {
+    level += 4;
+  }
 
   filter.action = "advanced";
   filter.searchString = keyWords.value;
@@ -312,6 +315,9 @@ function computeBonuses(): string[] {
   }
   if (filter.level && filter.level & 2) {
     bonuses.push("D");
+  }
+  if (filter.level && filter.level & 4) {
+    bonuses.push("U");
   }
   return bonuses;
 }
@@ -628,6 +634,7 @@ function onReset(evt: Event): void {
           <BFormCheckboxGroup id="bonuses" v-model="bonuses">
             <BFormCheckbox value="P">Not found in any publisher catalog</BFormCheckbox>
             <BFormCheckbox value="D">Not categorized by dance</BFormCheckbox>
+            <BFormCheckbox value="U">Not confirmed by a dancer</BFormCheckbox>
           </BFormCheckboxGroup>
           <template #description>
             <a href="https://music4dance.blog/music4dance-help/subscriptions/">Premium content</a>

--- a/m4d/ClientApp/src/pages/advanced-search/__tests__/__snapshots__/advanced-search.test.ts.snap
+++ b/m4d/ClientApp/src/pages/advanced-search/__tests__/__snapshots__/advanced-search.test.ts.snap
@@ -288,11 +288,12 @@ exports[`AdvancedSearch.vue > renders the advanced search page 1`] = `
             <div id="bonuses" role="group" class="bv-no-focus-ring" tabindex="-1">
               <div class="form-check form-check-inline"><input id="BootstrapVueNext__ID__v-111__form-check___" class="form-check-input" type="checkbox" name="BootstrapVueNext__ID__v-110__checkbox___" true-value="P" false-value="false" value="P"><label for="BootstrapVueNext__ID__v-111__form-check___" class="form-check-label">Not found in any publisher catalog</label></div>
               <div class="form-check form-check-inline"><input id="BootstrapVueNext__ID__v-112__form-check___" class="form-check-input" type="checkbox" name="BootstrapVueNext__ID__v-110__checkbox___" true-value="D" false-value="false" value="D"><label for="BootstrapVueNext__ID__v-112__form-check___" class="form-check-label">Not categorized by dance</label></div>
+              <div class="form-check form-check-inline"><input id="BootstrapVueNext__ID__v-113__form-check___" class="form-check-input" type="checkbox" name="BootstrapVueNext__ID__v-110__checkbox___" true-value="U" false-value="false" value="U"><label for="BootstrapVueNext__ID__v-113__form-check___" class="form-check-label">Not confirmed by a dancer</label></div>
             </div>
             <!---->
             <!----><small id="BootstrapVueNext__ID__v-108___BV_description____" class="text-body-secondary form-text"><a href="https://music4dance.blog/music4dance-help/subscriptions/">Premium content</a></small>
           </fieldset>
-          <fieldset id="sort-group" class="b-form-group"><label id="BootstrapVueNext__ID__v-114___BV_label____" for="sort" class="form-label d-block">Sort By:</label><select id="sort" class="form-select" required="" aria-required="true">
+          <fieldset id="sort-group" class="b-form-group"><label id="BootstrapVueNext__ID__v-115___BV_label____" for="sort" class="form-label d-block">Sort By:</label><select id="sort" class="form-select" required="" aria-required="true">
               <option selected="">Default: Closest Match</option>
               <option value="Dances">Dance Rating</option>
               <option value="Closest">Closest Match</option>
@@ -309,8 +310,8 @@ exports[`AdvancedSearch.vue > renders the advanced search page 1`] = `
               <option value="Comments">Comments</option>
             </select>
             <div id="sort-order" role="radiogroup" class="bv-no-focus-ring my-2" tabindex="-1">
-              <div class="form-check form-check-inline"><input id="BootstrapVueNext__ID__v-121__form-check___" class="form-check-input" type="radio" name="sort-order" value="asc"><label for="BootstrapVueNext__ID__v-121__form-check___" class="form-check-label">Ascending (A-Z, Slow-Fast, Newest-Oldest, Shortest-Longest)</label></div>
-              <div class="form-check form-check-inline"><input id="BootstrapVueNext__ID__v-122__form-check___" class="form-check-input" type="radio" name="sort-order" value="desc"><label for="BootstrapVueNext__ID__v-122__form-check___" class="form-check-label">Descending (Z-A, Fast-Slow, Oldest-Newest, Longest-Shortest)</label></div>
+              <div class="form-check form-check-inline"><input id="BootstrapVueNext__ID__v-122__form-check___" class="form-check-input" type="radio" name="sort-order" value="asc"><label for="BootstrapVueNext__ID__v-122__form-check___" class="form-check-label">Ascending (A-Z, Slow-Fast, Newest-Oldest, Shortest-Longest)</label></div>
+              <div class="form-check form-check-inline"><input id="BootstrapVueNext__ID__v-123__form-check___" class="form-check-input" type="radio" name="sort-order" value="desc"><label for="BootstrapVueNext__ID__v-123__form-check___" class="form-check-label">Descending (Z-A, Fast-Slow, Oldest-Newest, Longest-Shortest)</label></div>
             </div>
             <!---->
             <!---->

--- a/m4d/Controllers/SongController.cs
+++ b/m4d/Controllers/SongController.cs
@@ -81,8 +81,6 @@ public class SongController : ContentController
             Filter.Page = page;
         }
 
-        Filter.User = new UserQuery("dgsnure", false).Query;
-
         return await DoAzureSearch();
     }
 

--- a/m4d/Controllers/SongController.cs
+++ b/m4d/Controllers/SongController.cs
@@ -436,7 +436,7 @@ public class SongController : ContentController
     [AllowAnonymous]
     public async Task<ActionResult> RawSearch(
         [Bind(
-            "SearchText,ODataFilter,SortFields,SearchFields,Description,IsLucene,ExcludePublishers,ExcludeDances")]
+            "SearchText,ODataFilter,SortFields,SearchFields,Description,IsLucene,ExcludePublishers,ExcludeDances,ExcludeUnconfirmedDances")]
         RawSearch rawSearch)
     {
         HelpPage = "advanced-search";

--- a/m4d/Views/Song/RawSearchForm.cshtml
+++ b/m4d/Views/Song/RawSearchForm.cshtml
@@ -68,6 +68,10 @@
                             <input asp-for="ExcludeDances" class="form-check-input" />
                             <label asp-for="ExcludeDances" class="form-check-label"></label>
                         </div>
+                        <div class="form-check">
+                            <input asp-for="ExcludeUnconfirmedDances" class="form-check-input" />
+                            <label asp-for="ExcludeUnconfirmedDances" class="form-check-label"></label>
+                        </div>
                     </div>
                 </div>
 

--- a/m4dModels.Tests/RawSearchTests.cs
+++ b/m4dModels.Tests/RawSearchTests.cs
@@ -9,7 +9,7 @@ public class RawSearchTests
         var rawSearch = new RawSearch { ExcludeDances = true };
 
         rawSearch.ExcludePublishers = true;
-        Assert.AreEqual(CruftFilter.AllCruft, rawSearch.CruftFilter);
+        Assert.AreEqual(CruftFilter.NoPublishers | CruftFilter.NoDances, rawSearch.CruftFilter);
         Assert.IsTrue(rawSearch.ExcludeDances, "Setting ExcludePublishers should not clear ExcludeDances");
 
         rawSearch.ExcludePublishers = false;
@@ -23,7 +23,7 @@ public class RawSearchTests
         var rawSearch = new RawSearch { ExcludePublishers = true };
 
         rawSearch.ExcludeDances = true;
-        Assert.AreEqual(CruftFilter.AllCruft, rawSearch.CruftFilter);
+        Assert.AreEqual(CruftFilter.NoPublishers | CruftFilter.NoDances, rawSearch.CruftFilter);
         Assert.IsTrue(rawSearch.ExcludePublishers, "Setting ExcludeDances should not clear ExcludePublishers");
 
         rawSearch.ExcludeDances = false;
@@ -32,12 +32,28 @@ public class RawSearchTests
     }
 
     [TestMethod]
-    public void CruftFilter_DefaultsToNoCruft_WithBothFlagsFalse()
+    public void ExcludeUnconfirmedDances_SetsAndClearsBitIndependentlyOfOtherFlags()
+    {
+        var rawSearch = new RawSearch { ExcludePublishers = true, ExcludeDances = true };
+
+        rawSearch.ExcludeUnconfirmedDances = true;
+        Assert.AreEqual(CruftFilter.AllCruft, rawSearch.CruftFilter);
+        Assert.IsTrue(rawSearch.ExcludePublishers);
+        Assert.IsTrue(rawSearch.ExcludeDances);
+
+        rawSearch.ExcludeUnconfirmedDances = false;
+        Assert.AreEqual(CruftFilter.NoPublishers | CruftFilter.NoDances, rawSearch.CruftFilter);
+        Assert.IsFalse(rawSearch.ExcludeUnconfirmedDances);
+    }
+
+    [TestMethod]
+    public void CruftFilter_DefaultsToNoCruft_WithAllFlagsFalse()
     {
         var rawSearch = new RawSearch();
 
         Assert.AreEqual(CruftFilter.NoCruft, rawSearch.CruftFilter);
         Assert.IsFalse(rawSearch.ExcludePublishers);
         Assert.IsFalse(rawSearch.ExcludeDances);
+        Assert.IsFalse(rawSearch.ExcludeUnconfirmedDances);
     }
 }

--- a/m4dModels.Tests/UnconfirmedDanceVoteTests.cs
+++ b/m4dModels.Tests/UnconfirmedDanceVoteTests.cs
@@ -205,6 +205,20 @@ public class UnconfirmedDanceVoteTests
     }
 
     [TestMethod]
+    public void AddCruftInfo_NoDancesBitSetWithoutUnconfirmedBit_DoesNotReExcludeUncategorizedSongs()
+    {
+        // NoDances opted-in (show songs with no dance tags at all) but UnconfirmedDances still
+        // defaulted (hide unconfirmed-only songs). The unconfirmed clause must not re-exclude
+        // songs that have no DanceTags whatsoever - that's NoDances's job, not this bit's.
+        var options = new SearchOptions();
+        var result = SongIndex.AddCruftInfo(options, CruftFilter.NoDances);
+
+        Assert.AreEqual(
+            "Purchase/any() and (not DanceTags/any() or dance_ALL/Votes ne null)",
+            result.Filter);
+    }
+
+    [TestMethod]
     public void AddCruftInfo_UnconfirmedDancesBitSet_OmitsClause()
     {
         var options = new SearchOptions();

--- a/m4dModels.Tests/UnconfirmedDanceVoteTests.cs
+++ b/m4dModels.Tests/UnconfirmedDanceVoteTests.cs
@@ -1,0 +1,269 @@
+using Azure.Search.Documents;
+using Azure.Search.Documents.Models;
+
+namespace m4dModels.Tests;
+
+/// <summary>
+/// Tests for the "unconfirmed dance votes" feature (architecture/unconfirmed-dance-votes.md):
+/// a dance whose current weight traces back entirely to an unconfirmed vote source (currently
+/// just "dgsnure", the Spotify-playlist auto-import account) is flagged via
+/// DanceRating.IsUnconfirmedOnly, encoded in the index with a -1 Votes sentinel, and filtered
+/// out of default search via the new CruftFilter.UnconfirmedDances bit.
+/// </summary>
+[TestClass]
+public class UnconfirmedDanceVoteTests
+{
+    private static DanceMusicService _service;
+    private static DanceMusicCoreService _dms;
+
+    [ClassInitialize]
+    public static async Task ClassInitialize(TestContext _)
+    {
+        await DanceMusicTester.LoadDances();
+        _service = await DanceMusicTester.CreateServiceWithUsers("UnconfirmedDanceVotes");
+        _dms = _service;
+    }
+
+    // -------------------------------------------------------------------------
+    // Song.LoadProperties / SetRatingsFromProperties: attribution
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task UnconfirmedSourceOnly_Vote_IsMarkedUnconfirmedOnly()
+    {
+        var song = await Song.Create(
+            ".Create=\tUser=dgsnure|P\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=CHA+1\tTag+=Cha Cha:Dance",
+            _dms);
+
+        var rating = song.FindRating("CHA");
+        Assert.IsNotNull(rating, "Dance rating should exist");
+        Assert.AreEqual(1, rating.Weight, "Weight should reflect the actual vote");
+        Assert.IsTrue(rating.IsUnconfirmedOnly, "A dance voted only by an unconfirmed source should be flagged");
+    }
+
+    [TestMethod]
+    public async Task ConfirmedUser_Vote_IsNotMarkedUnconfirmed()
+    {
+        var song = await Song.Create(
+            ".Create=\tUser=alice\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=CHA+1\tTag+=Cha Cha:Dance",
+            _dms);
+
+        var rating = song.FindRating("CHA");
+        Assert.IsNotNull(rating, "Dance rating should exist");
+        Assert.IsFalse(rating.IsUnconfirmedOnly, "A real user's vote should not be flagged as unconfirmed-only");
+    }
+
+    [TestMethod]
+    public async Task ConfirmedAndUnconfirmedVotes_IsNotMarkedUnconfirmed()
+    {
+        var song = await Song.Create(
+            ".Create=\tUser=alice\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=CHA+1\tTag+=Cha Cha:Dance\t" +
+            ".Edit=\tUser=dgsnure|P\tTime=02/01/2024 10:00:00 AM\tDanceRating=CHA+1",
+            _dms);
+
+        var rating = song.FindRating("CHA");
+        Assert.IsNotNull(rating, "Dance rating should exist");
+        Assert.AreEqual(2, rating.Weight, "Both votes should contribute to the total weight");
+        Assert.IsFalse(rating.IsUnconfirmedOnly, "A dance with any confirmed net contribution should not be flagged");
+    }
+
+    [TestMethod]
+    public async Task ConfirmedVotesNetZero_UnconfirmedPositive_IsMarkedUnconfirmed()
+    {
+        // alice +1, bob -1 (confirmed net = 0), dgsnure +1 -> weight 1, entirely unconfirmed-derived.
+        var song = await Song.Create(
+            ".Create=\tUser=alice\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=CHA+1\tTag+=Cha Cha:Dance\t" +
+            ".Edit=\tUser=bob\tTime=02/01/2024 10:00:00 AM\tDanceRating=CHA-1\t" +
+            ".Edit=\tUser=dgsnure|P\tTime=03/01/2024 10:00:00 AM\tDanceRating=CHA+1",
+            _dms);
+
+        var rating = song.FindRating("CHA");
+        Assert.IsNotNull(rating, "Dance rating should exist");
+        Assert.AreEqual(1, rating.Weight, "Net weight should be 1");
+        Assert.IsTrue(
+            rating.IsUnconfirmedOnly,
+            "With confirmed contributions netting to zero, the surviving weight is entirely unconfirmed-derived");
+    }
+
+    [TestMethod]
+    public async Task UnconfirmedOnly_DoesNotAffectOtherDances()
+    {
+        var song = await Song.Create(
+            ".Create=\tUser=alice\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\t" +
+            "DanceRating=CHA+1\tDanceRating=SLS+1\tTag+=Cha Cha:Dance|Salsa:Dance\t" +
+            ".Edit=\tUser=dgsnure|P\tTime=02/01/2024 10:00:00 AM\tDanceRating=SLS+1",
+            _dms);
+
+        var chaRating = song.FindRating("CHA");
+        var slsRating = song.FindRating("SLS");
+        Assert.IsNotNull(chaRating);
+        Assert.IsNotNull(slsRating);
+        Assert.IsFalse(chaRating.IsUnconfirmedOnly, "CHA has only a confirmed vote");
+        Assert.IsFalse(slsRating.IsUnconfirmedOnly, "SLS has a confirmed vote alongside the unconfirmed one");
+    }
+
+    [TestMethod]
+    public async Task SetRatingsFromProperties_RecomputesSameUnconfirmedFlag()
+    {
+        var song = await Song.Create(
+            ".Create=\tUser=dgsnure|P\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=CHA+1\tTag+=Cha Cha:Dance",
+            _dms);
+
+        song.SetRatingsFromProperties();
+
+        var rating = song.FindRating("CHA");
+        Assert.IsNotNull(rating, "Dance rating should exist after recalculation");
+        Assert.AreEqual(1, rating.Weight);
+        Assert.IsTrue(rating.IsUnconfirmedOnly, "SetRatingsFromProperties should apply the same attribution as LoadProperties");
+    }
+
+    // -------------------------------------------------------------------------
+    // SongIndex.DocumentFromSong: index encoding
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task DocumentFromSong_UnconfirmedOnlyDance_VotesIsNegativeOne()
+    {
+        var song = await Song.Create(
+            ".Create=\tUser=dgsnure|P\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=CHA+1\tTag+=Cha Cha:Dance",
+            _dms);
+
+        var index = new TestSongIndex();
+        index.AttachToService(_dms);
+        var doc = (SearchDocument)index.CallDocumentFromSong(song);
+        var chaDoc = (Dictionary<string, object>)doc["dance_CHA"];
+
+        Assert.AreEqual(-1, chaDoc[SongIndex.Votes], "Unconfirmed-only dance should be encoded as -1 in the index");
+    }
+
+    [TestMethod]
+    public async Task DocumentFromSong_ConfirmedDance_VotesIsRealWeight()
+    {
+        var song = await Song.Create(
+            ".Create=\tUser=alice\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=CHA+1\tTag+=Cha Cha:Dance",
+            _dms);
+
+        var index = new TestSongIndex();
+        index.AttachToService(_dms);
+        var doc = (SearchDocument)index.CallDocumentFromSong(song);
+        var chaDoc = (Dictionary<string, object>)doc["dance_CHA"];
+
+        Assert.AreEqual(1, chaDoc[SongIndex.Votes], "Confirmed dance should keep its real weight in the index");
+    }
+
+    [TestMethod]
+    public async Task DocumentFromSong_DanceAllVotes_IsNull_WhenOnlyUnconfirmedDance()
+    {
+        var song = await Song.Create(
+            ".Create=\tUser=dgsnure|P\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\tDanceRating=CHA+1\tTag+=Cha Cha:Dance",
+            _dms);
+
+        var index = new TestSongIndex();
+        index.AttachToService(_dms);
+        var doc = (SearchDocument)index.CallDocumentFromSong(song);
+        var danceAll = (Dictionary<string, object>)doc["dance_ALL"];
+
+        Assert.IsNull(
+            danceAll[SongIndex.Votes],
+            "dance_ALL/Votes should be null when the song's only dance rating is unconfirmed-only");
+    }
+
+    [TestMethod]
+    public async Task DocumentFromSong_DanceAllVotes_ExcludesUnconfirmedOnlyDance()
+    {
+        var song = await Song.Create(
+            ".Create=\tUser=alice\tTime=01/01/2024 10:00:00 AM\tTitle=Test Song\tArtist=Test Artist\t" +
+            "DanceRating=CHA+1\tDanceRating=SLS+1\tTag+=Cha Cha:Dance|Salsa:Dance\t" +
+            ".Edit=\tUser=bob\tTime=02/01/2024 10:00:00 AM\tDanceRating=CHA-1\t" +
+            ".Edit=\tUser=dgsnure|P\tTime=03/01/2024 10:00:00 AM\tDanceRating=CHA+1",
+            _dms);
+
+        // CHA ends up unconfirmed-only (alice/bob cancel out, dgsnure supplies the weight);
+        // SLS is a plain confirmed +1.
+        var chaRating = song.FindRating("CHA");
+        Assert.IsTrue(chaRating.IsUnconfirmedOnly, "Precondition: CHA should be unconfirmed-only");
+
+        var index = new TestSongIndex();
+        index.AttachToService(_dms);
+        var doc = (SearchDocument)index.CallDocumentFromSong(song);
+        var danceAll = (Dictionary<string, object>)doc["dance_ALL"];
+
+        Assert.AreEqual(1, danceAll[SongIndex.Votes], "dance_ALL/Votes should only total the confirmed (SLS) weight");
+    }
+
+    // -------------------------------------------------------------------------
+    // SongIndex.AddCruftInfo: new CruftFilter.UnconfirmedDances clause
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public void AddCruftInfo_DefaultCruft_ExcludesUnconfirmedOnlySongs()
+    {
+        var options = new SearchOptions();
+        var result = SongIndex.AddCruftInfo(options, CruftFilter.NoCruft);
+
+        StringAssert.Contains(result.Filter, "dance_ALL/Votes ne null");
+    }
+
+    [TestMethod]
+    public void AddCruftInfo_UnconfirmedDancesBitSet_OmitsClause()
+    {
+        var options = new SearchOptions();
+        var result = SongIndex.AddCruftInfo(options, CruftFilter.UnconfirmedDances);
+
+        Assert.IsFalse(
+            (result.Filter ?? string.Empty).Contains("dance_ALL/Votes"),
+            "Opting in to UnconfirmedDances should omit the dance_ALL/Votes restriction");
+    }
+
+    [TestMethod]
+    public void AddCruftInfo_AllCruft_BypassesEveryClause()
+    {
+        var options = new SearchOptions();
+        var result = SongIndex.AddCruftInfo(options, CruftFilter.AllCruft);
+
+        Assert.IsNull(result.Filter, "AllCruft should bypass all cruft restrictions, including the new one");
+    }
+
+    // -------------------------------------------------------------------------
+    // DanceQuery / SongFilter: opting unconfirmed votes back into a specific-dance query
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public void GetODataFilter_IncludeUnconfirmedFalse_HasNoSentinelClause()
+    {
+        var q = new DanceQuery("CHA");
+        var odata = q.GetODataFilter(_dms);
+
+        Assert.IsFalse(odata.Contains("Votes eq -1"), "Default query should not reference the sentinel");
+    }
+
+    [TestMethod]
+    public void GetODataFilter_IncludeUnconfirmedTrue_AddsSentinelOrClause()
+    {
+        var q = new DanceQuery("CHA");
+        var odata = q.GetODataFilter(_dms, includeUnconfirmed: true);
+
+        StringAssert.Contains(odata, "(dance_CHA/Votes ge 1 or dance_CHA/Votes eq -1)");
+    }
+
+    [TestMethod]
+    public void SongFilter_GetOdataFilter_UnconfirmedDancesBitSet_BringsBackSpecificDance()
+    {
+        var filter = SongFilter.Create(false);
+        filter.Dances = "CHA";
+        filter.Level = (int)CruftFilter.UnconfirmedDances;
+        var odata = filter.GetOdataFilter(_dms);
+
+        StringAssert.Contains(odata, "dance_CHA/Votes eq -1");
+    }
+
+    [TestMethod]
+    public void SongFilter_GetOdataFilter_DefaultLevel_DoesNotBringBackSpecificDance()
+    {
+        var filter = SongFilter.Create(false);
+        filter.Dances = "CHA";
+        var odata = filter.GetOdataFilter(_dms);
+
+        Assert.IsFalse(odata.Contains("Votes eq -1"));
+    }
+}

--- a/m4dModels/CruftFilter.cs
+++ b/m4dModels/CruftFilter.cs
@@ -6,5 +6,6 @@ public enum CruftFilter
     NoCruft = 0x00,
     NoPublishers = 0x01,
     NoDances = 0x02,
-    AllCruft = 0x03
+    UnconfirmedDances = 0x04,
+    AllCruft = 0x07
 }

--- a/m4dModels/DanceQuery.cs
+++ b/m4dModels/DanceQuery.cs
@@ -116,7 +116,12 @@ public class DanceQuery
         }
     }
 
-    public virtual string GetODataFilter(DanceMusicCoreService dms)
+    // includeUnconfirmed opts a dance-scoped query back into unconfirmed-only matches for that
+    // dance (CruftFilter.UnconfirmedDances) - see SongFilter.GetDanceODataFilter, the only caller
+    // that passes true. It can't respect item.Threshold (the -1 sentinel carries no magnitude,
+    // only "unconfirmed-only" - see SongIndex.DocumentFromSong), so opting in surfaces every
+    // unconfirmed-only match for the dance regardless of the requested threshold.
+    public virtual string GetODataFilter(DanceMusicCoreService dms, bool includeUnconfirmed = false)
     {
         var dances = DanceLibrary.Dances.Instance.ExpandGroups(Dances).ToList();
         if (dances.Count == 0)
@@ -146,10 +151,14 @@ public class DanceQuery
             var subFilters = matches.Select(d =>
             {
                 var danceField = $"dance_{d.Id}";
-                var filterParts = new List<string>
-                    {
-                        $"{danceField}/Votes {(item.Threshold > 0 ? "ge" : "le")} {Math.Abs(item.Threshold)}"
-                    };
+                var voteClause =
+                    $"{danceField}/Votes {(item.Threshold > 0 ? "ge" : "le")} {Math.Abs(item.Threshold)}";
+                if (includeUnconfirmed)
+                {
+                    voteClause = $"({voteClause} or {danceField}/Votes eq -1)";
+                }
+
+                var filterParts = new List<string> { voteClause };
 
                 // Use generalized TagQuery OData for this dance field (with tag ring expansion)
                 if (item.TagQuery != null && item.TagQuery.TagList != null && !item.TagQuery.TagList.IsEmpty)

--- a/m4dModels/DanceRating.cs
+++ b/m4dModels/DanceRating.cs
@@ -78,6 +78,12 @@ public class DanceRating : TaggableObject
     [DataMember]
     public decimal? Tempo { get; set; }
 
+    // Computed during property replay (Song.LoadProperties / Song.SetRatingsFromProperties);
+    // never persisted - no [DataMember], so it's excluded from DataContract serialization and
+    // doesn't round-trip through SongProperties. True when every unit of this dance's current
+    // Weight traces back to an unconfirmed vote source (see Song.IsUnconfirmedSource).
+    public bool IsUnconfirmedOnly { get; set; }
+
     protected override HashSet<string> ValidClasses => s_validClasses;
 
     public static Dictionary<string, string> DanceMap

--- a/m4dModels/RawSearch.cs
+++ b/m4dModels/RawSearch.cs
@@ -78,6 +78,15 @@ public class RawSearch
             : CruftFilter & ~CruftFilter.NoDances;
     }
 
+    [Display(Name = @"Exclude songs with unconfirmed-only dance votes")]
+    public bool ExcludeUnconfirmedDances
+    {
+        get => CruftFilter.HasFlag(CruftFilter.UnconfirmedDances);
+        set => CruftFilter = value
+            ? CruftFilter | CruftFilter.UnconfirmedDances
+            : CruftFilter & ~CruftFilter.UnconfirmedDances;
+    }
+
     public string Flags { get; set; }
 
     [Display(Name = @"Flags")]

--- a/m4dModels/Song.cs
+++ b/m4dModels/Song.cs
@@ -1584,6 +1584,11 @@ public class Song : TaggableObject
         // Batch and service accounts (batch*, tempo-bot) are exempt and may use any delta.
         var userDanceContributions = new Dictionary<(string, string), int>();
 
+        // Track net contribution per dance from confirmed (non-unconfirmed-source) voters, so
+        // a dance whose entire current weight traces back to an unconfirmed source (see
+        // IsUnconfirmedSource) can be flagged after the replay completes.
+        var confirmedNet = new Dictionary<string, int>();
+
         foreach (var prop in properties)
         {
             var bn = prop.BaseName;
@@ -1604,6 +1609,12 @@ public class Song : TaggableObject
                         if (TryGetCappedDelta(drd, user, userDanceContributions, out var effective))
                         {
                             var del = SoftUpdateDanceRating(effective);
+                            if (!IsUnconfirmedSource(user))
+                            {
+                                confirmedNet[effective.DanceId] =
+                                    confirmedNet.GetValueOrDefault(effective.DanceId) + effective.Delta;
+                            }
+
                             if (del != null)
                             {
                                 drDelete.Add(del);
@@ -1796,6 +1807,11 @@ public class Song : TaggableObject
                     null, new TagList(
                         $"{danceName}:Dance|!{danceName}:Dance"));
             }
+        }
+
+        foreach (var dr in DanceRatings)
+        {
+            dr.IsUnconfirmedOnly = confirmedNet.GetValueOrDefault(dr.DanceId) <= 0;
         }
 
         if (deleted)
@@ -4257,6 +4273,10 @@ public class Song : TaggableObject
         var userDanceContributions = new Dictionary<(string, string), int>();
         string user = null;
 
+        // See LoadProperties - net contribution per dance from confirmed (non-unconfirmed-source)
+        // voters, used to flag a dance whose entire current weight is unconfirmed-source-only.
+        var confirmedNet = new Dictionary<string, int>();
+
         foreach (var prop in SongProperties)
         {
             switch (prop.BaseName)
@@ -4271,6 +4291,12 @@ public class Song : TaggableObject
                     if (TryGetCappedDelta(drd, user, userDanceContributions, out var effective))
                     {
                         var rating = SoftUpdateDanceRating(effective);
+                        if (!IsUnconfirmedSource(user))
+                        {
+                            confirmedNet[effective.DanceId] =
+                                confirmedNet.GetValueOrDefault(effective.DanceId) + effective.Delta;
+                        }
+
                         if (rating != null)
                         {
                             _ = DanceRatings.Remove(rating);
@@ -4279,6 +4305,11 @@ public class Song : TaggableObject
                     break;
                 }
             }
+        }
+
+        foreach (var dr in DanceRatings)
+        {
+            dr.IsUnconfirmedOnly = confirmedNet.GetValueOrDefault(dr.DanceId) <= 0;
         }
     }
 
@@ -4314,6 +4345,19 @@ public class Song : TaggableObject
         contributions[key] = effectiveNet;
         effective = new DanceRatingDelta(drd.DanceId, effectiveDelta);
         return true;
+    }
+
+    // Users whose dance votes are applied in bulk by an automated process rather than a person
+    // judging the song (e.g. Spotify-playlist auto-import) - not the same axis as IsPseudo, which
+    // marks trusted batch/system accounts exempt from the ±1 cap above. An unconfirmed source is
+    // still subject to that cap; it's just not treated as a real dancer's opinion for the purposes
+    // of DanceRating.IsUnconfirmedOnly (see LoadProperties/SetRatingsFromProperties).
+    private static readonly HashSet<string> s_unconfirmedVoteSources =
+        new(StringComparer.OrdinalIgnoreCase) { "dgsnure" };
+
+    private static bool IsUnconfirmedSource(string user)
+    {
+        return user != null && s_unconfirmedVoteSources.Contains(user);
     }
 
     public static string TagsFromDances(IEnumerable<string> dances)

--- a/m4dModels/SongFilter.cs
+++ b/m4dModels/SongFilter.cs
@@ -761,7 +761,7 @@ public class SongFilter
     {
         return IsRaw
             ? RawDanceQuery?.GetODataFilter(dms)
-            : DanceQuery?.GetODataFilter(dms);
+            : DanceQuery?.GetODataFilter(dms, CruftFilter.HasFlag(CruftFilter.UnconfirmedDances));
     }
 
     private static string CombineFilter(string existing, string newData)

--- a/m4dModels/SongIndex.cs
+++ b/m4dModels/SongIndex.cs
@@ -1491,6 +1491,16 @@ public class SongIndex
             _ = extra.Append("DanceTags/any()");
         }
 
+        if ((cruft & CruftFilter.UnconfirmedDances) != CruftFilter.UnconfirmedDances)
+        {
+            if (extra.Length > 0)
+            {
+                _ = extra.Append(" and ");
+            }
+
+            _ = extra.Append("dance_ALL/Votes ne null");
+        }
+
         if (parameters.Filter == null)
         {
             parameters.Filter = extra.ToString();
@@ -1908,7 +1918,13 @@ public class SongIndex
             var oneOther = dr.TagSummary.GetTagSet("Other");
             doc[BuildDanceFieldName(dr.DanceId)] = new Dictionary<string, object>
                 {
-                    { Votes, dr.Weight },
+                    // -1 is a sentinel for "every vote on this dance came from an unconfirmed
+                    // source" (see Song.IsUnconfirmedSource) - never a legitimate value, since a
+                    // DanceRating is removed rather than allowed to go negative (see
+                    // EditDanceRating/SoftUpdateDanceRating). Keeps unconfirmed-only dances out of
+                    // dance_{id}/Votes threshold comparisons by default; see CruftFilter.UnconfirmedDances
+                    // and DanceQuery.GetODataFilter for the opt-in path back in.
+                    { Votes, dr.IsUnconfirmedOnly ? -1 : dr.Weight },
                     { DanceTempoSubField, CleanNumber((float?)(dr.Tempo ?? song.Tempo)) },
                     { TempoTags, oneTempo.ToArray() },
                     { StyleTags, oneStyle.ToArray() },
@@ -1925,7 +1941,9 @@ public class SongIndex
             allStyle.UnionWith(oneStyle);
         }
 
-        var all = song.DanceRatings.Sum(dr => dr.Weight);
+        // Excludes unconfirmed-only dances, so "does this song have any confirmed dance rating
+        // at all" can be answered with "dance_ALL/Votes ne null" - see CruftFilter.UnconfirmedDances.
+        var all = song.DanceRatings.Where(dr => !dr.IsUnconfirmedOnly).Sum(dr => dr.Weight);
         doc["dance_ALL"] = new Dictionary<string, object>
             {
                 { Votes, all == 0 ? null : all },

--- a/m4dModels/SongIndex.cs
+++ b/m4dModels/SongIndex.cs
@@ -1498,7 +1498,7 @@ public class SongIndex
                 _ = extra.Append(" and ");
             }
 
-            _ = extra.Append("dance_ALL/Votes ne null");
+            _ = extra.Append("(not DanceTags/any() or dance_ALL/Votes ne null)");
         }
 
         if (parameters.Filter == null)


### PR DESCRIPTION
## Summary
- Adds a new `CruftFilter.UnconfirmedDances` bit so a dance rating whose current weight traces back entirely to an unconfirmed vote source (currently just `dgsnure`, the Spotify-playlist auto-import account) is excluded from default search, the same way uncategorized songs already are — without any Azure Search index schema change, by reusing the existing `dance_{id}/Votes` and `dance_ALL/Votes` fields via a `-1` sentinel.
- Adds a "Not confirmed by a dancer" checkbox to Advanced Search's "Bonus content" group and a matching admin Raw Search checkbox to opt back in; opting in also brings unconfirmed-only votes back for a specific selected dance, not just the general browse case.
- Removes the older, cruder `dgsnure` exclusion from the New Music page (`SongController.NewMusic`), which hid every song the account had ever touched — this feature is strictly more precise, since it only suppresses dance ratings that are actually unconfirmed-only.
- Design writeup: `architecture/unconfirmed-dance-votes.md`.

## Test plan
- [x] `dotnet build` — clean
- [x] `m4dModels.Tests` — 475 passed, 1 skipped
- [x] `m4d.Tests` — 164 passed
- [x] Client `type-check` and `lint` — clean on touched files
- [x] `advanced-search.test.ts` snapshot updated for the new checkbox
- [x] Manual verification in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)