### PR TITLE
List voters for each dance in Song Details

### DIFF
--- a/m4d/ClientApp/src/models/SongHistory.ts
+++ b/m4d/ClientApp/src/models/SongHistory.ts
@@ -281,14 +281,29 @@ export class SongHistory {
   }
 
   /**
-   * Users who currently have an active up/down vote on the given dance, derived by
-   * replaying each user's tag additions/removals (dance votes are plain Tag+/Tag- entries,
-   * not dance-qualified) and keeping only their most recent vote for this dance.
+   * Users who currently have an active up/down vote on the given dance. Convenience wrapper
+   * around danceVotersMap for a single dance — prefer danceVotersMap when resolving voters for
+   * several dances on the same history, since it only replays the history once.
    */
   public danceVoters(rating: DanceRating): DanceVoters {
-    const posKey = rating.positiveTag.key;
-    const negKey = rating.negativeTag.key;
-    const votes = new Map<string, boolean>();
+    return this.danceVotersMap([rating]).get(rating.danceId)!;
+  }
+
+  /**
+   * Users who currently have an active up/down vote on each of the given dances, derived by
+   * replaying each user's tag additions/removals once (dance votes are plain Tag+/Tag- entries,
+   * not dance-qualified) and keeping only their most recent vote per dance. Doing this as a
+   * single pass over history keyed by tag avoids re-scanning the full history per dance.
+   */
+  public danceVotersMap(ratings: DanceRating[]): Map<string, DanceVoters> {
+    const danceIdByKey = new Map<string, string>();
+    for (const rating of ratings) {
+      danceIdByKey.set(rating.positiveTag.key, rating.danceId);
+      danceIdByKey.set(rating.negativeTag.key, rating.danceId);
+    }
+
+    // danceId -> user -> vote (true = up, false = down)
+    const votesByDance = new Map<string, Map<string, boolean>>();
 
     for (const change of this.userChanges) {
       if (!change.user) {
@@ -300,30 +315,32 @@ export class SongHistory {
         if (!isAdd && !isRemove) {
           continue;
         }
-        const keys = new TagList(property.value).tags.map((t) => t.key);
-        if (keys.includes(posKey)) {
+        for (const tag of new TagList(property.value).tags) {
+          const danceId = danceIdByKey.get(tag.key);
+          if (!danceId) {
+            continue;
+          }
+          const votes = votesByDance.get(danceId) ?? new Map<string, boolean>();
           if (isAdd) {
-            votes.set(change.user, true);
+            votes.set(change.user, tag.positive);
           } else {
             votes.delete(change.user);
           }
-        }
-        if (keys.includes(negKey)) {
-          if (isAdd) {
-            votes.set(change.user, false);
-          } else {
-            votes.delete(change.user);
-          }
+          votesByDance.set(danceId, votes);
         }
       }
     }
 
-    const up: string[] = [];
-    const down: string[] = [];
-    for (const [user, isUp] of votes) {
-      (isUp ? up : down).push(user);
+    const result = new Map<string, DanceVoters>();
+    for (const rating of ratings) {
+      const up: string[] = [];
+      const down: string[] = [];
+      for (const [user, isUp] of votesByDance.get(rating.danceId) ?? []) {
+        (isUp ? up : down).push(user);
+      }
+      result.set(rating.danceId, { up, down });
     }
-    return { up, down };
+    return result;
   }
 
   /**

--- a/m4d/ClientApp/src/models/SongHistory.ts
+++ b/m4d/ClientApp/src/models/SongHistory.ts
@@ -5,9 +5,16 @@ import { Song } from "./Song";
 import { SongChange } from "./SongChange";
 import { SongEditor } from "./SongEditor";
 import { PropertyType, SongProperty } from "./SongProperty";
+import { TagList } from "./TagList";
 import { TrackModel } from "./TrackModel";
 import { UserQuery } from "./UserQuery";
+import type { DanceRating } from "./DanceRating";
 import { formatNow } from "@/helpers/timeHelpers";
+
+export interface DanceVoters {
+  up: string[];
+  down: string[];
+}
 
 interface SongRef {
   song: Song;
@@ -271,6 +278,52 @@ export class SongHistory {
    */
   public get inclusiveChanges(): SongChange[] {
     return this.filterChanges(this.changes, false);
+  }
+
+  /**
+   * Users who currently have an active up/down vote on the given dance, derived by
+   * replaying each user's tag additions/removals (dance votes are plain Tag+/Tag- entries,
+   * not dance-qualified) and keeping only their most recent vote for this dance.
+   */
+  public danceVoters(rating: DanceRating): DanceVoters {
+    const posKey = rating.positiveTag.key;
+    const negKey = rating.negativeTag.key;
+    const votes = new Map<string, boolean>();
+
+    for (const change of this.userChanges) {
+      if (!change.user) {
+        continue;
+      }
+      for (const property of change.properties) {
+        const isAdd = property.baseName === PropertyType.addedTags;
+        const isRemove = property.baseName === PropertyType.removedTags;
+        if (!isAdd && !isRemove) {
+          continue;
+        }
+        const keys = new TagList(property.value).tags.map((t) => t.key);
+        if (keys.includes(posKey)) {
+          if (isAdd) {
+            votes.set(change.user, true);
+          } else {
+            votes.delete(change.user);
+          }
+        }
+        if (keys.includes(negKey)) {
+          if (isAdd) {
+            votes.set(change.user, false);
+          } else {
+            votes.delete(change.user);
+          }
+        }
+      }
+    }
+
+    const up: string[] = [];
+    const down: string[] = [];
+    for (const [user, isUp] of votes) {
+      (isUp ? up : down).push(user);
+    }
+    return { up, down };
   }
 
   /**

--- a/m4d/ClientApp/src/models/__tests__/SongHistory.test.ts
+++ b/m4d/ClientApp/src/models/__tests__/SongHistory.test.ts
@@ -1000,6 +1000,37 @@ describe("SongHistory", () => {
     });
   });
 
+  describe("danceVotersMap", () => {
+    it("resolves voters for multiple dances in a single pass, matching danceVoters per-dance", () => {
+      const ecs = new DanceRating({ danceId: "ECS" });
+      const lhp = new DanceRating({ danceId: "LHP" });
+      const h = makeHistory([
+        { name: ".Create", value: "" },
+        { name: "User", value: "EthanH|P" },
+        { name: "Time", value: "1/1/2020 10:00:00 AM" },
+        { name: "Tag+", value: "East Coast Swing:Dance|Lindy Hop:Dance" },
+        { name: ".Edit", value: "" },
+        { name: "User", value: "JuliaS|P" },
+        { name: "Time", value: "1/2/2020 10:00:00 AM" },
+        { name: "Tag+", value: "!Lindy Hop:Dance" },
+      ]);
+
+      const map = h.danceVotersMap([ecs, lhp]);
+
+      expect(map.get("ECS")).toEqual({ up: ["EthanH|P"], down: [] });
+      expect(map.get("LHP")).toEqual({ up: ["EthanH|P"], down: ["JuliaS|P"] });
+      // Single-dance convenience wrapper should agree with the batched result.
+      expect(h.danceVoters(ecs)).toEqual(map.get("ECS"));
+      expect(h.danceVoters(lhp)).toEqual(map.get("LHP"));
+    });
+
+    it("returns empty voters for a dance with no votes in the history", () => {
+      const h = humanCreate("EthanH|P", "East Coast Swing:Dance");
+      const map = h.danceVotersMap([new DanceRating({ danceId: "LHP" })]);
+      expect(map.get("LHP")).toEqual({ up: [], down: [] });
+    });
+  });
+
   describe("fromString", () => {
     it("parses tab-delimited properties", () => {
       const s = ".Create=\tUser=EthanH|P\tTime=3/17/2014 5:46:07 PM\tTag+=East Coast Swing:Dance";

--- a/m4d/ClientApp/src/models/__tests__/SongHistory.test.ts
+++ b/m4d/ClientApp/src/models/__tests__/SongHistory.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { SongHistory } from "../SongHistory";
 import { SongProperty } from "../SongProperty";
+import { DanceRating } from "../DanceRating";
+import { setupTestEnvironment } from "@/helpers/TestHelpers";
+
+setupTestEnvironment();
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -923,6 +927,76 @@ describe("SongHistory", () => {
       const propNames = anonChanges[0]!.properties.map((p) => p.name);
       expect(propNames).toContain("Like");
       expect(propNames).toContain("Tag+");
+    });
+
+    it("danceVoters resolves the current up/down voters for Lindy Hop (LHP)", () => {
+      const h = new SongHistory({
+        id: "candyman",
+        properties: candymanFullProps.map(
+          (p) => new SongProperty({ name: p.name, value: p.value }),
+        ),
+      });
+      const voters = h.danceVoters(new DanceRating({ danceId: "LHP" }));
+      // Up: original adds that were never retracted, plus Carmichael's later re-add.
+      expect(voters.up).toEqual([
+        "EthanH|P",
+        "LincolnA|P",
+        "rhettbot|P",
+        "MaggieHaggerty|P",
+        "Arthur Murray Carmichael|P",
+      ]);
+      // Down: the three explicit negative votes (roblosapiens, annebaaner, Jazzup'n'Dance).
+      expect(voters.down).toEqual(["roblosapiens", "annebaaner", "Jazzup'n'Dance"]);
+    });
+  });
+
+  describe("danceVoters", () => {
+    const lhp = new DanceRating({ danceId: "LHP" });
+
+    it("returns empty up/down when no one has voted", () => {
+      const h = humanCreate("EthanH|P", "East Coast Swing:Dance");
+      const voters = h.danceVoters(lhp);
+      expect(voters.up).toHaveLength(0);
+      expect(voters.down).toHaveLength(0);
+    });
+
+    it("clears a user's vote once they remove the tag", () => {
+      const h = makeHistory([
+        { name: ".Create", value: "" },
+        { name: "User", value: "EthanH|P" },
+        { name: "Time", value: "1/1/2020 10:00:00 AM" },
+        { name: "Tag+", value: "Lindy Hop:Dance" },
+        { name: ".Edit", value: "" },
+        { name: "User", value: "EthanH|P" },
+        { name: "Time", value: "1/2/2020 10:00:00 AM" },
+        { name: "Tag-", value: "Lindy Hop:Dance" },
+      ]);
+      const voters = h.danceVoters(lhp);
+      expect(voters.up).toHaveLength(0);
+      expect(voters.down).toHaveLength(0);
+    });
+
+    it("flips a user from up to down when they change their vote", () => {
+      const h = makeHistory([
+        { name: ".Create", value: "" },
+        { name: "User", value: "EthanH|P" },
+        { name: "Time", value: "1/1/2020 10:00:00 AM" },
+        { name: "Tag+", value: "Lindy Hop:Dance" },
+        { name: ".Edit", value: "" },
+        { name: "User", value: "EthanH|P" },
+        { name: "Time", value: "1/2/2020 10:00:00 AM" },
+        { name: "Tag-", value: "Lindy Hop:Dance" },
+        { name: "Tag+", value: "!Lindy Hop:Dance" },
+      ]);
+      const voters = h.danceVoters(lhp);
+      expect(voters.up).toHaveLength(0);
+      expect(voters.down).toEqual(["EthanH|P"]);
+    });
+
+    it("excludes batch/algorithmic voters", () => {
+      const h = makeHistory([...algoTag("batch-i|P", "Lindy Hop:Dance")]);
+      const voters = h.danceVoters(lhp);
+      expect(voters.up).toHaveLength(0);
     });
   });
 

--- a/m4d/ClientApp/src/pages/song-merge/__tests__/__snapshots__/song-merge.test.ts.snap
+++ b/m4d/ClientApp/src/pages/song-merge/__tests__/__snapshots__/song-merge.test.ts.snap
@@ -86,41 +86,51 @@ exports[`Song Merge > Renders the Merge Page 1`] = `
       <div class="text-primary card-header">Dances</div>
       <div data-v-713e0d4a="" class="list-group list-group-flush">
         <div data-v-713e0d4a="" class="list-group-item"><button data-v-713e0d4a="" type="button" class="btn-close" aria-label="Close" text-variant="danger"></button>
-          <div data-v-713e0d4a="" class="d-flex align-items-center gap-2 mb-2">
-            <div data-v-d0b4fb7f="" class="vote-container">
-              <div data-v-d0b4fb7f="" class="vote-up"></div><span><span id="__m4d__000001_placeholder" style="display: none;"></span>
-              <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
-                <div id="__m4d__000001" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
-                  <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
-                  <div class="overflow-auto b-floating-size">
-                    <div class="position-sticky top-0 tooltip-inner">Click here to vote for this song being danceable Night Club Two Step</div>
-                    <!---->
+          <div data-v-713e0d4a="" class="d-flex align-items-start gap-2">
+            <div data-v-713e0d4a="" class="d-flex align-items-center gap-2 mb-2">
+              <div data-v-d0b4fb7f="" class="vote-container">
+                <div data-v-d0b4fb7f="" class="vote-up"></div><span><span id="__m4d__000001_placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="__m4d__000001" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <div class="position-sticky top-0 tooltip-inner">Click here to vote for this song being danceable Night Club Two Step</div>
+                      <!---->
+                    </div>
                   </div>
-                </div>
-              </transition-stub></span>
-              <div data-v-d0b4fb7f="" class="vote-number">1</div><span><span id="__m4d__000002_placeholder" style="display: none;"></span>
-              <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
-                <div id="__m4d__000002" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
-                  <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
-                  <div class="overflow-auto b-floating-size">
-                    <div class="position-sticky top-0 tooltip-inner">This song has 1 votes. The most popular Night Club Two Step has 5 votes</div>
-                    <!---->
+                </transition-stub></span>
+                <div data-v-d0b4fb7f="" class="vote-number">1</div><span><span id="__m4d__000002_placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="__m4d__000002" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <div class="position-sticky top-0 tooltip-inner">This song has 1 votes. The most popular Night Club Two Step has 5 votes</div>
+                      <!---->
+                    </div>
                   </div>
-                </div>
-              </transition-stub></span>
-              <div data-v-d0b4fb7f="" class="vote-down"></div><span><span id="__m4d__000003_placeholder" style="display: none;"></span>
-              <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
-                <div id="__m4d__000003" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
-                  <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
-                  <div class="overflow-auto b-floating-size">
-                    <div class="position-sticky top-0 tooltip-inner">Click here to vote that this song is not danceable to Night Club Two Step</div>
-                    <!---->
+                </transition-stub></span>
+                <div data-v-d0b4fb7f="" class="vote-down"></div><span><span id="__m4d__000003_placeholder" style="display: none;"></span>
+                <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                  <div id="__m4d__000003" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                    <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                    <div class="overflow-auto b-floating-size">
+                      <div class="position-sticky top-0 tooltip-inner">Click here to vote that this song is not danceable to Night Club Two Step</div>
+                      <!---->
+                    </div>
                   </div>
-                </div>
-              </transition-stub></span>
+                </transition-stub></span>
+              </div>
+              <!--teleport start-->
+              <!--teleport end-->
             </div>
-            <!--teleport start-->
-            <!--teleport end-->
+            <div data-v-713e0d4a="" class="small">
+              <div data-v-713e0d4a=""><svg data-v-713e0d4a="" viewBox="0 0 16 16" width="1.2em" height="1.2em" class="me-1 text-success">
+                  <path fill="currentColor" d="M8.864.046C7.908-.193 7.02.53 6.956 1.466c-.072 1.051-.23 2.016-.428 2.59c-.125.36-.479 1.013-1.04 1.639c-.557.623-1.282 1.178-2.131 1.41C2.685 7.288 2 7.87 2 8.72v4.001c0 .845.682 1.464 1.448 1.545c1.07.114 1.564.415 2.068.723l.048.03c.272.165.578.348.97.484c.397.136.861.217 1.466.217h3.5c.937 0 1.599-.477 1.934-1.064a1.86 1.86 0 0 0 .254-.912c0-.152-.023-.312-.077-.464c.201-.263.38-.578.488-.901c.11-.33.172-.762.004-1.149c.069-.13.12-.269.159-.403c.077-.27.113-.568.113-.857c0-.288-.036-.585-.113-.856a2 2 0 0 0-.138-.362a1.9 1.9 0 0 0 .234-1.734c-.206-.592-.682-1.1-1.2-1.272c-.847-.282-1.803-.276-2.516-.211a10 10 0 0 0-.443.05a9.4 9.4 0 0 0-.062-4.509A1.38 1.38 0 0 0 9.125.111zM11.5 14.721H8c-.51 0-.863-.069-1.14-.164c-.281-.097-.506-.228-.776-.393l-.04-.024c-.555-.339-1.198-.731-2.49-.868c-.333-.036-.554-.29-.554-.55V8.72c0-.254.226-.543.62-.65c1.095-.3 1.977-.996 2.614-1.708c.635-.71 1.064-1.475 1.238-1.978c.243-.7.407-1.768.482-2.85c.025-.362.36-.594.667-.518l.262.066c.16.04.258.143.288.255a8.34 8.34 0 0 1-.145 4.725a.5.5 0 0 0 .595.644l.003-.001l.014-.003l.058-.014a9 9 0 0 1 1.036-.157c.663-.06 1.457-.054 2.11.164c.175.058.45.3.57.65c.107.308.087.67-.266 1.022l-.353.353l.353.354c.043.043.105.141.154.315c.048.167.075.37.075.581c0 .212-.027.414-.075.582c-.05.174-.111.272-.154.315l-.353.353l.353.354c.047.047.109.177.005.488a2.2 2.2 0 0 1-.505.805l-.353.353l.353.354c.006.005.041.05.041.17a.9.9 0 0 1-.121.416c-.165.288-.503.56-1.066.56z"></path>
+                </svg><a data-v-6358290b="" data-v-713e0d4a="" href="/users/info/useral" class="pseudo">useral</a>
+                <!--v-if-->
+              </div>
+              <!--v-if-->
+            </div>
           </div><a data-v-713e0d4a="" href="/dances/night-club-two-step"><span data-v-713e0d4a=""><a href="/dances/night-club-two-step">Night Club Two Step</a><span><!--v-if--> (Night Club) </span>
             <!--v-if-->
             <!--v-if--></span>

--- a/m4d/ClientApp/src/pages/song/__tests__/__snapshots__/song.test.ts.snap
+++ b/m4d/ClientApp/src/pages/song/__tests__/__snapshots__/song.test.ts.snap
@@ -64,41 +64,51 @@ exports[`Song Details > Renders the Song Details Page 1`] = `
               <div data-v-713e0d4a="" class="list-group list-group-flush">
                 <div data-v-713e0d4a="" class="list-group-item">
                   <!--v-if-->
-                  <div data-v-713e0d4a="" class="d-flex align-items-center gap-2 mb-2">
-                    <div data-v-d0b4fb7f="" class="vote-container">
-                      <div data-v-d0b4fb7f="" class="vote-up"></div><span><span id="__m4d__000001_placeholder" style="display: none;"></span>
-                      <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
-                        <div id="__m4d__000001" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
-                          <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
-                          <div class="overflow-auto b-floating-size">
-                            <div class="position-sticky top-0 tooltip-inner">Click here to vote for this song being danceable East Coast Swing</div>
-                            <!---->
+                  <div data-v-713e0d4a="" class="d-flex align-items-start gap-2">
+                    <div data-v-713e0d4a="" class="d-flex align-items-center gap-2 mb-2">
+                      <div data-v-d0b4fb7f="" class="vote-container">
+                        <div data-v-d0b4fb7f="" class="vote-up"></div><span><span id="__m4d__000001_placeholder" style="display: none;"></span>
+                        <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                          <div id="__m4d__000001" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                            <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                            <div class="overflow-auto b-floating-size">
+                              <div class="position-sticky top-0 tooltip-inner">Click here to vote for this song being danceable East Coast Swing</div>
+                              <!---->
+                            </div>
                           </div>
-                        </div>
-                      </transition-stub></span>
-                      <div data-v-d0b4fb7f="" class="vote-number">2</div><span><span id="__m4d__000002_placeholder" style="display: none;"></span>
-                      <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
-                        <div id="__m4d__000002" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
-                          <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
-                          <div class="overflow-auto b-floating-size">
-                            <div class="position-sticky top-0 tooltip-inner">This song has 2 votes. The most popular East Coast Swing has 16 votes</div>
-                            <!---->
+                        </transition-stub></span>
+                        <div data-v-d0b4fb7f="" class="vote-number">2</div><span><span id="__m4d__000002_placeholder" style="display: none;"></span>
+                        <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                          <div id="__m4d__000002" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                            <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                            <div class="overflow-auto b-floating-size">
+                              <div class="position-sticky top-0 tooltip-inner">This song has 2 votes. The most popular East Coast Swing has 16 votes</div>
+                              <!---->
+                            </div>
                           </div>
-                        </div>
-                      </transition-stub></span>
-                      <div data-v-d0b4fb7f="" class="vote-down"></div><span><span id="__m4d__000003_placeholder" style="display: none;"></span>
-                      <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
-                        <div id="__m4d__000003" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
-                          <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
-                          <div class="overflow-auto b-floating-size">
-                            <div class="position-sticky top-0 tooltip-inner">Click here to vote that this song is not danceable to East Coast Swing</div>
-                            <!---->
+                        </transition-stub></span>
+                        <div data-v-d0b4fb7f="" class="vote-down"></div><span><span id="__m4d__000003_placeholder" style="display: none;"></span>
+                        <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                          <div id="__m4d__000003" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                            <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                            <div class="overflow-auto b-floating-size">
+                              <div class="position-sticky top-0 tooltip-inner">Click here to vote that this song is not danceable to East Coast Swing</div>
+                              <!---->
+                            </div>
                           </div>
-                        </div>
-                      </transition-stub></span>
+                        </transition-stub></span>
+                      </div>
+                      <!--teleport start-->
+                      <!--teleport end-->
                     </div>
-                    <!--teleport start-->
-                    <!--teleport end-->
+                    <div data-v-713e0d4a="" class="small">
+                      <div data-v-713e0d4a=""><svg data-v-713e0d4a="" viewBox="0 0 16 16" width="1.2em" height="1.2em" class="me-1 text-success">
+                          <path fill="currentColor" d="M8.864.046C7.908-.193 7.02.53 6.956 1.466c-.072 1.051-.23 2.016-.428 2.59c-.125.36-.479 1.013-1.04 1.639c-.557.623-1.282 1.178-2.131 1.41C2.685 7.288 2 7.87 2 8.72v4.001c0 .845.682 1.464 1.448 1.545c1.07.114 1.564.415 2.068.723l.048.03c.272.165.578.348.97.484c.397.136.861.217 1.466.217h3.5c.937 0 1.599-.477 1.934-1.064a1.86 1.86 0 0 0 .254-.912c0-.152-.023-.312-.077-.464c.201-.263.38-.578.488-.901c.11-.33.172-.762.004-1.149c.069-.13.12-.269.159-.403c.077-.27.113-.568.113-.857c0-.288-.036-.585-.113-.856a2 2 0 0 0-.138-.362a1.9 1.9 0 0 0 .234-1.734c-.206-.592-.682-1.1-1.2-1.272c-.847-.282-1.803-.276-2.516-.211a10 10 0 0 0-.443.05a9.4 9.4 0 0 0-.062-4.509A1.38 1.38 0 0 0 9.125.111zM11.5 14.721H8c-.51 0-.863-.069-1.14-.164c-.281-.097-.506-.228-.776-.393l-.04-.024c-.555-.339-1.198-.731-2.49-.868c-.333-.036-.554-.29-.554-.55V8.72c0-.254.226-.543.62-.65c1.095-.3 1.977-.996 2.614-1.708c.635-.71 1.064-1.475 1.238-1.978c.243-.7.407-1.768.482-2.85c.025-.362.36-.594.667-.518l.262.066c.16.04.258.143.288.255a8.34 8.34 0 0 1-.145 4.725a.5.5 0 0 0 .595.644l.003-.001l.014-.003l.058-.014a9 9 0 0 1 1.036-.157c.663-.06 1.457-.054 2.11.164c.175.058.45.3.57.65c.107.308.087.67-.266 1.022l-.353.353l.353.354c.043.043.105.141.154.315c.048.167.075.37.075.581c0 .212-.027.414-.075.582c-.05.174-.111.272-.154.315l-.353.353l.353.354c.047.047.109.177.005.488a2.2 2.2 0 0 1-.505.805l-.353.353l.353.354c.006.005.041.05.041.17a.9.9 0 0 1-.121.416c-.165.288-.503.56-1.066.56z"></path>
+                        </svg><a data-v-6358290b="" data-v-713e0d4a="" href="/users/info/useram" class="pseudo">useram</a>
+                        <!--v-if-->
+                      </div>
+                      <!--v-if-->
+                    </div>
                   </div><a data-v-713e0d4a="" href="/dances/east-coast-swing"><span data-v-713e0d4a=""><a href="/dances/east-coast-swing">East Coast Swing</a><span><!--v-if--> (Triple Swing, East Coast) </span>
                     <!--v-if-->
                     <!--v-if--></span>
@@ -114,41 +124,51 @@ exports[`Song Details > Renders the Song Details Page 1`] = `
                 </div>
                 <div data-v-713e0d4a="" class="list-group-item">
                   <!--v-if-->
-                  <div data-v-713e0d4a="" class="d-flex align-items-center gap-2 mb-2">
-                    <div data-v-d0b4fb7f="" class="vote-container">
-                      <div data-v-d0b4fb7f="" class="vote-up"></div><span><span id="__m4d__000004_placeholder" style="display: none;"></span>
-                      <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
-                        <div id="__m4d__000004" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
-                          <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
-                          <div class="overflow-auto b-floating-size">
-                            <div class="position-sticky top-0 tooltip-inner">Click here to vote for this song being danceable Slow Foxtrot</div>
-                            <!---->
+                  <div data-v-713e0d4a="" class="d-flex align-items-start gap-2">
+                    <div data-v-713e0d4a="" class="d-flex align-items-center gap-2 mb-2">
+                      <div data-v-d0b4fb7f="" class="vote-container">
+                        <div data-v-d0b4fb7f="" class="vote-up"></div><span><span id="__m4d__000004_placeholder" style="display: none;"></span>
+                        <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                          <div id="__m4d__000004" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                            <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                            <div class="overflow-auto b-floating-size">
+                              <div class="position-sticky top-0 tooltip-inner">Click here to vote for this song being danceable Slow Foxtrot</div>
+                              <!---->
+                            </div>
                           </div>
-                        </div>
-                      </transition-stub></span>
-                      <div data-v-d0b4fb7f="" class="vote-number">1</div><span><span id="__m4d__000005_placeholder" style="display: none;"></span>
-                      <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
-                        <div id="__m4d__000005" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
-                          <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
-                          <div class="overflow-auto b-floating-size">
-                            <div class="position-sticky top-0 tooltip-inner">This song has 1 votes. The most popular Slow Foxtrot has 27 votes</div>
-                            <!---->
+                        </transition-stub></span>
+                        <div data-v-d0b4fb7f="" class="vote-number">1</div><span><span id="__m4d__000005_placeholder" style="display: none;"></span>
+                        <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                          <div id="__m4d__000005" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                            <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                            <div class="overflow-auto b-floating-size">
+                              <div class="position-sticky top-0 tooltip-inner">This song has 1 votes. The most popular Slow Foxtrot has 27 votes</div>
+                              <!---->
+                            </div>
                           </div>
-                        </div>
-                      </transition-stub></span>
-                      <div data-v-d0b4fb7f="" class="vote-down"></div><span><span id="__m4d__000006_placeholder" style="display: none;"></span>
-                      <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
-                        <div id="__m4d__000006" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
-                          <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
-                          <div class="overflow-auto b-floating-size">
-                            <div class="position-sticky top-0 tooltip-inner">Click here to vote that this song is not danceable to Slow Foxtrot</div>
-                            <!---->
+                        </transition-stub></span>
+                        <div data-v-d0b4fb7f="" class="vote-down"></div><span><span id="__m4d__000006_placeholder" style="display: none;"></span>
+                        <transition-stub name="fade" enteractiveclass="" enterfromclass="showing" entertoclass="" leaveactiveclass="" leavefromclass="" leavetoclass="showing" appear="false" persisted="false" css="true">
+                          <div id="__m4d__000006" class="tooltip b-tooltip fade bs-tooltip-end" role="tooltip" tabindex="-1" style="position: absolute; left: 0px; top: 0px; display: none;">
+                            <div class="tooltip-arrow" style="position: absolute;" data-popper-arrow=""></div>
+                            <div class="overflow-auto b-floating-size">
+                              <div class="position-sticky top-0 tooltip-inner">Click here to vote that this song is not danceable to Slow Foxtrot</div>
+                              <!---->
+                            </div>
                           </div>
-                        </div>
-                      </transition-stub></span>
+                        </transition-stub></span>
+                      </div>
+                      <!--teleport start-->
+                      <!--teleport end-->
                     </div>
-                    <!--teleport start-->
-                    <!--teleport end-->
+                    <div data-v-713e0d4a="" class="small">
+                      <div data-v-713e0d4a=""><svg data-v-713e0d4a="" viewBox="0 0 16 16" width="1.2em" height="1.2em" class="me-1 text-success">
+                          <path fill="currentColor" d="M8.864.046C7.908-.193 7.02.53 6.956 1.466c-.072 1.051-.23 2.016-.428 2.59c-.125.36-.479 1.013-1.04 1.639c-.557.623-1.282 1.178-2.131 1.41C2.685 7.288 2 7.87 2 8.72v4.001c0 .845.682 1.464 1.448 1.545c1.07.114 1.564.415 2.068.723l.048.03c.272.165.578.348.97.484c.397.136.861.217 1.466.217h3.5c.937 0 1.599-.477 1.934-1.064a1.86 1.86 0 0 0 .254-.912c0-.152-.023-.312-.077-.464c.201-.263.38-.578.488-.901c.11-.33.172-.762.004-1.149c.069-.13.12-.269.159-.403c.077-.27.113-.568.113-.857c0-.288-.036-.585-.113-.856a2 2 0 0 0-.138-.362a1.9 1.9 0 0 0 .234-1.734c-.206-.592-.682-1.1-1.2-1.272c-.847-.282-1.803-.276-2.516-.211a10 10 0 0 0-.443.05a9.4 9.4 0 0 0-.062-4.509A1.38 1.38 0 0 0 9.125.111zM11.5 14.721H8c-.51 0-.863-.069-1.14-.164c-.281-.097-.506-.228-.776-.393l-.04-.024c-.555-.339-1.198-.731-2.49-.868c-.333-.036-.554-.29-.554-.55V8.72c0-.254.226-.543.62-.65c1.095-.3 1.977-.996 2.614-1.708c.635-.71 1.064-1.475 1.238-1.978c.243-.7.407-1.768.482-2.85c.025-.362.36-.594.667-.518l.262.066c.16.04.258.143.288.255a8.34 8.34 0 0 1-.145 4.725a.5.5 0 0 0 .595.644l.003-.001l.014-.003l.058-.014a9 9 0 0 1 1.036-.157c.663-.06 1.457-.054 2.11.164c.175.058.45.3.57.65c.107.308.087.67-.266 1.022l-.353.353l.353.354c.043.043.105.141.154.315c.048.167.075.37.075.581c0 .212-.027.414-.075.582c-.05.174-.111.272-.154.315l-.353.353l.353.354c.047.047.109.177.005.488a2.2 2.2 0 0 1-.505.805l-.353.353l.353.354c.006.005.041.05.041.17a.9.9 0 0 1-.121.416c-.165.288-.503.56-1.066.56z"></path>
+                        </svg><a data-v-6358290b="" data-v-713e0d4a="" href="/users/info/useram" class="pseudo">useram</a>
+                        <!--v-if-->
+                      </div>
+                      <!--v-if-->
+                    </div>
                   </div><a data-v-713e0d4a="" href="/dances/slow-foxtrot"><span data-v-713e0d4a=""><a href="/dances/slow-foxtrot">Slow Foxtrot</a><span><!--v-if--> (Foxtrot) </span>
                     <!--v-if-->
                     <!--v-if--></span>

--- a/m4d/ClientApp/src/pages/song/components/DanceDetails.vue
+++ b/m4d/ClientApp/src/pages/song/components/DanceDetails.vue
@@ -3,6 +3,7 @@ import { DanceRating } from "@/models/DanceRating";
 import { Song } from "@/models/Song";
 import { SongEditor } from "@/models/SongEditor";
 import { SongFilter } from "@/models/SongFilter";
+import type { DanceVoters, SongHistory } from "@/models/SongHistory";
 import { computed } from "vue";
 import { safeDanceDatabase } from "@/helpers/DanceEnvironmentManager";
 import type { NamedObject } from "@/models/DanceDatabase/NamedObject";
@@ -23,6 +24,7 @@ const props = defineProps<{
   user?: string;
   editor?: SongEditor;
   edit?: boolean;
+  history?: SongHistory;
 }>();
 
 const emit = defineEmits<{
@@ -38,6 +40,19 @@ const danceRatingsFiltered = computed(() => {
 const hasDances = computed(() => {
   return danceRatingsFiltered.value.length > 0;
 });
+
+const danceVotersById = computed(() => {
+  const map = new Map<string, DanceVoters>();
+  if (props.history) {
+    for (const dr of danceRatingsFiltered.value) {
+      map.set(dr.danceId, props.history.danceVoters(dr));
+    }
+  }
+  return map;
+});
+
+const votersFor = (dr: DanceRating): DanceVoters =>
+  danceVotersById.value.get(dr.danceId) ?? { up: [], down: [] };
 
 const danceFromRating = (dr: DanceRating): NamedObject => {
   return danceDB.fromId(dr.danceId)!;
@@ -99,13 +114,35 @@ const onEditDanceTempo = (dr: DanceRating): void => {
           @click="$emit('delete-dance', dr)"
           ><IBiX variant="danger"
         /></BCloseButton>
-        <DanceVote
-          :vote="song.danceVote(dr.danceId)"
-          :dance-rating="dr"
-          :authenticated="!!user"
-          :filter-family-tag="filterFamilyTag"
-          v-bind="$attrs"
-        />
+        <div class="d-flex align-items-start gap-2">
+          <DanceVote
+            :vote="song.danceVote(dr.danceId)"
+            :dance-rating="dr"
+            :authenticated="!!user"
+            :filter-family-tag="filterFamilyTag"
+            v-bind="$attrs"
+          />
+          <div v-if="votersFor(dr).up.length || votersFor(dr).down.length" class="small">
+            <div v-if="votersFor(dr).up.length">
+              <IBiHandThumbsUp class="me-1 text-success" /><template
+                v-for="(u, i) in votersFor(dr).up"
+                :key="u"
+                ><UserLink :user="u" /><span v-if="i < votersFor(dr).up.length - 1"
+                  >,
+                </span></template
+              >
+            </div>
+            <div v-if="votersFor(dr).down.length">
+              <IBiHandThumbsDown class="me-1 text-danger" /><template
+                v-for="(u, i) in votersFor(dr).down"
+                :key="u"
+                ><UserLink :user="u" /><span v-if="i < votersFor(dr).down.length - 1"
+                  >,
+                </span></template
+              >
+            </div>
+          </div>
+        </div>
         <a :href="danceLink(dr)"
           ><DanceName :dance="danceFromRating(dr)" :show-synonyms="true"
         /></a>

--- a/m4d/ClientApp/src/pages/song/components/DanceDetails.vue
+++ b/m4d/ClientApp/src/pages/song/components/DanceDetails.vue
@@ -41,15 +41,10 @@ const hasDances = computed(() => {
   return danceRatingsFiltered.value.length > 0;
 });
 
-const danceVotersById = computed(() => {
-  const map = new Map<string, DanceVoters>();
-  if (props.history) {
-    for (const dr of danceRatingsFiltered.value) {
-      map.set(dr.danceId, props.history.danceVoters(dr));
-    }
-  }
-  return map;
-});
+const danceVotersById = computed(
+  (): Map<string, DanceVoters> =>
+    props.history?.danceVotersMap(danceRatingsFiltered.value) ?? new Map(),
+);
 
 const votersFor = (dr: DanceRating): DanceVoters =>
   danceVotersById.value.get(dr.danceId) ?? { up: [], down: [] };

--- a/m4d/ClientApp/src/pages/song/components/SongCore.vue
+++ b/m4d/ClientApp/src/pages/song/components/SongCore.vue
@@ -466,6 +466,7 @@ onBeforeUnmount(() => {
           :filter="model.filter"
           :editor="editor as SongEditor"
           :edit="edit"
+          :history="history as SongHistory"
           @dance-vote="onDanceVote($event)"
           @update-song="updateSong"
           @edit="requestEdit"

--- a/m4d/ClientApp/src/pages/song/components/__tests__/DanceDetails.test.ts
+++ b/m4d/ClientApp/src/pages/song/components/__tests__/DanceDetails.test.ts
@@ -103,7 +103,12 @@ const STUBS = {
 
 function mountDetails(
   song: Song,
-  { edit = false, user, editor }: { edit?: boolean; user?: string; editor?: SongEditor } = {},
+  {
+    edit = false,
+    user,
+    editor,
+    history,
+  }: { edit?: boolean; user?: string; editor?: SongEditor; history?: SongHistory } = {},
 ) {
   return mount(DanceDetails, {
     props: {
@@ -114,9 +119,16 @@ function mountDetails(
       user,
       editor: editor ?? (user ? new SongEditor(undefined, user, makeHistory()) : undefined),
       edit,
+      history,
     },
     global: {
-      stubs: STUBS,
+      stubs: {
+        ...STUBS,
+        UserLink: {
+          props: ["user"],
+          template: "<a class='user-link-stub'>{{ user }}</a>",
+        },
+      },
       components: { BCard, BListGroup, BListGroupItem, BButton },
     },
   });
@@ -196,6 +208,65 @@ describe("DanceDetails.vue — tempo display (all users)", () => {
     // Override is active: view span shows text only, no SVG icon
     const viewSpan = wrapper.find("span.ms-2.small");
     expect(viewSpan.find("svg").exists()).toBe(false);
+  });
+});
+
+describe("DanceDetails.vue — dance voters", () => {
+  function makeVoteHistory(): SongHistory {
+    return new SongHistory({
+      id: "00000000-0000-0000-0000-000000000001",
+      properties: [
+        new SongProperty({ name: ".Create", value: "" }),
+        new SongProperty({ name: "User", value: "alice" }),
+        new SongProperty({ name: "Time", value: "01/01/2024 12:00:00 PM" }),
+        new SongProperty({ name: "DanceRating", value: "CHA+1" }),
+        new SongProperty({ name: "Tag+", value: "Cha Cha:Dance" }),
+        new SongProperty({ name: ".Edit", value: "" }),
+        new SongProperty({ name: "User", value: "bob" }),
+        new SongProperty({ name: "Time", value: "01/02/2024 12:00:00 PM" }),
+        new SongProperty({ name: "DanceRating", value: "CHA+1" }),
+        new SongProperty({ name: "Tag+", value: "Cha Cha:Dance" }),
+      ],
+    });
+  }
+
+  it("shows up-voters but no down-voters row when no one voted against", () => {
+    setRoles([]);
+    const history = makeVoteHistory();
+    const song = Song.fromHistory(history);
+    const wrapper = mountDetails(song, { history });
+
+    expect(wrapper.find(".text-success").exists()).toBe(true);
+    expect(wrapper.text()).toContain("alice");
+    expect(wrapper.text()).toContain("bob");
+    expect(wrapper.find(".text-danger").exists()).toBe(false);
+  });
+
+  it("shows both up and down voter rows when both exist", () => {
+    setRoles([]);
+    const history = makeVoteHistory();
+    history.properties.push(
+      new SongProperty({ name: ".Edit", value: "" }),
+      new SongProperty({ name: "User", value: "carol" }),
+      new SongProperty({ name: "Time", value: "01/03/2024 12:00:00 PM" }),
+      new SongProperty({ name: "DanceRating", value: "CHA-1" }),
+      new SongProperty({ name: "Tag+", value: "!Cha Cha:Dance" }),
+    );
+    const song = Song.fromHistory(history);
+    const wrapper = mountDetails(song, { history });
+
+    expect(wrapper.find(".text-success").exists()).toBe(true);
+    expect(wrapper.find(".text-danger").exists()).toBe(true);
+    expect(wrapper.text()).toContain("carol");
+  });
+
+  it("renders no voter block when history is not provided", () => {
+    setRoles([]);
+    const song = makeSong();
+    const wrapper = mountDetails(song);
+
+    expect(wrapper.find(".text-success").exists()).toBe(false);
+    expect(wrapper.find(".text-danger").exists()).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Show who voted for/against each dance directly in the dance list on the Song Details page, next to the vote control.
- Adds `SongHistory.danceVoters()`, which replays a dance's tag history to resolve each user's current up/down vote (excluding batch/algorithmic edits), and wires it through `SongCore` → `DanceDetails`.
- Renders a thumbs-up line with linked usernames, and a thumbs-down line (only when down-votes exist) — user names link to their user info page, consistent with the rest of the page.

## Test plan
- [x] `SongHistory.test.ts` — new `danceVoters` cases (Candyman fixture, vote retraction, up→down flip, batch/algo exclusion)
- [x] `DanceDetails.test.ts` — new cases for up-only, up+down, and no-history rendering
- [x] `yarn type-check`
- [x] Manually verified in the browser (per branch owner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)