### PR TITLE
Fix column header sort direction toggle

### DIFF
--- a/m4d/ClientApp/src/models/SongFilter.ts
+++ b/m4d/ClientApp/src/models/SongFilter.ts
@@ -281,8 +281,7 @@ export class SongFilter {
 
   public changeSort(order: string): SongFilter {
     const clone = this.clone();
-    const newSort = new SongSort(order, this.TextSearch);
-    clone.sortOrder = newSort.query;
+    clone.sortOrder = this.sort.change(order).query;
     return clone;
   }
 

--- a/m4d/ClientApp/src/models/SongSort.ts
+++ b/m4d/ClientApp/src/models/SongSort.ts
@@ -61,6 +61,18 @@ export class SongSort {
     return this.data && this.data.endsWith("_desc") ? "desc" : "asc";
   }
 
+  // Clicking the currently-sorted column should flip its direction; clicking a
+  // different column should switch to it with the default (ascending) direction.
+  public change(order: string): SongSort {
+    const sorder = toTitleCase(order);
+    if (sorder === this.id) {
+      const direction = this.direction === "desc" ? undefined : "desc";
+      return SongSort.fromParts(this.id, direction, this.hasQuery);
+    } else {
+      return new SongSort(order, this.hasQuery);
+    }
+  }
+
   public get friendlyName(): string {
     switch (this.computedId) {
       case SortOrder.Dances:

--- a/m4d/ClientApp/src/models/__tests__/SongFilter.test.ts
+++ b/m4d/ClientApp/src/models/__tests__/SongFilter.test.ts
@@ -326,4 +326,49 @@ describe("song filter", () => {
 
     expect(f.isRaw).toBe(true);
   });
+
+  it("should sort ascending by a new column when changing sort", () => {
+    const f = SongFilter.buildFilter(simple);
+    expect(f.sortOrder).toEqual("Modified");
+
+    const changed = f.changeSort("Title");
+
+    expect(changed.sortOrder).toEqual("Title");
+  });
+
+  it("should flip to descending when re-clicking the currently ascending column", () => {
+    const f = new SongFilter();
+    f.sortOrder = "Title";
+
+    const changed = f.changeSort("Title");
+
+    expect(changed.sortOrder).toEqual("Title_desc");
+  });
+
+  it("should flip back to ascending when re-clicking the currently descending column", () => {
+    const f = new SongFilter();
+    f.sortOrder = "Title_desc";
+
+    const changed = f.changeSort("Title");
+
+    expect(changed.sortOrder).toEqual("Title");
+  });
+
+  it("should reset to ascending when switching from a descending column to a different one", () => {
+    const f = new SongFilter();
+    f.sortOrder = "Tempo_desc";
+
+    const changed = f.changeSort("Artist");
+
+    expect(changed.sortOrder).toEqual("Artist");
+  });
+
+  it("should not mutate the original filter when changing sort", () => {
+    const f = new SongFilter();
+    f.sortOrder = "Title";
+
+    f.changeSort("Title");
+
+    expect(f.sortOrder).toEqual("Title");
+  });
 });

--- a/m4d/ClientApp/src/models/__tests__/SongSort.test.ts
+++ b/m4d/ClientApp/src/models/__tests__/SongSort.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { SongSort } from "../SongSort";
+
+describe("SongSort", () => {
+  describe("change", () => {
+    it("switches to a new column ascending when no sort is set", () => {
+      const sort = new SongSort();
+
+      const changed = sort.change("Title");
+
+      expect(changed.id).toEqual("Title");
+      expect(changed.direction).toEqual("asc");
+    });
+
+    it("switches to a new column ascending when a different column was sorted ascending", () => {
+      const sort = new SongSort("Artist");
+
+      const changed = sort.change("Title");
+
+      expect(changed.id).toEqual("Title");
+      expect(changed.direction).toEqual("asc");
+    });
+
+    it("switches to a new column ascending when a different column was sorted descending", () => {
+      const sort = new SongSort("Tempo_desc");
+
+      const changed = sort.change("Artist");
+
+      expect(changed.id).toEqual("Artist");
+      expect(changed.direction).toEqual("asc");
+    });
+
+    it("flips the same column from ascending to descending", () => {
+      const sort = new SongSort("Title");
+
+      const changed = sort.change("Title");
+
+      expect(changed.id).toEqual("Title");
+      expect(changed.direction).toEqual("desc");
+      expect(changed.query).toEqual("Title_desc");
+    });
+
+    it("flips the same column from descending back to ascending", () => {
+      const sort = new SongSort("Title_desc");
+
+      const changed = sort.change("Title");
+
+      expect(changed.id).toEqual("Title");
+      expect(changed.direction).toEqual("asc");
+      expect(changed.query).toEqual("Title");
+    });
+
+    it("is case-insensitive when matching the clicked column against the current one", () => {
+      const sort = new SongSort("Title");
+
+      const changed = sort.change("title");
+
+      expect(changed.query).toEqual("Title_desc");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Clicking a sortable column header wasn't toggling `asc`/`desc` — `SongFilter.changeSort()` always built a fresh `SongSort` from scratch instead of comparing against the current sort, a regression from an earlier refactor that dropped `SongSort`'s toggle logic.
- Restored `SongSort.change(order)`, which flips `_desc` on the currently-sorted column and resets to ascending when switching to a different column, using the typed `SongSort`/`fromParts` API rather than string munging.
- `SongFilter.changeSort()` now delegates to `this.sort.change(order)`.

## Test plan
- [x] Added `SongSort.test.ts` covering `change()`: new column defaults to ascending, re-clicking the active column toggles direction both ways, switching away from a descending column resets to ascending, case-insensitive id matching.
- [x] Added `changeSort()` cases in `SongFilter.test.ts`, including immutability of the original filter.
- [x] Full client suite (76 files, 843 tests) passes; `yarn type-check` clean.