### PR TITLE
Fix site-wide 500s during service outages

### DIFF
--- a/m4d.Tests/SpiderManagerTests.cs
+++ b/m4d.Tests/SpiderManagerTests.cs
@@ -59,4 +59,15 @@ public class SpiderManagerTests
         Assert.IsTrue(result);
     }
 
+    [TestMethod]
+    public void CheckSpiders_Returns_False_WhenBotFilterConfigMissing()
+    {
+        // Simulates Azure App Configuration being unavailable, which is where
+        // Configuration:BotFilter is normally sourced from.
+        var emptyConfig = new ConfigurationBuilder().Build();
+        var agent = "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/W.X.Y.Z Safari/537.36";
+        var result = SpiderManager.CheckAnySpiders(agent, emptyConfig);
+        Assert.IsFalse(result);
+    }
+
 }

--- a/m4d/Configuration/ServiceCollectionExtensions.cs
+++ b/m4d/Configuration/ServiceCollectionExtensions.cs
@@ -35,8 +35,9 @@ public static class ServiceCollectionExtensions
         {
             serviceHealth.MarkUnavailable("EmailService", $"{ex.GetType().Name}: {ex.Message}");
             Console.WriteLine($"WARNING: Email service not configured: {ex.Message}");
-            // Register a null email sender as fallback
-            services.AddTransient<IEmailSender, EmailSender>(provider => new EmailSender(null));
+            // Register a no-op fallback - EmailSender's constructor throws on a null
+            // connection string, which would just move this crash to first DI resolution.
+            services.AddTransient<IEmailSender, NullEmailSender>();
         }
 
         return services;

--- a/m4d/Services/ServiceHealth/NullEmailSender.cs
+++ b/m4d/Services/ServiceHealth/NullEmailSender.cs
@@ -1,0 +1,24 @@
+using m4d.Utilities;
+
+using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.Extensions.Logging;
+
+namespace m4d.Services.ServiceHealth;
+
+/// <summary>
+/// Null implementation of IEmailSender for when Azure Communication Services is unavailable.
+/// Unlike EmailSender, this never throws on construction or on send - callers that don't
+/// check ServiceHealth before sending shouldn't crash the page just because email is down.
+/// </summary>
+public class NullEmailSender : IEmailSender
+{
+    private static readonly ILogger Logger = ApplicationLogging.CreateLogger<NullEmailSender>();
+
+    public Task SendEmailAsync(string email, string subject, string message)
+    {
+        Logger.LogWarning(
+            "Email service is unavailable - message to {Email} with subject '{Subject}' was not sent",
+            email, subject);
+        return Task.CompletedTask;
+    }
+}

--- a/m4d/Utilities/SpiderManager.cs
+++ b/m4d/Utilities/SpiderManager.cs
@@ -45,7 +45,7 @@ public static class SpiderManager
 
         var agent = userAgent.ToLower();
         var botFilter = configuration
-            .GetSection(BotFilterInfo.SectionName).Get<BotFilterInfo>();
+            .GetSection(BotFilterInfo.SectionName).Get<BotFilterInfo>() ?? new BotFilterInfo();
 
         if (!botFilter.ExcludeFragmentList.Any(agent.Contains) &&
             !botFilter.ExcludeTokenList.Any(t => agent.Equals(t)))

--- a/m4d/Utilities/SpiderManager.cs
+++ b/m4d/Utilities/SpiderManager.cs
@@ -43,7 +43,7 @@ public static class SpiderManager
             return true;
         }
 
-        var agent = userAgent.ToLower();
+        var agent = userAgent.ToLowerInvariant();
         var botFilter = configuration
             .GetSection(BotFilterInfo.SectionName).Get<BotFilterInfo>() ?? new BotFilterInfo();
 


### PR DESCRIPTION
## Summary
- `SpiderManager.CheckSpiders` dereferenced the `Configuration:BotFilter` config section without a null check. That section is only ever supplied by Azure App Configuration, so an App Config outage threw an NRE on every single request (it runs in `DanceMusicController.OnActionExecutionAsync`), turning the intended graceful-degradation banner into a site-wide 500 page.
- The email-service resilience fallback registered `new EmailSender(null)`, but `EmailSender`'s constructor eagerly builds an `EmailClient` and throws `ArgumentNullException` on a null connection string - this just deferred the crash to first DI resolution, so any page injecting `IEmailSender` (Login, Register, ForgotPassword, etc.) 500'd instead of degrading. Replaced with a true no-op `NullEmailSender` that logs and returns `Task.CompletedTask`.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test m4d.Tests --filter FullyQualifiedName~SpiderManagerTests` passes (6/6), including a new regression test for a missing `BotFilter` config section