### PR TITLE
Protect UsageLog reporting endpoints and harden Index against repeated timeouts

### DIFF
--- a/m4d/Controllers/UsageLogController.cs
+++ b/m4d/Controllers/UsageLogController.cs
@@ -1,6 +1,7 @@
 ﻿using m4d.Services;
 using m4d.Services.ServiceHealth;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -56,10 +57,21 @@ public class PageUsageModel
     public BotFilter BotFilter { get; set; }
 }
 
+// Internal usage reporting only - the underlying queries scan the full
+// UsageLog table and are expensive, so this must stay admin-only.
+[Authorize(Roles = "showDiagnostics")]
 public class UsageLogController : DanceMusicController
 {
     // Cached model for default Index view (static for cross-request caching)
     private static UsageModel s_model;
+
+    // Guards against piling up concurrent/repeated runs of the expensive
+    // Index query - a prior failure (e.g. a timeout) blocks retries for a
+    // cooldown period instead of every request re-running the full scan.
+    private static readonly Lock s_refreshLock = new();
+    private static bool s_isRefreshing;
+    private static DateTime s_retryAfterUtc = DateTime.MinValue;
+    private static readonly TimeSpan RetryCooldown = TimeSpan.FromMinutes(15);
 
     // Bot detection patterns - centralized to avoid duplication
     private static readonly string[] BotPatterns = ["bot", "spider", "crawler", "slurp", "Mediapartners"];
@@ -103,24 +115,53 @@ public class UsageLogController : DanceMusicController
             return View(s_model);
         }
 
-        // Build bot filter SQL using shared helper
-        var botSqlFilter = GetBotFilterSql(botFilter);
-
-        var sql = $"""
-            SELECT [UsageId], MAX([UserName]) as UserName, MIN([Date]) as MinDate, MAX([Date]) as MaxDate, COUNT(*) as Hits 
-            FROM dbo.UsageLog 
-            WHERE 1=1 {botSqlFilter}
-            GROUP BY [UsageId] 
-            HAVING COUNT(*) > 5 
-            ORDER BY Hits DESC
-            """;
-
-        var model = new UsageModel
+        // The query below scans the full UsageLog table and can take minutes
+        // (or time out outright). Don't let a burst of requests - or repeated
+        // requests after a failure - pile up concurrent runs of it.
+        lock (s_refreshLock)
         {
-            Summaries = [.. Context.Database.SqlQueryRaw<UsageSummary>(sql)],
-            LastUpdate = DateTime.Now,
-            BotFilter = botFilter,
-        };
+            if (s_isRefreshing || DateTime.UtcNow < s_retryAfterUtc)
+            {
+                return View(s_model ?? new UsageModel { Summaries = [], LastUpdate = DateTime.Now, BotFilter = botFilter });
+            }
+
+            s_isRefreshing = true;
+        }
+
+        UsageModel model;
+        try
+        {
+            // Build bot filter SQL using shared helper
+            var botSqlFilter = GetBotFilterSql(botFilter);
+
+            var sql = $"""
+                SELECT [UsageId], MAX([UserName]) as UserName, MIN([Date]) as MinDate, MAX([Date]) as MaxDate, COUNT(*) as Hits
+                FROM dbo.UsageLog
+                WHERE 1=1 {botSqlFilter}
+                GROUP BY [UsageId]
+                HAVING COUNT(*) > 5
+                ORDER BY Hits DESC
+                """;
+
+            model = new UsageModel
+            {
+                Summaries = [.. Context.Database.SqlQueryRaw<UsageSummary>(sql)],
+                LastUpdate = DateTime.Now,
+                BotFilter = botFilter,
+            };
+        }
+        catch
+        {
+            s_retryAfterUtc = DateTime.UtcNow.Add(RetryCooldown);
+            throw;
+        }
+        finally
+        {
+            lock (s_refreshLock)
+            {
+                s_isRefreshing = false;
+            }
+        }
 
         // Cache only the default view
         if (botFilter == BotFilter.ExcludeBots)
@@ -182,6 +223,7 @@ public class UsageLogController : DanceMusicController
     public IActionResult ClearCache()
     {
         s_model = null;
+        s_retryAfterUtc = DateTime.MinValue;
         return RedirectToAction("Index");
     }
 

--- a/m4d/Controllers/UsageLogController.cs
+++ b/m4d/Controllers/UsageLogController.cs
@@ -122,7 +122,11 @@ public class UsageLogController : DanceMusicController
         {
             if (s_isRefreshing || DateTime.UtcNow < s_retryAfterUtc)
             {
-                return View(s_model ?? new UsageModel { Summaries = [], LastUpdate = DateTime.Now, BotFilter = botFilter });
+                // s_model only ever holds ExcludeBots data - don't surface it
+                // under a different filter, or the page would show data that
+                // doesn't match the highlighted filter button.
+                var fallback = botFilter == BotFilter.ExcludeBots ? s_model : null;
+                return View(fallback ?? new UsageModel { Summaries = [], LastUpdate = DateTime.Now, BotFilter = botFilter });
             }
 
             s_isRefreshing = true;
@@ -152,7 +156,11 @@ public class UsageLogController : DanceMusicController
         }
         catch
         {
-            s_retryAfterUtc = DateTime.UtcNow.Add(RetryCooldown);
+            lock (s_refreshLock)
+            {
+                s_retryAfterUtc = DateTime.UtcNow.Add(RetryCooldown);
+            }
+
             throw;
         }
         finally
@@ -222,8 +230,12 @@ public class UsageLogController : DanceMusicController
     // GET: UsageLogs/ClearCache
     public IActionResult ClearCache()
     {
-        s_model = null;
-        s_retryAfterUtc = DateTime.MinValue;
+        lock (s_refreshLock)
+        {
+            s_model = null;
+            s_retryAfterUtc = DateTime.MinValue;
+        }
+
         return RedirectToAction("Index");
     }
 


### PR DESCRIPTION
## Summary
- Investigated a multi-hour production outage (5+ hours, resolved by restart): server logs showed 44 recurring SQL command timeouts (~1000s each) from `UsageLogController.Index`'s raw-SQL usage report, which scans the full `UsageLog` table with non-sargable `LIKE` filters. Failed runs never populated the result cache, so every subsequent hit re-ran the same multi-minute query, piling up long-lived DB connections until the app became unresponsive.
- `UsageLogController` (the MVC read/report controller) had no `[Authorize]`, so this expensive page was publicly reachable and appears to have been probed - added `[Authorize(Roles = "showDiagnostics")]` at the class level, matching the existing `DiagRole` convention used elsewhere (`AdminController`, `ApplicationUsersController`). The separate, intentionally-anonymous write path (`APIControllers/UsageLogController.cs`, `POST api/UsageLog/batch`) is unaffected.
- Added a cooldown + concurrency guard around the `Index` query so a timeout no longer causes every following request to immediately re-trigger another multi-minute scan, and so concurrent requests can't pile up simultaneous long-running queries. `ClearCache` resets the cooldown for an explicit forced refresh.

## Test plan
- [x] `dotnet build` succeeds with no new warnings
- [x] Manually verify `/UsageLog` requires the `showDiagnostics` role in a deployed environment