### PR TITLE
Fix broken /css/site.css link; document known 404 sources

### DIFF
--- a/architecture/distributed-attack-mitigation.md
+++ b/architecture/distributed-attack-mitigation.md
@@ -165,6 +165,29 @@ convention — the standard Razor fallback then resolves it for any current or f
 
 ---
 
+### Known 404/4xx Sources (Triage Log)
+
+Started Aug 16, 2026, after a first pass through `/Admin/Diagnostics`'s "HTTP 4xx Errors" table
+(populated by `Http4xxTracker`, see above) now that the worst offender — a broken autocomplete
+endpoint — was fixed. Purpose: build a running record of what's already been triaged so recurring
+noise doesn't get re-investigated from scratch, and so a genuinely new pattern stands out. When
+reviewing `/Admin/Diagnostics` going forward, check new top URLs against this table first; add a
+row for anything not already covered.
+
+| URL / Pattern | Category | Explanation | Status |
+| --- | --- | --- | --- |
+| `/wp-admin/`, `/wp-login.php` | Bad actor / scanner | Generic WordPress scanner probes; not a WordPress site | Ignore |
+| `/.env` | Bad actor / scanner | Generic secret-hunting bot | Ignore |
+| `/account/signin?ReturnUrl=...` | Bad actor / scanner | `/account/signin` has never existed in this codebase (real path is `/Identity/Account/Login`). Bot guesses common auth paths; the `ReturnUrl` was a real artist-page URL the bot had already scraped, used as plausible bait | Ignore |
+| `/apple-touch-icon*.png` | Benign platform probe | iOS Safari auto-requests these when a user bookmarks/pins the site; we don't define them | Ignore (optional: add touch icons for polish) |
+| `/.well-known/traffic-advice`, `/.well-known/passkey-endpoints` | Benign platform probe | Browser auto-discovery requests (Chrome Privacy Sandbox, WebAuthn/passkeys) | Ignore |
+| `/sitemap.xml` | Benign platform probe (crawler) | Search-engine crawler checking for a sitemap we don't publish | Ignore (optional SEO win if we ever add one) |
+| `/css/site.css`, `/css/sitewicons.css` | **Internal bug — fixed Aug 16, 2026** | `_head.cshtml` linked a stylesheet with no build step producing it since a pre-Vite CSS pipeline was retired (no `site.scss` source anywhere, nothing in `wwwroot/css` but `bootstrap-icons`/`auth-buttons`). Other views worked around it ad hoc via `ViewData["NoSiteCss"]`, but `_vue-Layout.cshtml` — used by `UseVue.V3` pages (the main song-search index, `DanceController`, `CustomSearchController`) — never set that flag, so those pages rendered the dead link on every load | Fixed: removed the dead `styleSheet`/`styleModifier` computation and `<link>` from `_head.cshtml`, and the now-pointless `NoSiteCss` writes in `_bs5-Layout.cshtml` and `DMController.cs` |
+| `/vclient/assets/*.js` (Vite content-hashed filenames) | Expected — deploy artifact | Hashes didn't match current build output; all hits clustered in a ~12 min window matching a deploy. Anonymous HTML responses get `Cache-Control: public, max-age=300` for Front Door (`Program.cs:889`), so browsers/CDN holding pre-deploy HTML request stale bundle names for up to 5 min after each release | No action. Watch for hits **outside** a post-deploy window — that would indicate a real caching problem |
+| `/song/artist?name` (no value) | Known bot pattern (pre-documented) | `SongController.Artist(string name)` 404s on empty `name` ("Empty artist name not valid"); real links always carry a value. Matches the bot signature already noted in `usage-log-analysis-plan.md` | No action |
+
+---
+
 ## Attack Analysis
 
 ### Timeline: March 5, 2026 17:36-17:38 UTC

--- a/m4d/Controllers/DMController.cs
+++ b/m4d/Controllers/DMController.cs
@@ -581,8 +581,6 @@ public class DanceMusicController(
             model = s.Replace(@"'", @"\'");
         }
 
-        ViewData["NoSiteCss"] = true;
-
         return View(
             "Vue3", new VueModel
             {

--- a/m4d/Views/Shared/_bs5-Layout.cshtml
+++ b/m4d/Views/Shared/_bs5-Layout.cshtml
@@ -15,7 +15,6 @@
     {
         help = string.Format("https://music4dance.blog/music4dance-help/{0}/", ViewBag.Help);
     }
-    ViewData["NoSiteCss"] = true;
     var entry = "src/pages/header/main.ts";
     var isDatabaseHealthy = _serviceHealth.IsServiceHealthy("Database");
     var isIdentityArea = ViewContext.RouteData.Values["area"]?.ToString() == "Identity";

--- a/m4d/Views/Shared/_head.cshtml
+++ b/m4d/Views/Shared/_head.cshtml
@@ -40,8 +40,6 @@
     var isTestDb = _configuration.GetValue<bool>("TEST_DB");
     var isProdDb = _configuration.GetValue<bool>("PROD_DB");
     var hasIcons = ViewData.TryGetValue("HasIcons", out var hasIconsObj) && (hasIconsObj as bool?).Value;
-    var styleModifier = hasIcons ? "wicons" : "";
-    var styleSheet = ViewData.ContainsKey("NoSiteCss") ? null : $"/css/site{styleModifier}.css";
     var marketing = GlobalState.GetMarketing(user, Context.Request.Path);
     var marketingMessage = marketing.Enabled ? marketing.Banner : String.Empty;
     var customerReminder = !noWarnings && !isPremium && userMetadata.User != null && await _featureManager.IsEnabledAsync(FeatureFlags.CustomerReminder);
@@ -110,11 +108,6 @@
 
 <link rel="shortcut icon" href="~/images/favicon.png"/>
 <link href="//fonts.googleapis.com/css?family=Source+Sans+Pro|Merienda:700" rel="stylesheet" type="text/css">
-
-@if (styleSheet != null)
-{
-    <link rel="stylesheet" href=@styleSheet />
-}
 
 @if (hasIcons)
 {


### PR DESCRIPTION
## Summary
- Removes a dead stylesheet reference in `_head.cshtml` — `/css/site.css` (and `/css/sitewicons.css`) hasn't been produced by any build step since the pre-Vite CSS pipeline was retired, but the `<link>` was still rendered on `UseVue.V3` pages (song search index, `DanceController`, `CustomSearchController`), generating steady 404 noise. Also cleans up the now-pointless `ViewData["NoSiteCss"]` workarounds in `_bs5-Layout.cshtml` and `DMController.cs` that existed only to suppress it.
- Adds a "Known 404/4xx Sources" triage table to `architecture/distributed-attack-mitigation.md`, categorizing an initial sample from `/Admin/Diagnostics` (scanner noise, benign browser/crawler probes, expected post-deploy asset 404s, and this fix) so future reviews of that page don't re-investigate the same patterns from scratch.

## Test plan
- [x] `dotnet build` succeeds
- [x] No remaining references to `NoSiteCss` in the codebase