### PR TITLE
Track top URLs generating 4xx responses

### DIFF
--- a/architecture/distributed-attack-mitigation.md
+++ b/architecture/distributed-attack-mitigation.md
@@ -81,6 +81,60 @@ All three consult `SpiderManager`, but check different lists and produce differe
    `CheckAnySpiders` to skip writing a `UsageLog` row for bot traffic, independent of whether the
    request is otherwise short-circuited.
 
+---
+
+## Related Mechanism: 4xx-by-URL Tracking
+
+Added Aug 12, 2026, in response to a spike of 4xx (mostly 400/404) responses in production
+logs. `app.UseHttpLogging()` doesn't surface the request URL by default, and turning up log
+verbosity to get it would clutter the logs further, so this adds a bounded, in-process
+aggregate view instead: an admin-visible table of the URLs generating the most 4xx responses,
+independent of both `SpiderManager` (§ above, keyed by user-agent, not URL/status) and
+`RateLimitingTracker` (keyed by IP, scoped to `/identity/*`, and already covers 429s).
+
+### 4xx Tracking Components
+
+**`Http4xxTracker`** (`m4d/Security/Http4xxTracker.cs`) — DI singleton, same shape as
+`RateLimitingTracker`: a `CircularBuffer<Http4xxEvent>` (10,000 capacity, reusing the
+`CircularBuffer<T>` already defined in `RateLimitingTracker.cs`) behind a `lock`.
+`RecordEvent(url, statusCode)` appends an event; `GetStats(topN = 100)` groups by
+`(Url, StatusCode)`, orders by count descending, and returns the top N as `Http4xxUrlStats`
+(URL, status, count, last-seen timestamp) plus `TotalEventsTracked` / `LastHourCount`.
+
+**`Http4xxTrackingMiddleware`** (`m4d/Middleware/Http4xxTrackingMiddleware.cs`) — registered
+in `Program.cs` immediately after `app.UseRouting()`, before the DB-recovery and
+`RateLimitingMiddleware` blocks. Runs for every request, calls `await next(context)`, and if
+the final `context.Response.StatusCode` is in `[400, 500)` and not `429` (429s are already
+tracked in detail by `RateLimitingTracker` — excluded here to avoid duplicating that data),
+records `Path + QueryString` (truncated to 512 chars to bound memory against adversarially
+long URLs) and the status code.
+
+Placement matters: it sits *inside* (later-registered than) `UseStatusCodePagesWithReExecute`
+(registered earlier, in the non-dev branch around line 734). For a real 404, the first pass
+through the middleware sees the original path with status 404 and records it;
+`UseStatusCodePagesWithReExecute` then re-executes the pipeline against `/Error/404` to render
+the error body, which re-enters the middleware a second time — but that second pass sees
+status 200 (the `ErrorController` view rendering successfully), which falls outside the
+`[400, 500)` check and is correctly skipped. No double-counting.
+
+**Admin wiring**: `AdminController` takes `Http4xxTracker` as a constructor-injected singleton
+(alongside `AuthenticationTracker`/`RateLimitingTracker`), and `Diagnostics()` sets
+`ViewBag.Http4xxStats = _http4xxTracker.GetStats(100)`. Rendered in
+`Views/Admin/Diagnostics.cshtml` under "HTTP 4xx Errors" (between "Authentication Security" and
+"Bot Stats"), as a card + table following the same convention as the Rate Limiting/Auth
+sections — one row per (URL, status code), sorted by count.
+
+**Test coverage**: `m4d.Tests/Security/Http4xxTrackerTests.cs` (aggregation, top-N ordering,
+top-N limit, empty/null handling) and `m4d.Tests/Middleware/Http4xxTrackingMiddlewareTests.cs`
+(records 4xx, ignores 2xx/5xx/429, includes query string, truncates long URLs).
+
+**Limitations (by design, consistent with the other trackers on this page)**: in-memory only,
+resets on app restart; single-instance in-process (see
+[[project_single_instance_deployment]] — no cross-instance aggregation, which is fine at
+current scale); no automated alerting, admin must check `/Admin/Diagnostics` manually.
+
+---
+
 ### Bug found during this investigation (Aug 12, 2026): missing view for `CustomSearchController`
 
 `BotFilter.cshtml` had only ever existed at `Views/Song/BotFilter.cshtml`, created in 2016

--- a/m4d.Tests/Middleware/Http4xxTrackingMiddlewareTests.cs
+++ b/m4d.Tests/Middleware/Http4xxTrackingMiddlewareTests.cs
@@ -1,0 +1,126 @@
+using m4d.Middleware;
+using m4d.Security;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace m4d.Tests.Middleware;
+
+[TestClass]
+public class Http4xxTrackingMiddlewareTests
+{
+    private static Http4xxTrackingMiddleware CreateMiddleware(Http4xxTracker tracker, int responseStatusCode)
+    {
+        RequestDelegate next = ctx =>
+        {
+            ctx.Response.StatusCode = responseStatusCode;
+            return Task.CompletedTask;
+        };
+        return new Http4xxTrackingMiddleware(next, tracker);
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_404Response_RecordsEvent()
+    {
+        // Arrange
+        var tracker = new Http4xxTracker();
+        var middleware = CreateMiddleware(tracker, 404);
+        var context = new DefaultHttpContext();
+        context.Request.Path = $"/song/details/{Guid.NewGuid()}";
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        var stats = tracker.GetStats();
+        Assert.AreEqual(1, stats.TotalEventsTracked);
+        Assert.AreEqual(404, stats.TopUrls[0].StatusCode);
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_IncludesQueryStringInTrackedUrl()
+    {
+        // Arrange
+        var tracker = new Http4xxTracker();
+        var middleware = CreateMiddleware(tracker, 400);
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/customsearch";
+        context.Request.QueryString = new QueryString("?filter=bad-value");
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        var stats = tracker.GetStats();
+        Assert.AreEqual("/customsearch?filter=bad-value", stats.TopUrls[0].Url);
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_200Response_DoesNotRecord()
+    {
+        // Arrange
+        var tracker = new Http4xxTracker();
+        var middleware = CreateMiddleware(tracker, 200);
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/song";
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        var stats = tracker.GetStats();
+        Assert.AreEqual(0, stats.TotalEventsTracked);
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_500Response_DoesNotRecord()
+    {
+        // Arrange
+        var tracker = new Http4xxTracker();
+        var middleware = CreateMiddleware(tracker, 500);
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/song";
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        var stats = tracker.GetStats();
+        Assert.AreEqual(0, stats.TotalEventsTracked);
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_429Response_DoesNotRecord()
+    {
+        // Arrange - already tracked in detail by RateLimitingTracker, would just be noise here
+        var tracker = new Http4xxTracker();
+        var middleware = CreateMiddleware(tracker, 429);
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/identity/account/login";
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        var stats = tracker.GetStats();
+        Assert.AreEqual(0, stats.TotalEventsTracked);
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_VeryLongUrl_TruncatesToSafeLength()
+    {
+        // Arrange
+        var tracker = new Http4xxTracker();
+        var middleware = CreateMiddleware(tracker, 404);
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/song";
+        context.Request.QueryString = new QueryString("?" + new string('a', 1000));
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        var stats = tracker.GetStats();
+        Assert.IsTrue(stats.TopUrls[0].Url.Length <= 512, "URL should be truncated to protect tracker memory");
+    }
+}

--- a/m4d.Tests/Security/Http4xxTrackerTests.cs
+++ b/m4d.Tests/Security/Http4xxTrackerTests.cs
@@ -1,0 +1,152 @@
+using m4d.Security;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace m4d.Tests.Security;
+
+[TestClass]
+public class Http4xxTrackerTests
+{
+    [TestMethod]
+    public void RecordEvent_SingleEvent_TracksCorrectly()
+    {
+        // Arrange
+        var tracker = new Http4xxTracker();
+        var testUrl = $"/song/details/{Guid.NewGuid()}";
+
+        // Act
+        tracker.RecordEvent(testUrl, 404);
+
+        // Assert
+        var stats = tracker.GetStats();
+        Assert.AreEqual(1, stats.TotalEventsTracked);
+        Assert.AreEqual(1, stats.LastHourCount);
+    }
+
+    [TestMethod]
+    public void RecordEvent_RepeatedSameUrlAndStatus_AggregatesCount()
+    {
+        // Arrange
+        var tracker = new Http4xxTracker();
+        var testUrl = $"/song/details/{Guid.NewGuid()}";
+
+        // Act
+        tracker.RecordEvent(testUrl, 404);
+        tracker.RecordEvent(testUrl, 404);
+        tracker.RecordEvent(testUrl, 404);
+
+        // Assert
+        var stats = tracker.GetStats();
+        var found = stats.TopUrls.FirstOrDefault(u => u.Url == testUrl);
+        Assert.IsNotNull(found);
+        Assert.AreEqual(404, found.StatusCode);
+        Assert.AreEqual(3, found.Count);
+    }
+
+    [TestMethod]
+    public void RecordEvent_SameUrlDifferentStatusCodes_TracksSeparately()
+    {
+        // Arrange
+        var tracker = new Http4xxTracker();
+        var testUrl = $"/customsearch/{Guid.NewGuid()}";
+
+        // Act
+        tracker.RecordEvent(testUrl, 404);
+        tracker.RecordEvent(testUrl, 400);
+
+        // Assert
+        var stats = tracker.GetStats();
+        var entries = stats.TopUrls.Where(u => u.Url == testUrl).ToList();
+        Assert.AreEqual(2, entries.Count);
+        Assert.IsTrue(entries.Any(e => e.StatusCode == 404 && e.Count == 1));
+        Assert.IsTrue(entries.Any(e => e.StatusCode == 400 && e.Count == 1));
+    }
+
+    [TestMethod]
+    public void GetStats_TopUrls_OrderedByCountDescending()
+    {
+        // Arrange
+        var tracker = new Http4xxTracker();
+        var popularUrl = $"/song/details/{Guid.NewGuid()}";
+        var rareUrl = $"/song/details/{Guid.NewGuid()}";
+
+        // Act - popularUrl hit 5 times, rareUrl hit 2 times
+        for (var i = 0; i < 5; i++)
+        {
+            tracker.RecordEvent(popularUrl, 404);
+        }
+        for (var i = 0; i < 2; i++)
+        {
+            tracker.RecordEvent(rareUrl, 404);
+        }
+
+        // Assert
+        var stats = tracker.GetStats();
+        var popularIndex = stats.TopUrls.FindIndex(u => u.Url == popularUrl);
+        var rareIndex = stats.TopUrls.FindIndex(u => u.Url == rareUrl);
+        Assert.IsTrue(popularIndex >= 0 && rareIndex >= 0);
+        Assert.IsTrue(popularIndex < rareIndex, "More frequently hit URL should be ordered first");
+    }
+
+    [TestMethod]
+    public void GetStats_RespectsTopNLimit()
+    {
+        // Arrange
+        var tracker = new Http4xxTracker();
+        for (var i = 0; i < 10; i++)
+        {
+            tracker.RecordEvent($"/bad-link-{i}-{Guid.NewGuid()}", 404);
+        }
+
+        // Act
+        var stats = tracker.GetStats(topN: 3);
+
+        // Assert
+        Assert.AreEqual(3, stats.TopUrls.Count);
+    }
+
+    [TestMethod]
+    public void GetStats_EmptyTracker_ReturnsEmptyStats()
+    {
+        // Arrange
+        var tracker = new Http4xxTracker();
+
+        // Act
+        var stats = tracker.GetStats();
+
+        // Assert
+        Assert.AreEqual(0, stats.TotalEventsTracked);
+        Assert.AreEqual(0, stats.TopUrls.Count);
+    }
+
+    [TestMethod]
+    public void RecordEvent_WithNullUrl_HandlesGracefully()
+    {
+        // Arrange
+        var tracker = new Http4xxTracker();
+
+        // Act
+        tracker.RecordEvent(null, 404);
+
+        // Assert
+        var stats = tracker.GetStats();
+        Assert.AreEqual(1, stats.TotalEventsTracked);
+        Assert.AreEqual("/", stats.TopUrls[0].Url);
+    }
+
+    [TestMethod]
+    public void GetStats_DefaultTopN_Is100()
+    {
+        // Arrange
+        var tracker = new Http4xxTracker();
+        for (var i = 0; i < 150; i++)
+        {
+            tracker.RecordEvent($"/bad-link-{i}-{Guid.NewGuid()}", 404);
+        }
+
+        // Act
+        var stats = tracker.GetStats();
+
+        // Assert
+        Assert.AreEqual(100, stats.TopUrls.Count);
+    }
+}

--- a/m4d.Tests/Security/Http4xxTrackerTests.cs
+++ b/m4d.Tests/Security/Http4xxTrackerTests.cs
@@ -125,7 +125,7 @@ public class Http4xxTrackerTests
         var tracker = new Http4xxTracker();
 
         // Act
-        tracker.RecordEvent(null, 404);
+        tracker.RecordEvent(null!, 404);
 
         // Assert
         var stats = tracker.GetStats();

--- a/m4d/ClientApp/.yarnrc.yml
+++ b/m4d/ClientApp/.yarnrc.yml
@@ -1,1 +1,8 @@
+approvedGitRepositories:
+  - "**"
+
+enableScripts: true
+
 nodeLinker: pnpm
+
+npmMinimalAgeGate: 0

--- a/m4d/ClientApp/.yarnrc.yml
+++ b/m4d/ClientApp/.yarnrc.yml
@@ -1,8 +1,3 @@
-approvedGitRepositories:
-  - "**"
-
 enableScripts: true
 
 nodeLinker: pnpm
-
-npmMinimalAgeGate: 0

--- a/m4d/ClientApp/package.json
+++ b/m4d/ClientApp/package.json
@@ -76,5 +76,5 @@
     "string-width": "4.2.2",
     "wrap-ansi": "7.0.0"
   },
-  "packageManager": "yarn@4.9.2"
+  "packageManager": "yarn@4.18.0"
 }

--- a/m4d/ClientApp/yarn.lock
+++ b/m4d/ClientApp/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10c0
 
 "@antfu/install-pkg@npm:^1.1.0":

--- a/m4d/Controllers/AdminController.cs
+++ b/m4d/Controllers/AdminController.cs
@@ -82,12 +82,14 @@ public class AdminController(
     IOptionsMonitor<LoggerFilterOptions> loggerFilterOptions,
     ServiceHealthManager serviceHealth,
     AuthenticationTracker authTracker,
-    RateLimitingTracker rateLimitingTracker
+    RateLimitingTracker rateLimitingTracker,
+    Http4xxTracker http4xxTracker
 ) : DanceMusicController(context, userManager, searchService, danceStatsManager, configuration,
     fileProvider, backroundTaskQueue, featureManager, logger, serviceHealth)
 {
     private readonly AuthenticationTracker _authTracker = authTracker;
     private readonly RateLimitingTracker _rateLimitingTracker = rateLimitingTracker;
+    private readonly Http4xxTracker _http4xxTracker = http4xxTracker;
 
     #region Commands
 
@@ -443,6 +445,7 @@ public class AdminController(
         // Add security stats for Phase 1
         ViewBag.AuthStats = _authTracker.GetStats();
         ViewBag.RateLimitStats = _rateLimitingTracker.GetStats();
+        ViewBag.Http4xxStats = _http4xxTracker.GetStats(100);
         return View();
     }
 

--- a/m4d/Middleware/Http4xxTrackingMiddleware.cs
+++ b/m4d/Middleware/Http4xxTrackingMiddleware.cs
@@ -1,0 +1,39 @@
+using m4d.Security;
+
+namespace m4d.Middleware;
+
+/// <summary>
+/// Records 4xx HTTP responses (mostly 400 and 404) by URL so admins can distinguish
+/// legitimate crawlers hitting stale links from malicious probing at a glance, without
+/// cluttering the default request log with a URL on every line.
+/// Runs after routing so it observes the final status code for every request, including
+/// ones that never match a route. 429s are excluded — those are already covered in detail
+/// by <see cref="RateLimitingTracker"/> and would just be noise here.
+/// </summary>
+public class Http4xxTrackingMiddleware(RequestDelegate next, Http4xxTracker tracker)
+{
+    private const int MaxUrlLength = 512;
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        await next(context);
+
+        var statusCode = context.Response.StatusCode;
+        if (statusCode is >= 400 and < 500 and not 429)
+        {
+            tracker.RecordEvent(BuildUrl(context), statusCode);
+        }
+    }
+
+    private static string BuildUrl(HttpContext context)
+    {
+        var url = context.Request.Path.Value ?? "/";
+        var query = context.Request.QueryString.Value;
+        if (!string.IsNullOrEmpty(query))
+        {
+            url += query;
+        }
+
+        return url.Length <= MaxUrlLength ? url : url[..MaxUrlLength];
+    }
+}

--- a/m4d/Program.cs
+++ b/m4d/Program.cs
@@ -554,6 +554,7 @@ services.AddScoped<m4d.Services.SpotifyAuthService>();
 // Security trackers for Phase 1 - singletons for in-memory tracking
 services.AddSingleton<m4d.Security.AuthenticationTracker>();
 services.AddSingleton<m4d.Security.RateLimitingTracker>();
+services.AddSingleton<m4d.Security.Http4xxTracker>();
 
 services.AddSingleton<IBackgroundTaskQueue, BackgroundTaskQueue>();
 services.AddHostedService<BackgroundQueueHostedService>();
@@ -766,6 +767,11 @@ else
 
 app.UseHttpLogging();
 app.UseRouting();
+
+// Track 4xx responses (by URL + status code) for the admin diagnostics page. Placed right
+// after routing so it sees the final status code for every request, including ones that
+// never match a route (404s) — default ASP.NET Core logging doesn't surface the URL for these.
+app.UseMiddleware<m4d.Middleware.Http4xxTrackingMiddleware>();
 
 // Database recovery: when the DB was unavailable at startup (e.g., Azure on-demand SQL still
 // waking up), attempt a reconnection on user requests.  The attempt is fire-and-forget and

--- a/m4d/Security/Http4xxTracker.cs
+++ b/m4d/Security/Http4xxTracker.cs
@@ -1,0 +1,89 @@
+namespace m4d.Security;
+
+/// <summary>
+/// Tracks 4xx HTTP responses (mostly 400/404) by URL for admin visibility into broken
+/// links, scraper probing, and malicious request patterns, without needing per-request
+/// URL logging in the default ASP.NET Core log output.
+/// Uses a circular buffer to store the last 10,000 events.
+/// </summary>
+public class Http4xxTracker
+{
+    private readonly CircularBuffer<Http4xxEvent> _events = new(10000);
+    private readonly object _lock = new();
+
+    public void RecordEvent(string url, int statusCode)
+    {
+        var evt = new Http4xxEvent
+        {
+            Timestamp = DateTime.UtcNow,
+            Url = string.IsNullOrEmpty(url) ? "/" : url,
+            StatusCode = statusCode
+        };
+
+        lock (_lock)
+        {
+            _events.Add(evt);
+        }
+    }
+
+    public Http4xxStats GetStats(int topN = 100)
+    {
+        lock (_lock)
+        {
+            var allEvents = _events.ToList();
+
+            if (!allEvents.Any())
+            {
+                return new Http4xxStats
+                {
+                    TotalEventsTracked = 0,
+                    TopUrls = new List<Http4xxUrlStats>()
+                };
+            }
+
+            var lastHour = DateTime.UtcNow.AddHours(-1);
+
+            return new Http4xxStats
+            {
+                TotalEventsTracked = allEvents.Count,
+                LastHourCount = allEvents.Count(e => e.Timestamp >= lastHour),
+                OldestEventTime = allEvents.Min(e => e.Timestamp),
+                TopUrls = allEvents
+                    .GroupBy(e => new { e.Url, e.StatusCode })
+                    .OrderByDescending(g => g.Count())
+                    .Take(topN)
+                    .Select(g => new Http4xxUrlStats
+                    {
+                        Url = g.Key.Url,
+                        StatusCode = g.Key.StatusCode,
+                        Count = g.Count(),
+                        LastSeen = g.Max(e => e.Timestamp)
+                    })
+                    .ToList()
+            };
+        }
+    }
+}
+
+public class Http4xxEvent
+{
+    public DateTime Timestamp { get; set; }
+    public string Url { get; set; }
+    public int StatusCode { get; set; }
+}
+
+public class Http4xxStats
+{
+    public int TotalEventsTracked { get; set; }
+    public int LastHourCount { get; set; }
+    public DateTime OldestEventTime { get; set; }
+    public List<Http4xxUrlStats> TopUrls { get; set; }
+}
+
+public class Http4xxUrlStats
+{
+    public string Url { get; set; }
+    public int StatusCode { get; set; }
+    public int Count { get; set; }
+    public DateTime LastSeen { get; set; }
+}

--- a/m4d/Views/Admin/Diagnostics.cshtml
+++ b/m4d/Views/Admin/Diagnostics.cshtml
@@ -771,5 +771,52 @@ else
 
 
 <hr />
+<h3>HTTP 4xx Errors</h3>
+@if (ViewBag.Http4xxStats is m4d.Security.Http4xxStats http4xxStats)
+{
+    <div class="card mb-3">
+        <div class="card-header">
+            <strong>Top URLs by 4xx Response (Top @http4xxStats.TopUrls.Count, all time)</strong>
+            <small class="text-muted ms-2">
+                @http4xxStats.TotalEventsTracked total tracked, @http4xxStats.LastHourCount in the last hour.
+                429s excluded — see Rate Limiting Activity above.
+            </small>
+        </div>
+        <div class="card-body">
+            @if (http4xxStats.TopUrls.Any())
+            {
+                <div class="table-responsive">
+                    <table class="table table-sm table-bordered table-hover">
+                        <thead class="table-light">
+                            <tr>
+                                <th>URL</th>
+                                <th>Status</th>
+                                <th>Count</th>
+                                <th>Last Seen</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var url in http4xxStats.TopUrls)
+                            {
+                                <tr class="@(url.StatusCode == 400 ? "table-warning" : "")">
+                                    <td class="text-break"><code>@url.Url</code></td>
+                                    <td>@url.StatusCode</td>
+                                    <td>@url.Count</td>
+                                    <td><small>@url.LastSeen.ToLocalTime().ToString("MMM dd HH:mm:ss")</small></td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+            else
+            {
+                <p class="text-muted mb-0">No 4xx responses tracked yet.</p>
+            }
+        </div>
+    </div>
+}
+
+<hr />
 <h3>Bot Stats</h3>
 <partial name="_botreport" model="ViewBag.BotReport" />


### PR DESCRIPTION
## Summary
- Adds an `Http4xxTracker` singleton (circular buffer of last 10k events) that records the URL + status code for every 400-499 response (excluding 429, which `RateLimitingTracker` already covers in detail).
- New `Http4xxTrackingMiddleware`, registered right after `UseRouting()`, so it sees the final status code for every request including unmatched routes, without duplicating requests re-executed by `UseStatusCodePagesWithReExecute`.
- Admin diagnostics page (`/Admin/Diagnostics`) gets a new "HTTP 4xx Errors" card showing the top 100 URLs by 4xx count, with status code, count, and last-seen time — giving visibility into broken links / bot probing / malicious requests without needing to turn up per-request URL logging.

## Why
Production logs were showing a lot of 4xx (mostly 400/404) noise, but default ASP.NET Core HTTP logging doesn't include the request URL, and enabling verbose logging to get it would clutter things further. This gives an aggregated, admin-visible view instead — same pattern as the existing `RateLimitingTracker`/`AuthenticationTracker`/`SpiderManager` mechanisms on that page.

## Client build tooling: Yarn 4.9.2 -> 4.18.0
While testing this change, the client-app Yarn version was bumped from 4.9.2 to 4.18.0 (`m4d/ClientApp/package.json`, `.yarnrc.yml`, `yarn.lock`). This is unrelated to the 4xx tracking feature itself but is bundled here since it was picked up during manual testing.

The upgrade's interactive migration wrote out three new Yarn security settings with permissive values, which was flagged in review and has been corrected:
- `approvedGitRepositories: ["**"]` — removed. The project has no git-based dependencies, so this allowlist-everything entry was unnecessary.
- `npmMinimalAgeGate: 0` — removed. Yarn 4.12+ defaults this to 1 day (blocks installing packages published in the last 24h, as a defense against just-published supply-chain attacks); the override disabled that protection. Restored to the default.
- `enableScripts: true` — kept. Verified via `yarn install` that `@parcel/watcher` and `vue-demi` have legitimate build scripts (needed by Vite's file watcher) that fail without it.

Verified `yarn install` and `yarn build` both succeed with the corrected settings.

## Test plan
- [x] New unit tests: `m4d.Tests/Security/Http4xxTrackerTests.cs`, `m4d.Tests/Middleware/Http4xxTrackingMiddlewareTests.cs`
- [x] Full `m4d.Tests` suite passes (183/183)
- [x] Manually tested and verified by David
- [x] `yarn install` / `yarn build` verified after scoping down the Yarn security settings

Documentation: `architecture/distributed-attack-mitigation.md` updated with a new "Related Mechanism: 4xx-by-URL Tracking" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
