### PR TITLE
Extend tempo validation to 10 more dances

### DIFF
--- a/DanceTests/ProductionDanceDataTests.cs
+++ b/DanceTests/ProductionDanceDataTests.cs
@@ -76,6 +76,27 @@ public class ProductionDanceDataTests
     }
 
     [TestMethod]
+    [DataRow("PBD", 145.0, 500.0)]
+    [DataRow("CST", 150.0, 500.0)]
+    [DataRow("BOL", 50.0, 150.0)]
+    [DataRow("JSW", 125.0, 300.0)]
+    [DataRow("BBA", 140.0, 500.0)]
+    [DataRow("JIV", 100.0, 230.0)]
+    [DataRow("NC2", 25.0, 140.0)]
+    [DataRow("BCH", 100.0, 190.0)]
+    [DataRow("ECS", 80.0, 175.0)]
+    [DataRow("SSW", 110.0, 240.0)]
+    public void NewlyAddedDance_HasValidationRules(string danceId, double doubleBelow, double halveAbove)
+    {
+        var dance = s_dances.DanceFromId(danceId) as DanceType;
+        Assert.IsNotNull(dance, $"{danceId} should exist in production dances.json as a DanceType");
+        Assert.IsNotNull(dance.Validation, $"{danceId} should have a validation block");
+        Assert.AreEqual((decimal)doubleBelow, dance.Validation.DoubleTempoIfBelow);
+        Assert.AreEqual((decimal)halveAbove, dance.Validation.HalveTempoIfAbove);
+        CollectionAssert.AreEquivalent(new[] { "3/4", "6/8" }, dance.Validation.FlagInvalidMeters);
+    }
+
+    [TestMethod]
     public void SlowWaltz_HasNoValidationRules()
     {
         // Sanity check against the opposite mistake: a copy-paste that gives every dance a

--- a/architecture/tempo-validation-rules.md
+++ b/architecture/tempo-validation-rules.md
@@ -6,7 +6,7 @@ Spotify/EchoNest tempo detection sometimes reports half-time or double-time erro
 
 Corrections are committed as a second edit under the `tempo-bot` pseudo-user, so the audit trail shows the algorithmic Spotify import separately from the bot's correction.
 
-**Status**: Implemented and covered by unit/integration tests, scoped to Salsa and Quickstep. Not yet exercised against real Spotify imports or run retroactively against the existing catalog (see "Running Against the Existing Catalog" below).
+**Status**: Implemented and covered by unit/integration tests, scoped to Salsa, Quickstep, and 10 additional dances (see "Current Scope" below). Not yet exercised against real Spotify imports or run retroactively against the existing catalog for any of them (see "Running Against the Existing Catalog" below).
 
 ## Data Model
 
@@ -102,16 +102,26 @@ Both tempo corrections and a meter flag can fire on the same edit — they aren'
 
 `tempo-bot` is a pseudo `ApplicationUser` (`IsPseudo == true`), the same pattern already used by `SongController.BatchCorrectTempo` for manual retroactive corrections. No new user, role, or database change was needed — `SongIndex.EditSong` and `SongProperties` already support attributing an edit to any `ApplicationUser`.
 
-## Current Scope: Salsa and Quickstep
+## Current Scope
 
-| Rule | Value |
-| --- | --- |
-| Double if tempo below | 120 BPM |
-| Halve if tempo above | 250 BPM |
-| Flag meters | `3/4`, `6/8` |
-| Typical valid range | 160–220 BPM (Salsa's Social-style tempo range, for reference — the rule itself applies to Salsa as a whole, not just that style) |
+Twelve dances currently have a `validation` block. All of them share the same `flagInvalidMeters` rule (`3/4`, `6/8`); `doubleTempoIfBelow`/`halveTempoIfAbove` are tuned per dance:
 
-Quickstep also has a `validation` block (same dance-level scoping as Salsa). The thresholds happen to match Salsa's numerically, but that's coincidental, not copy-paste — they've been validated as reasonable for Quickstep's own range (200–208 BPM, 200 flat under NDCA) independently. No other dance currently has a `validation` block, so `ValidateTempo` is a no-op for every other dance today.
+| Dance | ID | Double if below | Halve if above |
+| --- | --- | --- | --- |
+| Salsa | SLS | 120 BPM | 250 BPM |
+| Quickstep | QST | 120 BPM | 250 BPM |
+| Peabody | PBD | 145 BPM | 500 BPM |
+| Charleston | CST | 150 BPM | 500 BPM |
+| Bolero | BOL | 50 BPM | 150 BPM |
+| Jump Swing | JSW | 125 BPM | 300 BPM |
+| Balboa | BBA | 140 BPM | 500 BPM |
+| Jive | JIV | 100 BPM | 230 BPM |
+| Night Club Two Step | NC2 | 25 BPM | 140 BPM |
+| Bachata | BCH | 100 BPM | 190 BPM |
+| East Coast Swing | ECS | 80 BPM | 175 BPM |
+| Single Swing | SSW | 110 BPM | 240 BPM |
+
+Salsa and Quickstep's thresholds happen to match each other numerically, but that's coincidental, not copy-paste — each dance's thresholds are validated against its own typical tempo range (Salsa: 160–220 BPM Social-style; Quickstep: 200–208 BPM, 200 flat under NDCA). No other dance currently has a `validation` block, so `ValidateTempo` is a no-op for every other dance today.
 
 ## Running Against the Existing Catalog
 
@@ -134,7 +144,7 @@ Songs with a suspicious meter are tagged `check-accuracy:Tempo` and otherwise le
 ## Open Follow-Ups
 
 1. Test against real Salsa imports from Spotify playlists (no live/recorded-fixture test exists yet).
-2. Run "Validate Tempo" (filtered to Quickstep) against the existing catalog as a first trial of the batch path on a dance other than Salsa; review the results before adding more dances.
+2. Run "Validate Tempo" (filtered to Quickstep) against the existing catalog as a first trial of the batch path on a dance other than Salsa; review the results. The 10 dances added after Quickstep (see "Current Scope") were configured without waiting on this trial — extend the review to them once results come in, filtering the song list to each dance in turn.
 3. Periodically search for `check-accuracy:Tempo` and review flagged songs.
-4. Monitor false positive/negative rate before extending thresholds to other dances (Waltz, East Coast Swing, Cha Cha are plausible next candidates based on the same half/double-time failure mode).
+4. Monitor false positive/negative rate on the 10 newly added dances. Waltz and Cha Cha remain plausible next candidates for extension based on the same half/double-time failure mode.
 5. On songs where a real user already set the song-level tempo (or a given dance's own override), the corresponding correction/promotion step is a guaranteed no-op (see "Per-Dance Tempo Edits" above). That's likely fine for most catalog songs, but hasn't been evaluated against how much of the catalog's tempo data traces back to real users versus service imports; worth checking before relying on the correction/promotion behavior at scale.

--- a/m4d/ClientApp/src/assets/content/dances.json
+++ b/m4d/ClientApp/src/assets/content/dances.json
@@ -109,6 +109,11 @@
     },
     "blogTag": "castle-foxtrot",
     "synonyms": ["Slow Dance"],
+    "validation": {
+      "doubleTempoIfBelow": 25.0,
+      "halveTempoIfAbove": 125.0,
+      "flagInvalidMeters": ["3/4", "6/8"]
+    },
     "instances": [
       {
         "style": "Social",
@@ -218,6 +223,11 @@
     },
     "blogTag": "peabody",
     "synonyms": ["One Step"],
+    "validation": {
+      "doubleTempoIfBelow": 145.0,
+      "halveTempoIfAbove": 500.0,
+      "flagInvalidMeters": ["3/4", "6/8"]
+    },
     "instances": [
       {
         "style": "American Smooth",
@@ -331,6 +341,11 @@
       "denominator": 4
     },
     "blogTag": "bolero",
+    "validation": {
+      "doubleTempoIfBelow": 50.0,
+      "halveTempoIfAbove": 150.0,
+      "flagInvalidMeters": ["3/4", "6/8"]
+    },
     "instances": [
       {
         "style": "American Rhythm",
@@ -449,6 +464,11 @@
       "denominator": 4
     },
     "blogTag": "jive",
+    "validation": {
+      "doubleTempoIfBelow": 100.0,
+      "halveTempoIfAbove": 230.0,
+      "flagInvalidMeters": ["3/4", "6/8"]
+    },
     "instances": [
       {
         "style": "International Latin",
@@ -530,6 +550,11 @@
     "blogTag": "east-coast-swing",
     "synonyms": ["Triple Swing", "East Coast"],
     "searchonyms": ["swing", "ec swing"],
+    "validation": {
+      "doubleTempoIfBelow": 80.0,
+      "halveTempoIfAbove": 175.0,
+      "flagInvalidMeters": ["3/4", "6/8"]
+    },
     "instances": [
       {
         "style": "American Rhythm",
@@ -900,6 +925,11 @@
       "denominator": 4
     },
     "blogTag": "bachata",
+    "validation": {
+      "doubleTempoIfBelow": 100.0,
+      "halveTempoIfAbove": 190.0,
+      "flagInvalidMeters": ["3/4", "6/8"]
+    },
     "instances": [
       {
         "style": "American Rhythm",
@@ -929,6 +959,11 @@
     "blogTag": "night-club-two-step",
     "searchonyms": ["club two step"],
     "synonyms": ["Night Club"],
+    "validation": {
+      "doubleTempoIfBelow": 25.0,
+      "halveTempoIfAbove": 140.0,
+      "flagInvalidMeters": ["3/4", "6/8"]
+    },
     "instances": [
       {
         "style": "American Rhythm",
@@ -1114,6 +1149,11 @@
       "denominator": 4
     },
     "blogTag": "charleston",
+    "validation": {
+      "doubleTempoIfBelow": 150.0,
+      "halveTempoIfAbove": 500.0,
+      "flagInvalidMeters": ["3/4", "6/8"]
+    },
     "instances": [
       {
         "style": "Social",
@@ -1259,6 +1299,11 @@
       "denominator": 4
     },
     "blogTag": "jump-swing",
+    "validation": {
+      "doubleTempoIfBelow": 125.0,
+      "halveTempoIfAbove": 300.0,
+      "flagInvalidMeters": ["3/4", "6/8"]
+    },
     "instances": [
       {
         "style": "Social",
@@ -1312,6 +1357,11 @@
       "denominator": 4
     },
     "blogTag": "balboa",
+    "validation": {
+      "doubleTempoIfBelow": 140.0,
+      "halveTempoIfAbove": 500.0,
+      "flagInvalidMeters": ["3/4", "6/8"]
+    },
     "instances": [
       {
         "style": "Social",
@@ -1331,6 +1381,11 @@
     },
     "blogTag": "single-swing",
     "synonyms": ["Single-time Swing", "East Coast Single Swing", "Jitterbug"],
+    "validation": {
+      "doubleTempoIfBelow": 110.0,
+      "halveTempoIfAbove": 240.0,
+      "flagInvalidMeters": ["3/4", "6/8"]
+    },
     "instances": [
       {
         "style": "Social",


### PR DESCRIPTION
## Summary
- Add `validation` blocks (double/halve tempo thresholds + `flagInvalidMeters: ["3/4", "6/8"]`, same as Salsa) to 10 more 4/4 dances in `dances.json`: Peabody, Charleston, Bolero, Jump Swing, Balboa, Jive, Night Club Two Step, Bachata, East Coast Swing, and Single Swing.
- Update `architecture/tempo-validation-rules.md`'s "Current Scope" table and open follow-ups to reflect the expanded scope.
- Add `ProductionDanceDataTests` coverage asserting each new dance's validation block loads correctly from production `dances.json`.

## Test plan
- [x] `dotnet test DanceTests/DanceLibrary.Tests.csproj --filter "FullyQualifiedName~ProductionDanceDataTests"` — 15/15 passed
- [ ] Run "Validate Tempo" against the catalog, filtered per new dance, before relying on corrections at scale (tracked as an open follow-up in the doc)